### PR TITLE
Fixed focus and autoconnection issues on popup

### DIFF
--- a/material_maker/widgets/add_node_popup.gd
+++ b/material_maker/widgets/add_node_popup.gd
@@ -25,8 +25,6 @@ func filter_entered(filter) -> void:
 
 func add_node(data) -> void:
 	var node : GraphNode = get_current_graph().create_nodes(data, get_current_graph().offset_from_global_position(insert_position))[0]
-	hide()
-	clear()
 	# if this node created by dragging to an empty space
 	if quick_connect_node != null:
 		var type = quick_connect_node.get_connection_output_type(quick_connect_slot)
@@ -36,6 +34,7 @@ func add_node(data) -> void:
 				get_current_graph().connect_node(quick_connect_node.name, quick_connect_slot, node.name, new_slot)
 				break 
 	quick_connect_node = null
+	hide()
 
 func item_selected(index) -> void:
 	# checks if mouse left | enter pressed. it prevents
@@ -48,7 +47,17 @@ func item_selected(index) -> void:
 			return
 		add_node(data[index])
 		hide()
-		clear()
+
+func hide()->void:
+	.hide()
+	
+	# clearing the quick connect data after hiding to prevent unintended autoconnection
+	quick_connect_node = null
+	
+	# grabbing the focus for the graph again as creating popup removes the focus.
+	get_current_graph().grab_focus()
+	
+	clear()
 
 func show() -> void:
 	.show()


### PR DESCRIPTION
I realized that if you close the popup without adding a node after dragging to space, the next created node with a valid slot is connected to the previous node that you did the drag to space. 
Also after closing the popup, you have to click to the GraphEdit in order space key to work again