### PR TITLE
Add a Download section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ be used to create textures procedurally. It can also be used as a Godot addon
 Its user interface is based on Godot's GraphEdit node: textures are described
 as interconnected texture generators and operators.
 
+## Download
+
+- **[Download on itch.io](https://rodzilla.itch.io/material-maker)**
+
+On Windows, you can also install Material Maker using [Scoop](https://scoop.sh):
+
+```text
+scoop bucket add extras
+scoop install material-maker
+```
+
 ## Documentation
 
 - **[User manual](https://rodzill4.github.io/material-maker/doc/)**


### PR DESCRIPTION
This helps users find download links quickly when they find the GitHub page directly.

Material Maker is now available in [Scoop](https://scoop.sh), so I also added a mention in the README.