### PR TITLE
Update AppStream metadata for 0.9 release

### DIFF
--- a/material_maker/misc/linux/io.github.RodZill4.Material-Maker.appdata.xml
+++ b/material_maker/misc/linux/io.github.RodZill4.Material-Maker.appdata.xml
@@ -17,13 +17,13 @@
   <url type="bugtracker">https://github.com/RodZill4/godot-procedural-textures/issues</url>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://raw.githubusercontent.com/RodZill4/godot-procedural-textures/master/addons/material_maker/doc/images/screenshot.png</image>
+      <image type="source" width="1282" height="752">https://raw.githubusercontent.com/RodZill4/material-maker/master/material_maker/doc/images/screenshot.png</image>
       <caption>Editing a procedurally generated texture</caption>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="0.6" date="2019-10-13"/>
+    <release version="0.9" date="2020-03-15"/>
   </releases>
   <update_contact>hugo.locurcio@hugo.pro</update_contact>
 </component>


### PR DESCRIPTION
I'm working on [submitting Material Maker to Flathub](https://github.com/flathub/flathub/pull/1407), so we need the metadata to be up-to-date.