### PR TITLE
Fix syntax error

### DIFF
--- a/addons/material_maker/engine/gen_base.gd
+++ b/addons/material_maker/engine/gen_base.gd
@@ -264,7 +264,7 @@ func get_shader_code(uv : String, output_index : int, context : MMGenContext) ->
 		print(rv)
 	return rv
 
-func _get_shader_code(__, __, __) -> Dictionary:
+func _get_shader_code(_uv, _output_index, _context) -> Dictionary:
 	return {}
 
 


### PR DESCRIPTION
Hi!

This fixes the error "Parse Error: The argument name "__" is defined multiple times." on the latest engine.

closes #106 (this was the root cause)