### PR TITLE
Remove trailing `_` when exporting without suffix

### DIFF
--- a/addons/material_maker/engine/gen_export.gd
+++ b/addons/material_maker/engine/gen_export.gd
@@ -42,5 +42,8 @@ func export_material(prefix : String, _profile : String, size : int = 0) -> void
 		var result = source.generator.render(source.output_index, size)
 		while result is GDScriptFunctionState:
 			result = yield(result, "completed")
-		result.save_to_file("%s_%s.png" % [ prefix, parameters.suffix])
+		if parameters.suffix != "":
+			result.save_to_file("%s_%s.png" % [ prefix, parameters.suffix ])
+		else:
+			result.save_to_file("%s.png" % [ prefix ])
 		result.release()


### PR DESCRIPTION
When using the export node one might want to use no suffix.
I've choosen not to store some `result_file` because not worth it in this case imho.