### PR TITLE
Remove = null when initializing variable

### DIFF
--- a/addons/material_maker/engine/gen_base.gd
+++ b/addons/material_maker/engine/gen_base.gd
@@ -11,7 +11,7 @@ signal parameter_changed(n, v)
 const DEFAULT_GENERATED_SHADER : Dictionary = { defs="", code="", textures={}, type="f", f="0.0" }
 
 class InputPort:
-	var generator : MMGenBase = null
+	var generator : MMGenBase
 	var input_index : int = 0
 
 	func _init(g : MMGenBase, i : int) -> void:
@@ -22,7 +22,7 @@ class InputPort:
 		return generator.name+".in("+str(input_index)+")"
 
 class OutputPort:
-	var generator : MMGenBase = null
+	var generator : MMGenBase
 	var output_index : int = 0
 
 	func _init(g : MMGenBase, o : int) -> void:
@@ -33,7 +33,7 @@ class OutputPort:
 		return generator.name+".out("+str(output_index)+")"
 
 var position : Vector2 = Vector2(0, 0)
-var model = null
+var model
 var parameters = {}
 
 var seed_locked : bool = false

--- a/addons/material_maker/engine/gen_buffer.gd
+++ b/addons/material_maker/engine/gen_buffer.gd
@@ -7,7 +7,7 @@ Texture generator buffers, that render their input in a specific resolution and 
 This is useful when using generators that sample their inputs several times (such as convolutions)
 """
 
-var material : ShaderMaterial = null
+var material : ShaderMaterial
 var updating : bool = false
 var update_again : bool = false
 

--- a/addons/material_maker/engine/gen_context.gd
+++ b/addons/material_maker/engine/gen_context.gd
@@ -4,7 +4,7 @@ class_name MMGenContext
 
 
 var variants : Dictionary = {}
-var parent_context : MMGenContext = null
+var parent_context : MMGenContext
 
 func _init(p = null) -> void:
 	parent_context = p

--- a/addons/material_maker/engine/gen_convolution.gd
+++ b/addons/material_maker/engine/gen_convolution.gd
@@ -43,7 +43,7 @@ func _get_shader_code(uv : String, _output_index : int, context : MMGenContext) 
 		var errors = 0
 		var sum = [ 0.0, 0.0, 0.0, 0.0 ]
 		var matrix = []
-		var expr : Expression = null
+		var expr : Expression
 		var expr_variables : PoolStringArray
 		var expr_values : Array
 		var expr_variables_x_index : int

--- a/addons/material_maker/engine/gen_export.gd
+++ b/addons/material_maker/engine/gen_export.gd
@@ -6,7 +6,7 @@ class_name MMGenExport
 Can be used to export an additional texture
 """
 
-var texture = null
+var texture
 
 # The default texture size as a power-of-two exponent
 const TEXTURE_SIZE_DEFAULT = 10  # 1024x1024

--- a/addons/material_maker/engine/gen_graph.gd
+++ b/addons/material_maker/engine/gen_graph.gd
@@ -88,7 +88,7 @@ func source_changed(input_index : int) -> void:
 		get_node("gen_inputs").source_changed(input_index)
 
 func get_port_source(gen_name: String, input_index: int) -> OutputPort:
-	var rv = null
+	var rv
 	if gen_name == "gen_inputs":
 		var parent = get_parent()
 		if parent != null and parent.get_script() == get_script():

--- a/addons/material_maker/engine/gen_iterate_buffer.gd
+++ b/addons/material_maker/engine/gen_iterate_buffer.gd
@@ -7,8 +7,8 @@ Iterate buffers, that render their input in a specific resolution and apply
 a loop n times on the result.
 """
 
-var material : ShaderMaterial = null
-var loop_material : ShaderMaterial = null
+var material : ShaderMaterial
+var loop_material : ShaderMaterial
 var updating : bool = false
 var update_again : bool = false
 var current_iteration : int = 0

--- a/addons/material_maker/engine/gen_shader.gd
+++ b/addons/material_maker/engine/gen_shader.gd
@@ -195,7 +195,7 @@ func subst(string : String, context : MMGenContext, uv : String = "") -> Diction
 			if !p.has("name") or !p.has("type"):
 				continue
 			var value = parameters[p.name]
-			var value_string = null
+			var value_string
 			if p.type == "float":
 				if parameters[p.name] is float:
 					value_string = "p_%s_%s" % [ genname, p.name ]

--- a/addons/material_maker/engine/loader.gd
+++ b/addons/material_maker/engine/loader.gd
@@ -85,7 +85,7 @@ func create_gen(data) -> MMGenBase:
 		comment = MMGenComment,
 		debug = MMGenDebug
 	}
-	var generator = null
+	var generator
 	for g in guess:
 		if data.has(g.keyword):
 			generator = g.type.new()

--- a/addons/material_maker/import_plugin/ptex_import.gd
+++ b/addons/material_maker/import_plugin/ptex_import.gd
@@ -1,7 +1,7 @@
 tool
 extends EditorImportPlugin
 
-var plugin = null
+var plugin
 
 const PRESET_NAMES = [ "Render in game", "Prerender" ]
 const PRESET_OPTIONS = [
@@ -46,7 +46,7 @@ func get_visible_name() -> String:
 	return "Material Maker Importer"
 
 func import(source_file: String, save_path: String, options: Dictionary, platform_variants: Array, gen_files: Array) -> int:
-	var material = null
+	var material
 	if options.render:
 		var gen = mm_loader.load_gen(source_file)
 		if gen != null:

--- a/addons/material_maker/plugin.gd
+++ b/addons/material_maker/plugin.gd
@@ -1,7 +1,7 @@
 tool
 extends EditorPlugin
 
-var importer = null
+var importer
 
 func _enter_tree() -> void:
 	importer = preload("res://addons/material_maker/import_plugin/ptex_import.gd").new(self)

--- a/material_maker/graph_edit.gd
+++ b/material_maker/graph_edit.gd
@@ -1,16 +1,16 @@
 extends GraphEdit
 class_name MMGraphEdit
 
-var editor_interface = null
-var node_factory = null
+var editor_interface
+var node_factory
 
-var save_path = null setget set_save_path
+var save_path setget set_save_path
 var need_save = false
 
-var top_generator = null
-var generator = null
+var top_generator
+var generator
 
-var last_selected = null
+var last_selected
 
 onready var node_popup = $"../AddNodePopup"
 
@@ -185,7 +185,7 @@ func update_graph(generators, connections) -> Array:
 		rv.push_back(node)
 	for c in connections:
 		.connect_node("node_"+c.from, c.from_port, "node_"+c.to, c.to_port)
-	
+
 	return rv
 
 func new_material() -> void:

--- a/material_maker/library.gd
+++ b/material_maker/library.gd
@@ -75,7 +75,7 @@ func add_item(item, item_name, item_icon = null, item_parent = null, force_expan
 		item_parent = tree.get_root()
 	var slash_position = item_name.find("/")
 	if slash_position == -1:
-		var new_item : TreeItem = null
+		var new_item : TreeItem
 		var c = item_parent.get_children()
 		while c != null:
 			if c.get_text(0) == item_name:
@@ -97,7 +97,7 @@ func add_item(item, item_name, item_icon = null, item_parent = null, force_expan
 	else:
 		var prefix = item_name.left(slash_position)
 		var suffix = item_name.right(slash_position+1)
-		var new_parent = null
+		var new_parent
 		var c = item_parent.get_children()
 		while c != null:
 			if c.get_text(0) == prefix:

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -4,8 +4,8 @@ var recent_files = []
 
 var config_cache : ConfigFile = ConfigFile.new()
 
-var editor_interface = null
-var current_tab = null
+var editor_interface
+var current_tab
 
 var updating : bool = false
 var need_update : bool = false
@@ -62,10 +62,10 @@ const MENU = [
 	{ menu="Tools" },
 	{ menu="Tools", command="add_to_user_library", description="Add selected node to user library" },
 	{ menu="Tools", command="export_library", description="Export the nodes library" },
-	
+
 	#{ menu="Tools", command="generate_screenshots", description="Generate screenshots for the library nodes" },
-	
-	
+
+
 
 	{ menu="Help", command="show_doc", shortcut="F1", description="User manual" },
 	{ menu="Help", command="show_library_item_doc", shortcut="Control+F1", description="Show selected library item documentation" },
@@ -93,7 +93,7 @@ func _ready() -> void:
 			OS.window_position = config_cache.get_value("window", "position")
 		if config_cache.has_section_key("window", "size"):
 			OS.window_size = config_cache.get_value("window", "size")
-	
+
 	# Restore the theme
 	var theme_name : String = "default"
 	if config_cache.has_section_key("window", "theme"):
@@ -156,7 +156,7 @@ func _ready() -> void:
 		create_menu(menu, m.name)
 		m.connect("about_to_show", self, "menu_about_to_show", [ m.name, menu ])
 	new_material()
-	
+
 	do_load_materials(OS.get_cmdline_args())
 
 func _input(event: InputEvent) -> void:
@@ -609,7 +609,7 @@ func update_preview_3d(previews : Array) -> void:
 		for p in previews:
 			gen_material.update_materials(p.get_materials())
 
-var selected_node = null
+var selected_node
 func on_selected_node_change(node) -> void:
 	if node != selected_node:
 		selected_node = node

--- a/material_maker/node_factory.gd
+++ b/material_maker/node_factory.gd
@@ -3,8 +3,8 @@ extends Node
 var includes
 
 func create_node(model : String, type : String) -> Node:
-	var node_type = null
-	var node = null
+	var node_type
+	var node
 	var file_name = "res://material_maker/nodes/"+model+".tscn"
 	if ! ResourceLoader.exists(file_name):
 		file_name = "res://material_maker/nodes/"+type+".tscn"

--- a/material_maker/nodes/base.gd
+++ b/material_maker/nodes/base.gd
@@ -1,7 +1,7 @@
 extends GraphNode
 class_name MMGraphNodeBase
 
-var generator : MMGenBase = null setget set_generator
+var generator : MMGenBase setget set_generator
 
 func _ready() -> void:
 	connect("offset_changed", self, "_on_offset_changed")

--- a/material_maker/nodes/generic.gd
+++ b/material_maker/nodes/generic.gd
@@ -10,7 +10,7 @@ var preview : ColorRect
 var preview_index : int = -1
 var preview_position : int
 var preview_size : int
-var preview_timer : Timer = null
+var preview_timer : Timer
 
 func _draw() -> void:
 	._draw()
@@ -107,7 +107,7 @@ func _on_gradient_changed(new_gradient, variable) -> void:
 	get_parent().set_need_save()
 
 func create_parameter_control(p : Dictionary) -> Control:
-	var control = null
+	var control
 	if p.type == "float":
 		control = preload("res://material_maker/widgets/float_edit.tscn").instance()
 		control.min_value = p.min
@@ -323,7 +323,7 @@ func load_generator() -> void:
 	dialog.popup_centered()
 
 func do_load_generator(file_name : String) -> void:
-	var new_generator = null
+	var new_generator
 	if file_name.ends_with(".mmn"):
 		var file = File.new()
 		if file.open(file_name, File.READ) == OK:

--- a/material_maker/nodes/remote.gd
+++ b/material_maker/nodes/remote.gd
@@ -39,7 +39,7 @@ func update_node() -> void:
 			controls[control.name] = control
 			add_control(generator.get_widget(p.name).label, control)
 			if generator.widgets[i].type == "config_control" and control is OptionButton:
-				var current = null
+				var current
 				if control.get_item_count() > 0 and generator.parameters.has(p.name):
 					control.selected = generator.parameters[p.name]
 					current = control.get_item_text(control.selected)

--- a/material_maker/preview/control_point.gd
+++ b/material_maker/preview/control_point.gd
@@ -3,7 +3,7 @@ extends TextureRect
 export var parent_control : String = ""
 export(int, "Simple", "Rect", "Radius", "Scale" ) var control_type : int = 0
 
-var generator : MMGenBase = null
+var generator : MMGenBase
 var parameter_x : String = ""
 var parameter_y : String = ""
 var parameter_r : String = ""
@@ -12,7 +12,7 @@ var is_xy : bool = false
 
 var dragging : bool = false
 
-var parent_control_node = null
+var parent_control_node
 var children_control_nodes = []
 
 func _ready() -> void:
@@ -38,7 +38,7 @@ func _draw() -> void:
 			if parent_control_node == null:
 				ppos = get_parent().value_to_pos(Vector2(0, 0))
 			else:
-				ppos = parent_control_node.rect_position+0.5*parent_control_node.rect_size 
+				ppos = parent_control_node.rect_position+0.5*parent_control_node.rect_size
 			draw_rect(Rect2(0.5*rect_size, ppos-(rect_position+0.5*rect_size)), modulate, false)
 
 func setup_control(g : MMGenBase, param_defs : Array) -> void:

--- a/material_maker/preview/preview_2d.gd
+++ b/material_maker/preview/preview_2d.gd
@@ -2,7 +2,7 @@ extends ColorRect
 
 export(String, MULTILINE) var shader : String = ""
 
-var generator : MMGenBase = null
+var generator : MMGenBase
 var output : int = 0
 
 func update_export_menu() -> void:

--- a/material_maker/widgets/gradient_editor.gd
+++ b/material_maker/widgets/gradient_editor.gd
@@ -45,7 +45,7 @@ class GradientCursor:
 	static func sort(a, b) -> bool:
 		return a.get_position() < b.get_position()
 
-var value = null setget set_value
+var value setget set_value
 export var embedded : bool = true
 
 signal updated(value)

--- a/material_maker/widgets/graph_tree/hierarchy_pane.gd
+++ b/material_maker/widgets/graph_tree/hierarchy_pane.gd
@@ -4,9 +4,9 @@ export(int, 0, 3) var preview : int = 0
 
 var config_cache : ConfigFile
 
-var default_texture : ImageTexture = null
-var current_graph_edit = null
-var current_generator = null
+var default_texture : ImageTexture
+var current_graph_edit
+var current_generator
 var item_from_gen : Dictionary = {}
 var update_index = 0
 

--- a/material_maker/widgets/histogram/histogram.gd
+++ b/material_maker/widgets/histogram/histogram.gd
@@ -1,6 +1,6 @@
 extends Control
 
-var generator : MMGenBase = null
+var generator : MMGenBase
 var output : int = 0
 
 var updating : bool = false

--- a/material_maker/widgets/linked_widgets/link.gd
+++ b/material_maker/widgets/linked_widgets/link.gd
@@ -2,10 +2,10 @@ extends Control
 class_name MMNodeLink
 
 var end
-var source = null
-var target = null
+var source
+var target
 
-var generator = null
+var generator
 var param_name : String = ""
 var creating : bool = false
 

--- a/material_maker/widgets/node_editor/node_editor.gd
+++ b/material_maker/widgets/node_editor/node_editor.gd
@@ -1,6 +1,6 @@
 extends WindowDialog
 
-var model_data = null
+var model_data
 
 onready var parameter_list : VBoxContainer = $Sizer/Tabs/General/Parameters/Sizer
 onready var input_list : VBoxContainer = $Sizer/Tabs/General/Inputs/Sizer

--- a/start.gd
+++ b/start.gd
@@ -1,6 +1,6 @@
 extends Control
 
-var loader = null
+var loader
 
 onready var progress_bar = $VBoxContainer/ProgressBar
 


### PR DESCRIPTION
Again just a matter of preference, may break things.
Before:
```gdscript
var variable : Type = null
```
After:
```gdscript
var variable : Type
```