### PR TITLE
Remove fallback for `OS.min_window_size` now that Godot 3.2 is out

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -125,8 +125,7 @@ func _ready() -> void:
 		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED, SceneTree.STRETCH_ASPECT_IGNORE, Vector2(), 2)
 
 	# Set a minimum window size to prevent UI elements from collapsing on each other.
-	# This property is only available in 3.2alpha or later, so use `set()` to fail gracefully if it doesn't exist.
-	OS.set("min_window_size", Vector2(1024, 600))
+	OS.min_window_size = Vector2(1024, 600)
 
 	# Set window title
 	OS.set_window_title(ProjectSettings.get_setting("application/config/name")+" v"+ProjectSettings.get_setting("application/config/release"))


### PR DESCRIPTION
The latest Material Maker versions require Godot 3.2 to run.