### PR TITLE
Update AppStream metadata for 0.92

### DIFF
--- a/material_maker/misc/linux/io.github.RodZill4.Material-Maker.appdata.xml
+++ b/material_maker/misc/linux/io.github.RodZill4.Material-Maker.appdata.xml
@@ -12,9 +12,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
   <developer_name>Rodolphe Suescun and contributors</developer_name>
-  <url type="homepage">https://github.com/RodZill4/godot-procedural-textures</url>
-  <url type="help">https://rodzill4.github.io/godot-procedural-textures/doc/</url>
-  <url type="bugtracker">https://github.com/RodZill4/godot-procedural-textures/issues</url>
+  <url type="homepage">https://github.com/RodZill4/material-maker</url>
+  <url type="help">https://rodzill4.github.io/material-maker/doc/</url>
+  <url type="bugtracker">https://github.com/RodZill4/material-maker/issues</url>
   <screenshots>
     <screenshot type="default">
       <image type="source" width="1282" height="752">https://raw.githubusercontent.com/RodZill4/material-maker/master/material_maker/doc/images/screenshot.png</image>
@@ -23,6 +23,7 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="0.92" date="2020-06-27"/>
     <release version="0.9" date="2020-03-15"/>
   </releases>
   <update_contact>hugo.locurcio@hugo.pro</update_contact>


### PR DESCRIPTION
This also updates links to follow the repository rename.