### PR TITLE
Use the Dummy audio driver since Material Maker doesn't play any sounds

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -194,6 +194,10 @@ config/icon="res://icon.png"
 config/windows_native_icon="res://icon.ico"
 config/release="0.93"
 
+[audio]
+
+driver="Dummy"
+
 [autoload]
 
 mm_io_types="*res://addons/material_maker/engine/io_types.gd"


### PR DESCRIPTION
This prevents Godot from appearing as an application playing sound while Material Maker is running. This also decreases CPU usage (especially on macOS due to a known engine bug).