### PR TITLE
v4v4 preview interpretation using a Multi-Field Function

### DIFF
--- a/addons/material_maker/nodes/preview_v4v4.shader
+++ b/addons/material_maker/nodes/preview_v4v4.shader
@@ -1,0 +1,33 @@
+vec4 mfield(vec4 uv) {
+    $(code)
+    return $(value);
+}
+
+float raymarch(vec3 ro, vec3 rd) {
+    float d=0.0;
+    for (int i = 0; i < 200; i++) {
+        vec3 p = ro + rd*d;
+        float dstep = mfield(vec4(p,0.0)).w;
+        d += dstep;
+        if (dstep < 0.0001) break;
+    }
+    return d;
+}
+vec3 normal(vec3 p) {
+    float d = mfield(vec4(p,0.0)).w;
+    float e = .0001;
+    vec3 n = d - vec3(mfield(vec4(p-vec3(e, 0.0, 0.0),0.0)).w, mfield(vec4(p-vec3(0.0, e, 0.0),0.0)).w, mfield(vec4(p-vec3(0.0, 0.0, e),0.0)).w);
+    return normalize(n);
+}
+
+vec4 preview_2d(vec2 uv) {
+    uv -= vec2(0.5);
+    vec3 p = vec3(uv, 2.0-raymarch(vec3(uv, 2.0), vec3(0.0, 0.0, -1.0)));
+    vec3 n = normal(p);
+    vec3 l = vec3(5.0, 5.0, 10.0);
+    vec3 ld = normalize(l-p);
+    float o = step(p.z, 0.001);
+    float shadow = 1.0-0.75*step(raymarch(l, -ld), length(l-p)-0.01);
+    float light = 0.3+0.7*dot(n, ld)*shadow;
+    return vec4(mfield(vec4(p, 1.0)).xyz*light, 1.0);
+}


### PR DESCRIPTION
v4v4 preview interpretation using a Multi-Field Function ( x, y, z, FieldType ) -> (r, g, b, sdf)
Where FieldType=0 is just the SDF, and 1 is BaseColor / Albedo
In a near future it will suport:
1 - BaseColor (x, y, z, sdf)
2 - Metallic (x,?,?,sdf)
3 - Subsurface (x,?,?,sdf)
4 - Specular (x,?,?,sdf)
5 - Roughness (x,?,?,sdf)
6 - SpecularTint (x,?,?,sdf)
7 - Anisotropic (x,?,?,sdf)
8 - Sheen (x,?,?,sdf)
9 - SheenTint (x,?,?,sdf)
10 - Clearcoat (x,?,?,sdf)
11 - ClearcoatGloss (x,?,?,sdf)