### PR TITLE
Fix gaussian blur shader for divide by zero

### DIFF
--- a/addons/material_maker/nodes/gaussian_blur_x.mmg
+++ b/addons/material_maker/nodes/gaussian_blur_x.mmg
@@ -27,7 +27,7 @@
 				"type": "f"
 			}
 		],
-		"instance": "vec4 $(name)_fct(vec2 uv) {\n\tfloat e = 1.0/$size;\n\tvec4 rv = vec4(0.0);\n\tfloat sum = 0.0;\n\tfloat sigma = $sigma*$amount(uv);\n\tsigma = (sigma == 0.0) ? 0.000001 : sigma;\n\tfor (float i = -50.0; i <= 50.0; i += 1.0) {\n\t\tfloat coef = exp(-0.5*(pow(i/sigma, 2.0)))/(6.28318530718*sigma*sigma);\n\t\trv += $in(uv+vec2(i*e, 0.0))*coef;\n\t\tsum += coef;\n\t}\n\treturn rv/sum;\n}",
+		"instance": "vec4 $(name)_fct(vec2 uv) {\n\tfloat e = 1.0/$size;\n\tvec4 rv = vec4(0.0);\n\tfloat sum = 0.0;\n\tfloat sigma = max(0.000001, $sigma*$amount(uv));\n\tfor (float i = -50.0; i <= 50.0; i += 1.0) {\n\t\tfloat coef = exp(-0.5*(pow(i/sigma, 2.0)))/(6.28318530718*sigma*sigma);\n\t\trv += $in(uv+vec2(i*e, 0.0))*coef;\n\t\tsum += coef;\n\t}\n\treturn rv/sum;\n}",
 		"name": "Gaussian blur X",
 		"outputs": [
 			{

--- a/addons/material_maker/nodes/gaussian_blur_x.mmg
+++ b/addons/material_maker/nodes/gaussian_blur_x.mmg
@@ -27,7 +27,7 @@
 				"type": "f"
 			}
 		],
-		"instance": "vec4 $(name)_fct(vec2 uv) {\n\tfloat e = 1.0/$size;\n\tvec4 rv = vec4(0.0);\n\tfloat sum = 0.0;\n\tfloat sigma = $sigma*$amount(uv);\n\tfor (float i = -50.0; i <= 50.0; i += 1.0) {\n\t\tfloat coef = exp(-0.5*(pow(i/sigma, 2.0)))/(6.28318530718*sigma*sigma);\n\t\trv += $in(uv+vec2(i*e, 0.0))*coef;\n\t\tsum += coef;\n\t}\n\treturn rv/sum;\n}",
+		"instance": "vec4 $(name)_fct(vec2 uv) {\n\tfloat e = 1.0/$size;\n\tvec4 rv = vec4(0.0);\n\tfloat sum = 0.0;\n\tfloat sigma = $sigma*$amount(uv);\n\tsigma = (sigma == 0.0) ? 0.000001 : sigma;\n\tfor (float i = -50.0; i <= 50.0; i += 1.0) {\n\t\tfloat coef = exp(-0.5*(pow(i/sigma, 2.0)))/(6.28318530718*sigma*sigma);\n\t\trv += $in(uv+vec2(i*e, 0.0))*coef;\n\t\tsum += coef;\n\t}\n\treturn rv/sum;\n}",
 		"name": "Gaussian blur X",
 		"outputs": [
 			{

--- a/addons/material_maker/nodes/gaussian_blur_y.mmg
+++ b/addons/material_maker/nodes/gaussian_blur_y.mmg
@@ -28,7 +28,7 @@
 				"type": "f"
 			}
 		],
-		"instance": "vec4 $(name)_fct(vec2 uv) {\n\tfloat e = 1.0/$size;\n\tvec4 rv = vec4(0.0);\n\tfloat sum = 0.0;\n\tfloat sigma = $sigma*$amount(uv);\n\tfor (float i = -50.0; i <= 50.0; i += 1.0) {\n\t\tfloat coef = exp(-0.5*(pow(i/sigma, 2.0)))/(6.28318530718*sigma*sigma);\n\t\trv += $in(uv+vec2(0.0, i*e))*coef;\n\t\tsum += coef;\n\t}\n\treturn rv/sum;\n}",
+		"instance": "vec4 $(name)_fct(vec2 uv) {\n\tfloat e = 1.0/$size;\n\tvec4 rv = vec4(0.0);\n\tfloat sum = 0.0;\n\tfloat sigma = $sigma*$amount(uv);\n\tsigma = (sigma == 0.0) ? 0.000001 : sigma;\n\tfor (float i = -50.0; i <= 50.0; i += 1.0) {\n\t\tfloat coef = exp(-0.5*(pow(i/sigma, 2.0)))/(6.28318530718*sigma*sigma);\n\t\trv += $in(uv+vec2(0.0, i*e))*coef;\n\t\tsum += coef;\n\t}\n\treturn rv/sum;\n}",
 		"name": "Gaussian blur Y",
 		"outputs": [
 			{

--- a/addons/material_maker/nodes/gaussian_blur_y.mmg
+++ b/addons/material_maker/nodes/gaussian_blur_y.mmg
@@ -8,7 +8,6 @@
 		"sigma": 35.700001,
 		"size": 9
 	},
-	"seed_value": 12279,
 	"shader_model": {
 		"code": "",
 		"global": "",
@@ -28,7 +27,7 @@
 				"type": "f"
 			}
 		],
-		"instance": "vec4 $(name)_fct(vec2 uv) {\n\tfloat e = 1.0/$size;\n\tvec4 rv = vec4(0.0);\n\tfloat sum = 0.0;\n\tfloat sigma = $sigma*$amount(uv);\n\tsigma = (sigma == 0.0) ? 0.000001 : sigma;\n\tfor (float i = -50.0; i <= 50.0; i += 1.0) {\n\t\tfloat coef = exp(-0.5*(pow(i/sigma, 2.0)))/(6.28318530718*sigma*sigma);\n\t\trv += $in(uv+vec2(0.0, i*e))*coef;\n\t\tsum += coef;\n\t}\n\treturn rv/sum;\n}",
+		"instance": "vec4 $(name)_fct(vec2 uv) {\n\tfloat e = 1.0/$size;\n\tvec4 rv = vec4(0.0);\n\tfloat sum = 0.0;\n\tfloat sigma = max(0.000001, $sigma*$amount(uv));\n\tfor (float i = -50.0; i <= 50.0; i += 1.0) {\n\t\tfloat coef = exp(-0.5*(pow(i/sigma, 2.0)))/(6.28318530718*sigma*sigma);\n\t\trv += $in(uv+vec2(0.0, i*e))*coef;\n\t\tsum += coef;\n\t}\n\treturn rv/sum;\n}",
 		"name": "Gaussian blur Y",
 		"outputs": [
 			{


### PR DESCRIPTION
Fix the gaussian blur shader by never quite going to zero for values
of sigma.  This stops driver crashes on AMD cards in Linux.