### PR TITLE
Add Ctrl + mouse wheel to change 3D preview FOV

### DIFF
--- a/material_maker/panels/preview_3d/preview_3d.gd
+++ b/material_maker/panels/preview_3d/preview_3d.gd
@@ -1,7 +1,9 @@
 extends ViewportContainer
 
 const CAMERA_DISTANCE_MIN = 1.0
-const CAMERA_DISTANCE_MAX = 10.0
+const CAMERA_DISTANCE_MAX = 15.0
+const CAMERA_FOV_MIN = 10
+const CAMERA_FOV_MAX = 90
 
 export var ui_path : String = "UI/Preview3DUI"
 
@@ -126,17 +128,23 @@ func on_gui_input(event) -> void:
 		$MaterialPreview/Preview3d/ObjectRotate.stop(false)
 		match event.button_index:
 			BUTTON_WHEEL_UP:
-				camera.translation.z = clamp(
-					camera.translation.z / (1.01 if event.shift else 1.1),
-					CAMERA_DISTANCE_MIN,
-					CAMERA_DISTANCE_MAX
-				)
+				if event.command:
+					camera.fov = clamp(camera.fov + 1, CAMERA_FOV_MIN, CAMERA_FOV_MAX)
+				else:
+					camera.translation.z = clamp(
+						camera.translation.z / (1.01 if event.shift else 1.1),
+						CAMERA_DISTANCE_MIN,
+						CAMERA_DISTANCE_MAX
+					)
 			BUTTON_WHEEL_DOWN:
-				camera.translation.z = clamp(
-					camera.translation.z * (1.01 if event.shift else 1.1),
-					CAMERA_DISTANCE_MIN,
-					CAMERA_DISTANCE_MAX
-				)
+				if event.command:
+					camera.fov = clamp(camera.fov - 1, CAMERA_FOV_MIN, CAMERA_FOV_MAX)
+				else:
+					camera.translation.z = clamp(
+						camera.translation.z * (1.01 if event.shift else 1.1),
+						CAMERA_DISTANCE_MIN,
+						CAMERA_DISTANCE_MAX
+					)
 			BUTTON_LEFT, BUTTON_RIGHT:
 				var mask : int = Input.get_mouse_button_mask()
 				var lpressed : bool = (mask & BUTTON_MASK_LEFT) != 0

--- a/material_maker/panels/preview_3d/preview_3d.tscn
+++ b/material_maker/panels/preview_3d/preview_3d.tscn
@@ -39,4 +39,5 @@ physics_object_picking = true
 
 [node name="ObjLoader" type="Node" parent="."]
 script = ExtResource( 3 )
+
 [connection signal="gui_input" from="." to="." method="on_gui_input"]

--- a/material_maker/panels/preview_3d/preview_3d_scene.tscn
+++ b/material_maker/panels/preview_3d/preview_3d_scene.tscn
@@ -38,9 +38,10 @@ tracks/0/keys = {
 transform = Transform( 1, 0, 0, 0, 0.766044, 0.642788, 0, -0.642788, 0.766044, 0, 0, 0 )
 
 [node name="Camera" type="Camera" parent="CameraPivot"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3.5 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4 )
 environment = SubResource( 2 )
 current = true
+fov = 50.0
 
 [node name="ObjectRotate" type="AnimationPlayer" parent="."]
 autoplay = "rotate"

--- a/material_maker/windows/accept_dialog/accept_dialog.tscn
+++ b/material_maker/windows/accept_dialog/accept_dialog.tscn
@@ -7,6 +7,7 @@ margin_right = 95.0
 margin_bottom = 58.0
 window_title = "Alerte !"
 script = ExtResource( 1 )
+
 [connection signal="confirmed" from="." to="." method="_on_AcceptDialog_confirmed"]
 [connection signal="custom_action" from="." to="." method="_on_AcceptDialog_custom_action"]
 [connection signal="popup_hide" from="." to="." method="_on_AcceptDialog_popup_hide"]


### PR DESCRIPTION
The shortcuts match the painter mode.

- Decrease the default FOV and increase the default camera distance to better preview materials in a small viewport.
- Increase the camera distance limit to account for low FOVs.