### PR TITLE
Fix alert dialog title

### DIFF
--- a/material_maker/windows/accept_dialog/accept_dialog.tscn
+++ b/material_maker/windows/accept_dialog/accept_dialog.tscn
@@ -5,7 +5,7 @@
 [node name="AcceptDialog" type="AcceptDialog"]
 margin_right = 95.0
 margin_bottom = 58.0
-window_title = "Alerte !"
+window_title = "Alert"
 script = ExtResource( 1 )
 [connection signal="confirmed" from="." to="." method="_on_AcceptDialog_confirmed"]
 [connection signal="custom_action" from="." to="." method="_on_AcceptDialog_custom_action"]


### PR DESCRIPTION
Follow-up to https://github.com/RodZill4/material-maker/pull/183.

The title is "Alert" and not "Alert!" so that it doesn't match the default English text. Otherwise, it will be removed by the Godot editor when saving the scene if you use the editor in English.

See #270.