### PR TITLE
Increase 3D preview anisotropic filtering level from 4x to 16x

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -274,4 +274,5 @@ limits/message_queue/max_size_kb=16384
 
 [rendering]
 
+quality/filters/anisotropic_filter_level=16
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
This improves the texture's appearance when viewed at oblique angles.