### PR TITLE
Improve parallax mapping quality in the 3D preview

### DIFF
--- a/addons/material_maker/engine/gen_material.gd
+++ b/addons/material_maker/engine/gen_material.gd
@@ -251,6 +251,8 @@ func update_material(m, file_prefix = null) -> void:
 		if get_source(INPUT_DEPTH) != null and parameters.depth_scale > 0:
 			m.depth_enabled = true
 			m.depth_deep_parallax = true
+			# Increase level of detail for parallax occlusion mapping (the default is 32).
+			m.depth_max_layers = 64
 			m.depth_scale = parameters.depth_scale * 0.2
 			m.depth_texture = get_generated_texture("depth", file_prefix)
 		else:


### PR DESCRIPTION
Increasing the number of maximum deep parallax steps to 64 reduces visible banding in the 3D preview.
This works in both Godot 3.2.3 and 3.2.4rc2.

## Preview

### Before

![2021-02-12_21 38 02](https://user-images.githubusercontent.com/180032/107820406-052a5f00-6d7b-11eb-9933-acdd3c37bc90.png)

### After

![2021-02-12_21 39 30](https://user-images.githubusercontent.com/180032/107820408-065b8c00-6d7b-11eb-83ad-e3d3f53324b7.png)