### PR TITLE
Increase detail for non-tesselated sphere and cylinder in 3D preview

### DIFF
--- a/material_maker/panels/preview_3d/preview_mesh.gd
+++ b/material_maker/panels/preview_3d/preview_mesh.gd
@@ -68,12 +68,11 @@ func update_material() -> void:
 				mesh.subdivide_width = 0
 				mesh.subdivide_depth = 0
 			"CylinderMesh":
-				mesh.radial_segments = 32
+				mesh.radial_segments = 64
 				mesh.rings = 1
 			"SphereMesh":
-				mesh.radial_segments = 32
-				mesh.rings = 16
+				mesh.radial_segments = 64
+				mesh.rings = 32
 			_:
-				#print(mesh.get_class())
 				pass
 	set_surface_material(0, material)


### PR DESCRIPTION
The polygons were previously visible when using a relatively large preview size.

The difference is especially noticeable in motion (when rotating the camera).

## Preview

*Look at the corners of the sphere.*

### Before

![2021-02-12_21 52 01](https://user-images.githubusercontent.com/180032/107821476-d319fc80-6d7c-11eb-8f0a-c3827f677273.png)

### After

![2021-02-12_21 51 25](https://user-images.githubusercontent.com/180032/107821472-d1e8cf80-6d7c-11eb-8419-e2dd8845aaf2.png)