### PR TITLE
Don't stop the 3D preview rotation animation when zooming in or out

### DIFF
--- a/material_maker/panels/preview_3d/preview_3d.gd
+++ b/material_maker/panels/preview_3d/preview_3d.gd
@@ -122,7 +122,10 @@ func get_materials() -> Array:
 
 func on_gui_input(event) -> void:
 	if event is InputEventMouseButton:
-		$MaterialPreview/Preview3d/ObjectRotate.stop(false)
+		if event.button_index == BUTTON_LEFT or event.button_index == BUTTON_RIGHT or event.button_index == BUTTON_MIDDLE:
+			# Don't stop rotating the preview on mouse wheel usage (zoom change).
+			$MaterialPreview/Preview3d/ObjectRotate.stop(false)
+
 		match event.button_index:
 			BUTTON_WHEEL_UP:
 				camera.translation.z = clamp(


### PR DESCRIPTION
The rotation is still stopped when pressing any other mouse button.

I've often wanted to zoom while letting the automatic rotation do its job :slightly_smiling_face: