### PR TITLE
Enable debanding on the 3D preview if using Godot 3.2.4 or later

### DIFF
--- a/material_maker/panels/preview_3d/preview_3d.gd
+++ b/material_maker/panels/preview_3d/preview_3d.gd
@@ -32,6 +32,10 @@ var _mouse_start_position := Vector2.ZERO
 
 
 func _ready() -> void:
+	# Enable viewport debanding if running with Godot 3.2.4 or later.
+	# This mostly suppresses banding artifacts at a very small performance cost.
+	$MaterialPreview.set("debanding", true)
+
 	ui = get_node(ui_path)
 	get_node("/root/MainWindow").create_menus(MENU, self, ui)
 	$MaterialPreview/Preview3d/ObjectRotate.play("rotate")


### PR DESCRIPTION
This mostly suppresses banding artifacts at a very small performance cost.

## Preview

*The difference is usually not as extreme, but this showcases how effective debanding can be. Banding artifacts are also more noticeable in motion.*

*Make sure to view each image at full size by clicking on it.*

### Debanding disabled

![2021-02-15_00 48 49](https://user-images.githubusercontent.com/180032/107892796-bb32ac00-6f27-11eb-9225-b41089458448.png)

### Debanding enabled

![2021-02-15_00 48 08](https://user-images.githubusercontent.com/180032/107892795-ba9a1580-6f27-11eb-9095-d29a8fe2d8b3.png)