### PR TITLE
Add a setting to enable the sun shadow in the 3D preview

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -123,6 +123,7 @@ const DEFAULT_CONFIG = {
 	ui_scale = 0,
 	ui_3d_preview_resolution = 2.0,
 	ui_3d_preview_tesselation_detail = 256,
+	ui_3d_preview_sun_shadow = false,
 	bake_ray_count = 64,
 	bake_ao_ray_dist = 128.0,
 	bake_denoise_radius = 3

--- a/material_maker/panels/preview_3d/preview_3d.gd
+++ b/material_maker/panels/preview_3d/preview_3d.gd
@@ -10,6 +10,7 @@ onready var current_object = objects.get_child(0)
 
 onready var camera_stand = $MaterialPreview/Preview3d/CameraPivot
 onready var camera = $MaterialPreview/Preview3d/CameraPivot/Camera
+onready var sun = $MaterialPreview/Preview3d/Sun
 
 var ui
 
@@ -48,6 +49,11 @@ func _ready() -> void:
 	$MaterialPreview.get_texture().flags = Texture.FLAG_FILTER
 
 	$MaterialPreview.connect("size_changed", self, "_on_material_preview_size_changed")
+
+	# Delay setting the sun shadow by one frame. Otherwise, the large 3D preview
+	# attempts to read the setting before the configuration file is loaded.
+	yield(get_tree(), "idle_frame")
+	sun.shadow_enabled = get_node("/root/MainWindow").get_config("ui_3d_preview_sun_shadow")
 
 func create_menu_model_list(menu : PopupMenu) -> void:
 	menu.clear()
@@ -101,7 +107,6 @@ func select_object(id) -> void:
 func _on_Environment_item_selected(id) -> void:
 	var environment_manager = get_node("/root/MainWindow/EnvironmentManager")
 	var environment = $MaterialPreview/Preview3d/CameraPivot/Camera.environment
-	var sun = $MaterialPreview/Preview3d/Sun
 	environment_manager.apply_environment(id, environment, sun)
 
 func _on_material_preview_size_changed() -> void:

--- a/material_maker/panels/preview_3d/preview_3d.tscn
+++ b/material_maker/panels/preview_3d/preview_3d.tscn
@@ -34,10 +34,10 @@ msaa = 1
 render_target_clear_mode = 1
 render_target_update_mode = 3
 physics_object_picking = true
+shadow_atlas_size = 4096
 
 [node name="Preview3d" parent="MaterialPreview" instance=ExtResource( 2 )]
 
 [node name="ObjLoader" type="Node" parent="."]
 script = ExtResource( 3 )
-
 [connection signal="gui_input" from="." to="." method="on_gui_input"]

--- a/material_maker/panels/preview_3d/preview_3d_scene.tscn
+++ b/material_maker/panels/preview_3d/preview_3d_scene.tscn
@@ -43,3 +43,8 @@ playback_speed = 0.1
 anims/rotate = SubResource( 3 )
 
 [node name="Sun" type="DirectionalLight" parent="."]
+shadow_enabled = true
+shadow_bias = 0.03
+directional_shadow_mode = 0
+directional_shadow_normal_bias = 0.0
+directional_shadow_max_distance = 5.0

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -34,7 +34,7 @@ __meta__ = {
 
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
 margin_right = 366.0
-margin_bottom = 267.0
+margin_bottom = 284.0
 rect_min_size = Vector2( 289, 172 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -154,23 +154,33 @@ step = 1.0
 float_only = true
 config_variable = "ui_3d_preview_tesselation_detail"
 
-[node name="Space2" type="Control" parent="VBoxContainer/TabContainer/General"]
+[node name="Gui3DPreviewSunShadow" parent="VBoxContainer/TabContainer/General" instance=ExtResource( 1 )]
 margin_top = 154.0
 margin_right = 358.0
-margin_bottom = 164.0
+margin_bottom = 178.0
+hint_tooltip = "If enabled, the DirectionalLight will cast shadows in the 3D preview. This has a moderate performance cost.
+The effect of this shadow is only visible when using a tesselated mesh or a custom object.
+Changes to this setting are only applied on application restart."
+text = "3D preview sun shadow (requires restart)"
+config_variable = "ui_3d_preview_sun_shadow"
+
+[node name="Space2" type="Control" parent="VBoxContainer/TabContainer/General"]
+margin_top = 182.0
+margin_right = 358.0
+margin_bottom = 192.0
 rect_min_size = Vector2( 0, 10 )
 
 [node name="EnableVSync" parent="VBoxContainer/TabContainer/General" instance=ExtResource( 1 )]
-margin_top = 168.0
+margin_top = 196.0
 margin_right = 358.0
-margin_bottom = 192.0
+margin_bottom = 220.0
 text = "Enable VSync"
 config_variable = "vsync"
 
 [node name="FPSLimit" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
-margin_top = 196.0
+margin_top = 224.0
 margin_right = 358.0
-margin_bottom = 220.0
+margin_bottom = 248.0
 
 [node name="Label1" type="Label" parent="VBoxContainer/TabContainer/General/FPSLimit"]
 margin_top = 5.0
@@ -199,11 +209,15 @@ float_only = true
 config_variable = "fps_limit"
 
 [node name="Space" type="Control" parent="VBoxContainer/TabContainer/General/FPSLimit"]
+margin_left = 126.0
+margin_right = 141.0
+margin_bottom = 24.0
 rect_min_size = Vector2( 15, 0 )
 
 [node name="Label2" type="Label" parent="VBoxContainer/TabContainer/General/FPSLimit"]
+margin_left = 145.0
 margin_top = 5.0
-margin_right = 60.0
+margin_right = 234.0
 margin_bottom = 19.0
 hint_tooltip = "A higher FPS limit may result in smoother operation but may use more CPU/GPU resources.
 Higher values may increase power usage, leading to reduced battery life on laptops."
@@ -214,8 +228,8 @@ text = "Idle FPS limit:"
 anchor_left = 0.0
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_left = 64.0
-margin_right = 122.0
+margin_left = 238.0
+margin_right = 296.0
 margin_bottom = 24.0
 hint_tooltip = "A higher FPS limit may result in smoother operation but may use more CPU/GPU resources.
 Higher values may increase power usage, leading to reduced battery life on laptops."
@@ -315,16 +329,16 @@ float_only = true
 config_variable = "bake_denoise_radius"
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
-margin_top = 271.0
+margin_top = 288.0
 margin_right = 366.0
-margin_bottom = 271.0
+margin_bottom = 288.0
 custom_constants/separation = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 margin_left = 178.0
-margin_top = 275.0
+margin_top = 292.0
 margin_right = 366.0
-margin_bottom = 295.0
+margin_bottom = 312.0
 size_flags_horizontal = 8
 
 [node name="Apply" type="Button" parent="VBoxContainer/HBoxContainer"]

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -5,14 +5,15 @@
 [ext_resource path="res://material_maker/windows/preferences/float_option.tscn" type="PackedScene" id=3]
 
 [node name="Preferences" type="WindowDialog"]
+visible = true
 anchor_left = 0.377
 anchor_top = 0.383
 anchor_right = 0.601
 anchor_bottom = 0.619
 margin_left = 0.440002
 margin_top = 0.240021
-margin_right = 83.72
-margin_bottom = 129.32
+margin_right = 81.72
+margin_bottom = 156.32
 rect_min_size = Vector2( 320, 220 )
 popup_exclusive = true
 window_title = "Preferences"
@@ -33,8 +34,8 @@ __meta__ = {
 }
 
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
-margin_right = 366.0
-margin_bottom = 284.0
+margin_right = 364.0
+margin_bottom = 294.0
 rect_min_size = Vector2( 289, 172 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -52,25 +53,25 @@ __meta__ = {
 }
 
 [node name="ConfirmQuit" parent="VBoxContainer/TabContainer/General" instance=ExtResource( 1 )]
-margin_right = 358.0
+margin_right = 356.0
 config_variable = "confirm_quit"
 
 [node name="ConfirmCloseProject" parent="VBoxContainer/TabContainer/General" instance=ExtResource( 1 )]
 margin_top = 28.0
-margin_right = 358.0
+margin_right = 356.0
 margin_bottom = 52.0
 text = "Confirm when closing a project"
 config_variable = "confirm_close_project"
 
 [node name="Space1" type="Control" parent="VBoxContainer/TabContainer/General"]
 margin_top = 56.0
-margin_right = 358.0
+margin_right = 356.0
 margin_bottom = 66.0
 rect_min_size = Vector2( 0, 10 )
 
 [node name="GuiScale" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
 margin_top = 70.0
-margin_right = 358.0
+margin_right = 356.0
 margin_bottom = 94.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/General/GuiScale"]
@@ -94,7 +95,7 @@ config_variable = "ui_scale"
 
 [node name="Gui3DPreviewResolution" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
 margin_top = 98.0
-margin_right = 358.0
+margin_right = 356.0
 margin_bottom = 122.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/General/Gui3DPreviewResolution"]
@@ -123,7 +124,7 @@ config_variable = "ui_3d_preview_resolution"
 
 [node name="Gui3DPreviewTesselationDetail" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
 margin_top = 126.0
-margin_right = 358.0
+margin_right = 356.0
 margin_bottom = 150.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/General/Gui3DPreviewTesselationDetail"]
@@ -156,7 +157,7 @@ config_variable = "ui_3d_preview_tesselation_detail"
 
 [node name="Gui3DPreviewSunShadow" parent="VBoxContainer/TabContainer/General" instance=ExtResource( 1 )]
 margin_top = 154.0
-margin_right = 358.0
+margin_right = 356.0
 margin_bottom = 178.0
 hint_tooltip = "If enabled, the DirectionalLight will cast shadows in the 3D preview. This has a moderate performance cost.
 The effect of this shadow is only visible when using a tesselated mesh or a custom object.
@@ -166,20 +167,20 @@ config_variable = "ui_3d_preview_sun_shadow"
 
 [node name="Space2" type="Control" parent="VBoxContainer/TabContainer/General"]
 margin_top = 182.0
-margin_right = 358.0
+margin_right = 356.0
 margin_bottom = 192.0
 rect_min_size = Vector2( 0, 10 )
 
 [node name="EnableVSync" parent="VBoxContainer/TabContainer/General" instance=ExtResource( 1 )]
 margin_top = 196.0
-margin_right = 358.0
+margin_right = 356.0
 margin_bottom = 220.0
 text = "Enable VSync"
 config_variable = "vsync"
 
 [node name="FPSLimit" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
 margin_top = 224.0
-margin_right = 358.0
+margin_right = 356.0
 margin_bottom = 248.0
 
 [node name="Label1" type="Label" parent="VBoxContainer/TabContainer/General/FPSLimit"]
@@ -329,16 +330,16 @@ float_only = true
 config_variable = "bake_denoise_radius"
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
-margin_top = 288.0
-margin_right = 366.0
-margin_bottom = 288.0
+margin_top = 298.0
+margin_right = 364.0
+margin_bottom = 298.0
 custom_constants/separation = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
-margin_left = 178.0
-margin_top = 292.0
-margin_right = 366.0
-margin_bottom = 312.0
+margin_left = 176.0
+margin_top = 302.0
+margin_right = 364.0
+margin_bottom = 322.0
 size_flags_horizontal = 8
 
 [node name="Apply" type="Button" parent="VBoxContainer/HBoxContainer"]

--- a/project.godot
+++ b/project.godot
@@ -275,4 +275,5 @@ limits/message_queue/max_size_kb=16384
 [rendering]
 
 quality/filters/anisotropic_filter_level=16
+quality/shadows/filter_mode=2
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
The setting is disabled by default for performance reasons (also because it won't be effective with a non-tesselated mesh).

The setting requires an application restart to apply. Suggestions to make it work without an application restart are welcome :slightly_smiling_face: 

To test this, enable tesselation and set the environment to Moonless Golf or Studio. (Epping Forest doesn't have a DirectionalLight that actually emits any light.)

## Preview

![Sun shadow](https://user-images.githubusercontent.com/180032/111209747-b582c180-85cc-11eb-8da9-3c6d2d8d5442.png)