### PR TITLE
Use 4× MSAA for the environment editor 3D preview

### DIFF
--- a/material_maker/windows/environment_editor/environment_editor.tscn
+++ b/material_maker/windows/environment_editor/environment_editor.tscn
@@ -58,6 +58,7 @@ size_flags_horizontal = 3
 size = Vector2( 200, 200 )
 own_world = true
 handle_input_locally = false
+msaa = 2
 render_target_update_mode = 3
 
 [node name="Objects" parent="HSplitContainer/ViewportContainer/Viewport" instance=ExtResource( 1 )]


### PR DESCRIPTION
This makes aliasing much harder to notice.

Since the environment editor doesn't display parallax-mapped surfaces, we don't need to use supersampling.

## Preview

![Environment editor](https://user-images.githubusercontent.com/180032/111210826-00510900-85ce-11eb-8093-9182040eb894.png)