### PR TITLE
Make Escape close the Preferences and Environment editor dialogs

### DIFF
--- a/material_maker/widgets/linked_widgets/link.gd
+++ b/material_maker/widgets/linked_widgets/link.gd
@@ -59,11 +59,11 @@ func _draw() -> void:
 	draw_line(start, end, color, 1.5, true)
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventKey:
-		if event.scancode == KEY_ESCAPE:
-			set_process_input(false)
-			queue_free()
-	elif event is InputEventMouseMotion:
+	if event.is_action_pressed("ui_cancel"):
+		set_process_input(false)
+		queue_free()
+
+	if event is InputEventMouseMotion:
 		var control = find_control(event.global_position)
 		end = get_global_transform().xform_inv(event.global_position)
 		target = control.widget if control != null and !control.empty() and generator.can_link_parameter(param_name, control.node.generator, control.widget.name) else null

--- a/material_maker/windows/add_node_popup/add_node_popup.gd
+++ b/material_maker/windows/add_node_popup/add_node_popup.gd
@@ -171,5 +171,5 @@ func _input(event) -> void:
 			hide()
 
 func _unhandled_input(event) -> void:
-	if event is InputEventKey and event.scancode == KEY_ESCAPE:
+	if event.is_action_pressed("ui_cancel"):
 		hide()

--- a/material_maker/windows/environment_editor/environment_editor.gd
+++ b/material_maker/windows/environment_editor/environment_editor.gd
@@ -24,6 +24,10 @@ func _ready():
 	environment_manager.connect("thumbnail_updated", self, "on_thumbnail_updated")
 	read_environment_list()
 
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		queue_free()
+
 func connect_controls() -> void:
 	for c in ui.get_children():
 		if c is LineEdit:

--- a/material_maker/windows/preferences/preferences.gd
+++ b/material_maker/windows/preferences/preferences.gd
@@ -2,12 +2,11 @@ extends WindowDialog
 
 var config : ConfigFile
 
-
 signal config_changed()
 
-
-func _ready():
-	pass # Replace with function body.
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		queue_free()
 
 func edit_preferences(c : ConfigFile) -> void:
 	config = c


### PR DESCRIPTION
- Harmonize logic for hiding dialogs using the built-in `ui_cancel` action.