### PR TITLE
Add shortcuts to navigate between tabs

### DIFF
--- a/material_maker/widgets/tabs/tabs.gd
+++ b/material_maker/widgets/tabs/tabs.gd
@@ -122,3 +122,23 @@ func _on_CrashRecoveryTimer_timeout():
 		var tab_control = get_child(i)
 		if tab_control.has_method("crash_recovery_save"):
 			tab_control.crash_recovery_save()
+
+func _input(event: InputEvent) -> void:
+	# Navigate between tabs using keyboard shortcuts.
+	if event.is_action_pressed("ui_previous_tab"):
+		set_current_tab(wrapi(current_tab - 1, 0, $Tabs.get_tab_count()))
+	elif event.is_action_pressed("ui_next_tab"):
+		set_current_tab(wrapi(current_tab + 1, 0, $Tabs.get_tab_count()))
+
+func _gui_input(event: InputEvent) -> void:
+	# Navigate between tabs by hovering tabs then using the mouse wheel.
+	# Only take into account the mouse wheel scrolling on the tabs themselves,
+	# not their content.
+	var rect := get_global_rect()
+	# Roughly matches the height of the tabs bar itself (with some additional tolerance for better usability).
+	rect.size.y = 30
+	if event is InputEventMouseButton and event.pressed and rect.has_point(get_global_mouse_position()):
+		if event.button_index == BUTTON_WHEEL_UP:
+			set_current_tab(wrapi(current_tab - 1, 0, $Tabs.get_tab_count()))
+		elif event.button_index == BUTTON_WHEEL_DOWN:
+			set_current_tab(wrapi(current_tab + 1, 0, $Tabs.get_tab_count()))

--- a/project.godot
+++ b/project.godot
@@ -268,6 +268,16 @@ ui_toggle_docks={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":false,"command":true,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
  ]
 }
+ui_previous_tab={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":true,"control":true,"meta":false,"command":true,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ui_next_tab={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":false,"command":true,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [logging]
 


### PR DESCRIPTION
- Ctrl+Tab and Ctrl+Shift+Tab to go to the next/previous tab.
- Alternatively, use the mouse wheel while hovering tabs.