### PR TITLE
Allow drag-and-drop rearranging tabs and always display the Close button

### DIFF
--- a/material_maker/main_window.tscn
+++ b/material_maker/main_window.tscn
@@ -210,7 +210,8 @@ __meta__ = {
 margin_right = 950.0
 margin_bottom = 24.0
 tab_align = 0
-tab_close_display_policy = 1
+tab_close_display_policy = 2
+drag_to_rearrange_enabled = true
 __meta__ = {
 "_edit_use_anchors_": false
 }


### PR DESCRIPTION
Always displaying the Close button avoids layout shifts while changing tabs, which can have unexpected results when clicking around (such as accidentally closing tabs).