### PR TITLE
fixes the alignment in node layouts of lines with outputs

### DIFF
--- a/material_maker/nodes/generic/generic.gd
+++ b/material_maker/nodes/generic/generic.gd
@@ -384,7 +384,6 @@ func update_node() -> void:
 		initialize_properties()
 	# Outputs
 	var outputs = generator.get_output_defs()
-	var button_width = 0
 	output_count = outputs.size()
 	for i in range(output_count):
 		var output = outputs[i]
@@ -406,12 +405,6 @@ func update_node() -> void:
 		hsizer = get_child(i)
 		if hsizer.get_child_count() == 0:
 			hsizer.rect_min_size.y = 12
-	if !outputs.empty():
-		for i in range(output_count, get_child_count()):
-			var hsizer : HBoxContainer = get_child(i)
-			var empty_control : Control = Control.new()
-			empty_control.rect_min_size.x = button_width
-			hsizer.add_child(empty_control)
 	# Edit buttons
 	if generator.is_editable():
 		var edit_buttons = preload("res://material_maker/nodes/edit_buttons.tscn").instance()


### PR DESCRIPTION
As discussed, removing this section in the generic.gd file, fixes the alignment. I've tested 100+ nodes and seen no issues from doing this.

Before:
![image](https://user-images.githubusercontent.com/4955051/128303158-b9572f03-dcc4-4026-9d8c-185eadacd088.png)

After:
![image](https://user-images.githubusercontent.com/4955051/128303175-e36c26be-90f3-4f0c-863c-a655fff8c0df.png)
