### PR TITLE
this removes colons in the parameter names that has them as it's inconsistent and takes up space

### DIFF
--- a/addons/material_maker/nodes/bricks.mmg
+++ b/addons/material_maker/nodes/bricks.mmg
@@ -125,7 +125,7 @@
 			{
 				"control": "None",
 				"default": 1,
-				"label": "Repeat:",
+				"label": "Repeat",
 				"longdesc": "The number of repetitions of the whole pattern",
 				"max": 8,
 				"min": 1,
@@ -137,7 +137,7 @@
 			{
 				"control": "None",
 				"default": 6,
-				"label": "Rows:",
+				"label": "Rows",
 				"longdesc": "The number of rows of a pattern",
 				"max": 64,
 				"min": 1,
@@ -149,7 +149,7 @@
 			{
 				"control": "None",
 				"default": 3,
-				"label": "Columns:",
+				"label": "Columns",
 				"longdesc": "The number of columns of a pattern",
 				"max": 64,
 				"min": 1,
@@ -161,7 +161,7 @@
 			{
 				"control": "None",
 				"default": 0.5,
-				"label": "Offset:",
+				"label": "Offset",
 				"longdesc": "The offset of the pattern (not useful for all patterns)",
 				"max": 1,
 				"min": 0,
@@ -173,7 +173,7 @@
 			{
 				"control": "None",
 				"default": 0.1,
-				"label": "Mortar:",
+				"label": "Mortar",
 				"longdesc": "The width of the space between bricks",
 				"max": 0.5,
 				"min": 0,
@@ -185,7 +185,7 @@
 			{
 				"control": "None",
 				"default": 0.1,
-				"label": "Bevel:",
+				"label": "Bevel",
 				"longdesc": "The width of the edge of each brick",
 				"max": 0.5,
 				"min": 0,
@@ -197,7 +197,7 @@
 			{
 				"control": "None",
 				"default": 0,
-				"label": "Round:",
+				"label": "Round",
 				"longdesc": "The radius of the round corners of bricks",
 				"max": 0.5,
 				"min": 0,
@@ -209,7 +209,7 @@
 			{
 				"control": "None",
 				"default": 0.1,
-				"label": "Corner:",
+				"label": "Corner",
 				"longdesc": "The size of the corner part of each brick (only used by the Corner UV output)",
 				"max": 0.5,
 				"min": 0,

--- a/addons/material_maker/nodes/bricks_nontileable.mmg
+++ b/addons/material_maker/nodes/bricks_nontileable.mmg
@@ -128,7 +128,7 @@
 			{
 				"control": "None",
 				"default": 1,
-				"label": "Repeat:",
+				"label": "Repeat",
 				"longdesc": "The number of repetitions of the whole pattern",
 				"max": 8,
 				"min": 1,
@@ -140,7 +140,7 @@
 			{
 				"control": "None",
 				"default": 6,
-				"label": "Rows:",
+				"label": "Rows",
 				"longdesc": "The number of rows of a pattern",
 				"max": 64,
 				"min": 1,
@@ -152,7 +152,7 @@
 			{
 				"control": "None",
 				"default": 3,
-				"label": "Columns:",
+				"label": "Columns",
 				"longdesc": "The number of columns of a pattern",
 				"max": 64,
 				"min": 1,
@@ -164,7 +164,7 @@
 			{
 				"control": "None",
 				"default": 0.5,
-				"label": "Offset:",
+				"label": "Offset",
 				"longdesc": "The offset of the pattern (not useful for all patterns)",
 				"max": 1,
 				"min": 0,
@@ -176,7 +176,7 @@
 			{
 				"control": "None",
 				"default": 0.1,
-				"label": "Mortar:",
+				"label": "Mortar",
 				"longdesc": "The width of the space between bricks",
 				"max": 0.5,
 				"min": 0,
@@ -188,7 +188,7 @@
 			{
 				"control": "None",
 				"default": 0.1,
-				"label": "Bevel:",
+				"label": "Bevel",
 				"longdesc": "The width of the edge of each brick",
 				"max": 0.5,
 				"min": 0,
@@ -200,7 +200,7 @@
 			{
 				"control": "None",
 				"default": 0,
-				"label": "Round:",
+				"label": "Round",
 				"longdesc": "The radius of the round corners of bricks",
 				"max": 0.5,
 				"min": 0,
@@ -212,7 +212,7 @@
 			{
 				"control": "None",
 				"default": 0.1,
-				"label": "Corner:",
+				"label": "Corner",
 				"longdesc": "The size of the corner part of each brick (only used by the Corner UV output)",
 				"max": 0.5,
 				"min": 0,

--- a/addons/material_maker/nodes/bricks_uneven.mmg
+++ b/addons/material_maker/nodes/bricks_uneven.mmg
@@ -108,7 +108,7 @@
 			{
 				"control": "None",
 				"default": 0.3,
-				"label": "Min size:",
+				"label": "Min size",
 				"longdesc": "The minimum size of a brick",
 				"max": 0.5,
 				"min": 0,
@@ -132,7 +132,7 @@
 			{
 				"control": "None",
 				"default": 0.05,
-				"label": "Mortar:",
+				"label": "Mortar",
 				"longdesc": "The width of the space between bricks",
 				"max": 0.5,
 				"min": 0,
@@ -144,7 +144,7 @@
 			{
 				"control": "None",
 				"default": 0.05,
-				"label": "Bevel:",
+				"label": "Bevel",
 				"longdesc": "The width of the edge of each brick",
 				"max": 0.5,
 				"min": 0,
@@ -156,7 +156,7 @@
 			{
 				"control": "None",
 				"default": 0,
-				"label": "Round:",
+				"label": "Round",
 				"longdesc": "The radius of the round corners of bricks",
 				"max": 0.5,
 				"min": 0,
@@ -168,7 +168,7 @@
 			{
 				"control": "None",
 				"default": 0.1,
-				"label": "Corner:",
+				"label": "Corner",
 				"longdesc": "The size of the corner part of each brick (only used by the Corner UV output)",
 				"max": 0.5,
 				"min": 0,

--- a/addons/material_maker/nodes/color_noise.mmg
+++ b/addons/material_maker/nodes/color_noise.mmg
@@ -28,7 +28,7 @@
 			{
 				"default": 8,
 				"first": 2,
-				"label": "Grid Size:",
+				"label": "Grid Size",
 				"last": 12,
 				"longdesc": "The grid size",
 				"name": "size",

--- a/addons/material_maker/nodes/directional_blur.mmg
+++ b/addons/material_maker/nodes/directional_blur.mmg
@@ -59,7 +59,7 @@
 			"type": "remote",
 			"widgets": [
 				{
-					"label": "Grid size:",
+					"label": "Grid size",
 					"linked_widgets": [
 						{
 							"node": "buffer",

--- a/addons/material_maker/nodes/magnify.mmg
+++ b/addons/material_maker/nodes/magnify.mmg
@@ -45,7 +45,7 @@
 			{
 				"control": "P1.x",
 				"default": 0,
-				"label": "Center X:",
+				"label": "Center X",
 				"longdesc": "X coordinate of the magnifying glass center",
 				"max": 0.5,
 				"min": -0.5,
@@ -57,7 +57,7 @@
 			{
 				"control": "P1.y",
 				"default": 0,
-				"label": "Center Y:",
+				"label": "Center Y",
 				"longdesc": "Y coordinate of the magnifying glass center",
 				"max": 0.5,
 				"min": -0.5,
@@ -69,7 +69,7 @@
 			{
 				"control": "None",
 				"default": 1,
-				"label": "Scale:",
+				"label": "Scale",
 				"longdesc": "The maximum scaling factor for the magnifying glass",
 				"max": 10,
 				"min": 0,

--- a/addons/material_maker/nodes/noise.mmg
+++ b/addons/material_maker/nodes/noise.mmg
@@ -29,7 +29,7 @@
 			{
 				"default": 8,
 				"first": 2,
-				"label": "Grid Size:",
+				"label": "Grid Size",
 				"last": 12,
 				"longdesc": "The grid size",
 				"name": "size",
@@ -39,7 +39,7 @@
 			{
 				"control": "None",
 				"default": 0.5,
-				"label": "Density:",
+				"label": "Density",
 				"longdesc": "The density of white squares",
 				"max": 1,
 				"min": 0,

--- a/addons/material_maker/nodes/noise_color.mmg
+++ b/addons/material_maker/nodes/noise_color.mmg
@@ -28,7 +28,7 @@
 			{
 				"default": 8,
 				"first": 2,
-				"label": "Grid Size:",
+				"label": "Grid Size",
 				"last": 12,
 				"longdesc": "The grid size",
 				"name": "size",

--- a/addons/material_maker/nodes/occlusion.mmg
+++ b/addons/material_maker/nodes/occlusion.mmg
@@ -102,7 +102,7 @@
 			"type": "remote",
 			"widgets": [
 				{
-					"label": "Grid size:",
+					"label": "Grid size",
 					"linked_widgets": [
 						{
 							"node": "buffer",

--- a/addons/material_maker/nodes/pixelize.mmg
+++ b/addons/material_maker/nodes/pixelize.mmg
@@ -38,7 +38,7 @@
 			{
 				"control": "None",
 				"default": 4,
-				"label": "Columns:",
+				"label": "Columns",
 				"longdesc": "Number of pixel columns of the output",
 				"max": 256,
 				"min": 1,
@@ -50,7 +50,7 @@
 			{
 				"control": "None",
 				"default": 4,
-				"label": "Rows:",
+				"label": "Rows",
 				"longdesc": "Number of pixel rows of the output",
 				"max": 256,
 				"min": 1,
@@ -62,7 +62,7 @@
 			{
 				"control": "None",
 				"default": 4,
-				"label": "Levels:",
+				"label": "Levels",
 				"longdesc": "Number of color levels for each channel",
 				"max": 32,
 				"min": 2,
@@ -74,7 +74,7 @@
 			{
 				"control": "None",
 				"default": 0.5,
-				"label": "Dither:",
+				"label": "Dither",
 				"longdesc": "Amount of dithering in the output image",
 				"max": 1,
 				"min": 0,

--- a/addons/material_maker/nodes/rotate.mmg
+++ b/addons/material_maker/nodes/rotate.mmg
@@ -37,7 +37,7 @@
 			{
 				"control": "P1.x",
 				"default": 0,
-				"label": "Center X:",
+				"label": "Center X",
 				"longdesc": "The position of the rotation center",
 				"max": 1,
 				"min": -1,
@@ -49,7 +49,7 @@
 			{
 				"control": "P1.y",
 				"default": 0,
-				"label": "Center Y:",
+				"label": "Center Y",
 				"longdesc": "The position of the rotation center",
 				"max": 1,
 				"min": -1,
@@ -61,7 +61,7 @@
 			{
 				"control": "Radius1.a",
 				"default": 0,
-				"label": "Rotate:",
+				"label": "Rotate",
 				"longdesc": "The angle of the rotation",
 				"max": 720,
 				"min": -720,

--- a/addons/material_maker/nodes/scale.mmg
+++ b/addons/material_maker/nodes/scale.mmg
@@ -38,7 +38,7 @@
 			{
 				"control": "P1.x",
 				"default": 0,
-				"label": "Center X:",
+				"label": "Center X",
 				"longdesc": "The position of the scale center",
 				"max": 1,
 				"min": -1,
@@ -50,7 +50,7 @@
 			{
 				"control": "P1.y",
 				"default": 0,
-				"label": "Center Y:",
+				"label": "Center Y",
 				"longdesc": "The poisition of the scale center",
 				"max": 1,
 				"min": -1,
@@ -62,7 +62,7 @@
 			{
 				"control": "Scale1.x",
 				"default": 1,
-				"label": "Scale X:",
+				"label": "Scale X",
 				"longdesc": "The scale amount along the X axis",
 				"max": 50,
 				"min": 0,
@@ -74,7 +74,7 @@
 			{
 				"control": "Scale1.y",
 				"default": 1,
-				"label": "Scale Y:",
+				"label": "Scale Y",
 				"longdesc": "The scale amount along the Y axis",
 				"max": 50,
 				"min": 0,

--- a/addons/material_maker/nodes/slope_blur.mmg
+++ b/addons/material_maker/nodes/slope_blur.mmg
@@ -64,7 +64,7 @@
 			"type": "remote",
 			"widgets": [
 				{
-					"label": "Grid size:",
+					"label": "Grid size",
 					"linked_widgets": [
 						{
 							"node": "buffer",

--- a/addons/material_maker/nodes/transform.mmg
+++ b/addons/material_maker/nodes/transform.mmg
@@ -80,7 +80,7 @@
 			{
 				"control": "P1.x",
 				"default": 0,
-				"label": "2:Translate X:",
+				"label": "2:Translate X",
 				"longdesc": "The translation along the X axis",
 				"max": 1,
 				"min": -1,
@@ -92,7 +92,7 @@
 			{
 				"control": "P1.y",
 				"default": 0,
-				"label": "Translate Y:",
+				"label": "Translate Y",
 				"longdesc": "The translation along the Y axis",
 				"max": 1,
 				"min": -1,
@@ -104,7 +104,7 @@
 			{
 				"control": "Radius1.a",
 				"default": 0,
-				"label": "Rotate:",
+				"label": "Rotate",
 				"longdesc": "The rotation angle",
 				"max": 720,
 				"min": -720,
@@ -116,7 +116,7 @@
 			{
 				"control": "Scale1.x",
 				"default": 1,
-				"label": "Scale X:",
+				"label": "Scale X",
 				"longdesc": "The scaling factor along the X axis",
 				"max": 50,
 				"min": 0,
@@ -128,7 +128,7 @@
 			{
 				"control": "Scale1.y",
 				"default": 1,
-				"label": "Scale Y:",
+				"label": "Scale Y",
 				"longdesc": "The scaling factor along the Y axis",
 				"max": 50,
 				"min": 0,
@@ -139,7 +139,7 @@
 			},
 			{
 				"default": false,
-				"label": "Repeat:",
+				"label": "Repeat",
 				"longdesc": "Repeat the input if checked, clamps otherwise",
 				"name": "repeat",
 				"shortdesc": "Repeat",

--- a/addons/material_maker/nodes/transform2.mmg
+++ b/addons/material_maker/nodes/transform2.mmg
@@ -80,7 +80,7 @@
 			{
 				"control": "P1.x",
 				"default": 0,
-				"label": "2:Translate X:",
+				"label": "2:Translate X",
 				"longdesc": "The translation along the X axis",
 				"max": 1,
 				"min": -1,
@@ -92,7 +92,7 @@
 			{
 				"control": "P1.y",
 				"default": 0,
-				"label": "Translate Y:",
+				"label": "Translate Y",
 				"longdesc": "The translation along the Y axis",
 				"max": 1,
 				"min": -1,
@@ -104,7 +104,7 @@
 			{
 				"control": "Radius1.a",
 				"default": 0,
-				"label": "Rotate:",
+				"label": "Rotate",
 				"longdesc": "The rotation angle",
 				"max": 720,
 				"min": -720,
@@ -116,7 +116,7 @@
 			{
 				"control": "Scale1.x",
 				"default": 1,
-				"label": "Scale X:",
+				"label": "Scale X",
 				"longdesc": "The scaling factor along the X axis",
 				"max": 50,
 				"min": 0,
@@ -128,7 +128,7 @@
 			{
 				"control": "Scale1.y",
 				"default": 1,
-				"label": "Scale Y:",
+				"label": "Scale Y",
 				"longdesc": "The scaling factor along the Y axis",
 				"max": 50,
 				"min": 0,

--- a/addons/material_maker/nodes/translate.mmg
+++ b/addons/material_maker/nodes/translate.mmg
@@ -36,7 +36,7 @@
 			{
 				"control": "P1.x",
 				"default": 0,
-				"label": "Translate X:",
+				"label": "Translate X",
 				"longdesc": "The translation along the X axis",
 				"max": 1,
 				"min": -1,
@@ -48,7 +48,7 @@
 			{
 				"control": "P1.y",
 				"default": 0,
-				"label": "Translate Y:",
+				"label": "Translate Y",
 				"longdesc": "The translation along the Y axis",
 				"max": 1,
 				"min": -1,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4955051/128413443-18440d48-9dcb-4db2-8836-9c3fe608fa86.png)

After:
![image](https://user-images.githubusercontent.com/4955051/128413486-8395a6c5-563e-4f75-afd2-f127b0a00669.png)
