### PR TITLE
remove unneeded label for gradient parameters

### DIFF
--- a/addons/material_maker/nodes/circular_gradient.mmg
+++ b/addons/material_maker/nodes/circular_gradient.mmg
@@ -77,7 +77,7 @@
 					],
 					"type": "Gradient"
 				},
-				"label": "Gradient",
+				"label": "",
 				"longdesc": "Gradient to be spread on the image",
 				"name": "gradient",
 				"shortdesc": "Gradient",

--- a/addons/material_maker/nodes/gradient.mmg
+++ b/addons/material_maker/nodes/gradient.mmg
@@ -90,7 +90,7 @@
 					],
 					"type": "Gradient"
 				},
-				"label": "Gradient",
+				"label": "",
 				"longdesc": "Gradient to be spread on the image",
 				"name": "gradient",
 				"shortdesc": "Gradient",

--- a/addons/material_maker/nodes/radial_gradient.mmg
+++ b/addons/material_maker/nodes/radial_gradient.mmg
@@ -77,7 +77,7 @@
 					],
 					"type": "Gradient"
 				},
-				"label": "Gradient",
+				"label": "",
 				"longdesc": "Gradient to be spread on the image",
 				"name": "gradient",
 				"shortdesc": "Gradient",


### PR DESCRIPTION
This removes the "Gradient" label as it's redundant, makes the node bigger and the editable gradient area smaller.

Before:
![image](https://user-images.githubusercontent.com/4955051/128464365-b7b25884-9ae2-4973-ba68-56364dd00d2b.png)

After:
![image](https://user-images.githubusercontent.com/4955051/128464395-3d33e898-a34d-4368-8faa-c56058400826.png)
