### PR TITLE
fix: change popup to popup panel to add background to color picker

### DIFF
--- a/material_maker/nodes/comment/comment.tscn
+++ b/material_maker/nodes/comment/comment.tscn
@@ -51,11 +51,11 @@ __meta__ = {
 [node name="VBox" type="VBoxContainer" parent="."]
 margin_left = 16.0
 margin_top = 24.0
-margin_right = 239.0
+margin_right = 346.0
 margin_bottom = 38.0
 
 [node name="Label" type="Label" parent="VBox"]
-margin_right = 223.0
+margin_right = 330.0
 margin_bottom = 14.0
 mouse_filter = 0
 text = "Double-click to write a comment"
@@ -71,18 +71,22 @@ custom_styles/focus = SubResource( 2 )
 custom_styles/normal = SubResource( 2 )
 wrap_enabled = true
 
-[node name="Popup" type="Popup" parent="."]
+[node name="Popup" type="PopupPanel" parent="."]
+visible = true
 margin_left = 16.0
 margin_top = 39.0
-margin_right = 239.0
-margin_bottom = 39.0
+margin_right = 346.0
+margin_bottom = 509.0
 
 [node name="ColorPicker" type="ColorPicker" parent="Popup"]
-margin_left = 12.0
-margin_top = 12.0
-margin_right = 12.0
-margin_bottom = 12.0
-rect_scale = Vector2( 0.75, 0.75 )
+margin_left = 4.0
+margin_top = 4.0
+margin_right = 326.0
+margin_bottom = 466.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [connection signal="resize_request" from="." to="." method="_on_resize_request"]
 [connection signal="gui_input" from="VBox/Label" to="." method="_on_Label_gui_input"]
 [connection signal="focus_entered" from="VBox/TextEdit" to="." method="_on_TextEdit_focus_entered"]

--- a/material_maker/nodes/comment/comment.tscn
+++ b/material_maker/nodes/comment/comment.tscn
@@ -72,7 +72,6 @@ custom_styles/normal = SubResource( 2 )
 wrap_enabled = true
 
 [node name="Popup" type="PopupPanel" parent="."]
-visible = true
 margin_left = 16.0
 margin_top = 39.0
 margin_right = 346.0


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4955051/131255263-51713e51-81b4-413a-a62e-d6a9a5a96644.png)

After:
![image](https://user-images.githubusercontent.com/4955051/131255284-fac66abd-628e-47ac-812f-94eed5c52534.png)

NB: The color picker was also set to be at 0.75 scale for some reason, so this colorpicker was smaller than all other color pickers in MM. I couldn't really see a reason for this, so I set it to 1.0. If that's an issue let me know and I'll set it back to 0.75.

Resolves: https://github.com/RodZill4/material-maker/issues/271