### PR TITLE
Alignment fixes for enum, text and file fields

### DIFF
--- a/material_maker/nodes/generic/generic.gd
+++ b/material_maker/nodes/generic/generic.gd
@@ -195,6 +195,7 @@ static func create_parameter_control(p : Dictionary, accept_float_expressions : 
 			var value = p.values[i]
 			control.add_item(value.name)
 			control.selected = 0 if !p.has("default") else p.default
+		control.rect_min_size.x = 80
 	elif p.type == "boolean":
 		control = CheckBox.new()
 	elif p.type == "color":
@@ -212,10 +213,12 @@ static func create_parameter_control(p : Dictionary, accept_float_expressions : 
 		control.set_closed(false)
 	elif p.type == "string":
 		control = LineEdit.new()
+		control.rect_min_size.x = 80
 	elif p.type == "image_path":
 		control = preload("res://material_maker/widgets/image_picker_button/image_picker_button.tscn").instance()
 	elif p.type == "file":
 		control = preload("res://material_maker/widgets/file_picker_button/file_picker_button.tscn").instance()
+		control.rect_min_size.x = 80
 		if p.has("filters"):
 			for f in p.filters:
 				control.add_filter(f)


### PR DESCRIPTION
This fixes the alignment of certain fields by setting their minimum width:

Before:
![image](https://user-images.githubusercontent.com/4955051/138261687-dd4dfc75-de7f-42b6-9313-5b93f43b7483.png)

After:
![image](https://user-images.githubusercontent.com/4955051/138261730-0a6dc6a4-4e14-4d2e-924b-df9fa4097173.png)
