### PR TITLE
Undo Redo support

### DIFF
--- a/addons/material_maker/engine/gen_base.gd
+++ b/addons/material_maker/engine/gen_base.gd
@@ -152,7 +152,7 @@ class CustomGradientSorter:
 func set_parameter(n : String, v) -> void:
 	var old_value = parameters[n] if parameters.has(n) else null
 	parameters[n] = v
-	emit_signal("parameter_changed", n, v)
+	emit_signal("parameter_changed", n, v, old_value)
 	if is_inside_tree():
 		var parameter_def : Dictionary = get_parameter_def(n)
 		if parameter_def.has("type"):

--- a/material_maker/nodes/generic/generic.gd
+++ b/material_maker/nodes/generic/generic.gd
@@ -59,7 +59,7 @@ static func update_control_from_parameter(parameter_controls : Dictionary, p : S
 		else:
 			print("unsupported widget "+str(o))
 
-func on_parameter_changed(p : String, v) -> void:
+func on_parameter_changed(p : String, v, o) -> void:
 	if ignore_parameter_change == p:
 		return
 	if p == "__update_all__":
@@ -78,7 +78,7 @@ static func initialize_controls_from_generator(control_list, generator, object) 
 			continue
 		var o = control_list[c]
 		if generator.parameters.has(c):
-			object.on_parameter_changed(c, generator.get_parameter(c))
+			object.on_parameter_changed(c, generator.get_parameter(c), null)
 		if o is Control and o.filename == "res://material_maker/widgets/float_edit/float_edit.tscn":
 			o.connect("value_changed", object, "_on_value_changed", [ o.name ])
 		elif o is LineEdit:

--- a/material_maker/panels/graph_edit/undo_redo.gd
+++ b/material_maker/panels/graph_edit/undo_redo.gd
@@ -1,23 +1,60 @@
 extends Node
 
 var stack = []
-var available_undos = 0
+var position = 0
+var lock = false
+
+var composite
 
 func _ready():
 	pass # Replace with function body.
 
 func can_undo() -> bool:
-	return available_undos > 0
+	return position > 0 && stack.size() > 0
+func can_redo() -> bool:
+	return position + 1 < stack.size()
+
 
 func undo() -> void:
-	print("undo")
-
-func can_redo() -> bool:
-	return available_undos < stack.size()
+	if !can_undo():	return
+	var action = stack[position]
+	
+	lock = true
+	
+	action.undo()
+	
+	lock = false
+	position -= 1
+	position = clamp(position, 0, stack.size() - 1)
 
 func redo() -> void:
-	print("redo")
+	if !can_redo():	return
+	position += 1
+	var action = stack[position]
+	lock = true
+	action.do()
+	lock = false
+	position = clamp(position, 0, stack.size() - 1)
 
-func add_action(action_name : String, actions : Array) -> void:
-	stack.append( { name:action_name, actions: actions} )
-	available_undos += 1
+func add_action(action) -> void:
+	if lock:	return
+
+	for i in range(position + 1, stack.size()):
+		stack[i].destroy()
+	stack = stack.slice(0, position)
+	
+	if composite != null:
+		composite.actions.append(action)
+	else:
+		stack.append(action)
+	position = stack.size() - 1
+	
+	
+# creates a composite action, adds every action into the composite until end_composite is called
+func begin_composite():
+	var new_composite = CompositeUndoAction.new()
+	add_action(new_composite)
+	composite = new_composite
+
+func end_composite():
+	composite = null

--- a/material_maker/undo/actions/add_node_undo_action.gd
+++ b/material_maker/undo/actions/add_node_undo_action.gd
@@ -1,0 +1,14 @@
+extends UndoAction
+class_name AddNodeUndoAction
+
+var graph_edit
+var node
+
+func do():
+	graph_edit.add_child(node)
+	pass
+func undo():
+	graph_edit.remove_node(node)
+	pass
+func destroy():
+	graph_edit.destroy_node(node)

--- a/material_maker/undo/actions/composite_undo_action.gd
+++ b/material_maker/undo/actions/composite_undo_action.gd
@@ -1,0 +1,11 @@
+extends UndoAction
+class_name CompositeUndoAction
+
+var actions = []
+
+func do():
+	for action in actions:
+		action.do()
+func undo():
+	for action in actions:
+		action.undo()

--- a/material_maker/undo/actions/connect_node_undo_action.gd
+++ b/material_maker/undo/actions/connect_node_undo_action.gd
@@ -1,0 +1,17 @@
+extends UndoAction
+class_name ConnectNodeUndoAction
+
+
+var graph_edit
+
+var from
+var from_slot
+var to
+var to_slot
+
+func do():
+	graph_edit.connect_node(from,from_slot,to,to_slot)
+	pass
+func undo():
+	graph_edit.disconnect_node(from,from_slot,to,to_slot)
+	pass

--- a/material_maker/undo/actions/disconnect_node_undo_action.gd
+++ b/material_maker/undo/actions/disconnect_node_undo_action.gd
@@ -1,0 +1,17 @@
+extends UndoAction
+class_name DisconnectNodeUndoAction
+
+
+var graph_edit
+
+var from
+var from_slot
+var to
+var to_slot
+
+func do():
+	graph_edit.disconnect_node(from,from_slot,to,to_slot)
+	pass
+func undo():
+	graph_edit.connect_node(from,from_slot,to,to_slot)
+	pass

--- a/material_maker/undo/actions/move_node_undo_action.gd
+++ b/material_maker/undo/actions/move_node_undo_action.gd
@@ -1,0 +1,14 @@
+extends UndoAction
+class_name MoveNodeUndoAction
+
+var from_position:Vector2
+var to_position:Vector2
+
+var node:GraphNode
+
+func do():
+	node.offset = to_position
+	pass
+func undo():
+	node.offset = from_position
+	pass

--- a/material_maker/undo/actions/parameter_change_undo_action.gd
+++ b/material_maker/undo/actions/parameter_change_undo_action.gd
@@ -1,0 +1,15 @@
+extends UndoAction
+class_name ParameterChangeUndoAction
+
+var generator
+var parameter_name
+var new_value
+var previous_value
+
+
+func do():
+	generator.set_parameter(parameter_name, new_value)
+	pass
+func undo():
+	generator.set_parameter(parameter_name, previous_value)
+	pass

--- a/material_maker/undo/actions/remove_node_undo_action.gd
+++ b/material_maker/undo/actions/remove_node_undo_action.gd
@@ -1,0 +1,13 @@
+extends UndoAction
+class_name RemoveNodeUndoAction
+
+var graph_edit
+var node
+var connections = []
+
+func do():
+	graph_edit.remove_node(node)
+	pass
+func undo():
+	graph_edit.add_child(node)
+	pass

--- a/material_maker/undo/undo_action.gd
+++ b/material_maker/undo/undo_action.gd
@@ -1,0 +1,9 @@
+extends Resource
+class_name UndoAction
+
+func do():
+	pass
+func undo():
+	pass
+func destroy():
+	pass

--- a/project.godot
+++ b/project.godot
@@ -9,6 +9,26 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "UndoAction",
+"class": "AddNodeUndoAction",
+"language": "GDScript",
+"path": "res://material_maker/undo/actions/add_node_undo_action.gd"
+}, {
+"base": "UndoAction",
+"class": "CompositeUndoAction",
+"language": "GDScript",
+"path": "res://material_maker/undo/actions/composite_undo_action.gd"
+}, {
+"base": "UndoAction",
+"class": "ConnectNodeUndoAction",
+"language": "GDScript",
+"path": "res://material_maker/undo/actions/connect_node_undo_action.gd"
+}, {
+"base": "UndoAction",
+"class": "DisconnectNodeUndoAction",
+"language": "GDScript",
+"path": "res://material_maker/undo/actions/disconnect_node_undo_action.gd"
+}, {
 "base": "Button",
 "class": "FilePickerButton",
 "language": "GDScript",
@@ -149,17 +169,41 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/material_maker/types/types.gd"
 }, {
+"base": "UndoAction",
+"class": "MoveNodeUndoAction",
+"language": "GDScript",
+"path": "res://material_maker/undo/actions/move_node_undo_action.gd"
+}, {
+"base": "UndoAction",
+"class": "ParameterChangeUndoAction",
+"language": "GDScript",
+"path": "res://material_maker/undo/actions/parameter_change_undo_action.gd"
+}, {
 "base": "TextureButton",
 "class": "PortGroupButton",
 "language": "GDScript",
 "path": "res://material_maker/widgets/port_group_button/port_group_button.gd"
 }, {
+"base": "UndoAction",
+"class": "RemoveNodeUndoAction",
+"language": "GDScript",
+"path": "res://material_maker/undo/actions/remove_node_undo_action.gd"
+}, {
 "base": "OptionButton",
 "class": "SizeOptionButton",
 "language": "GDScript",
 "path": "res://material_maker/widgets/size_option_button/size_option_button.gd"
+}, {
+"base": "Resource",
+"class": "UndoAction",
+"language": "GDScript",
+"path": "res://material_maker/undo/undo_action.gd"
 } ]
 _global_script_class_icons={
+"AddNodeUndoAction": "",
+"CompositeUndoAction": "",
+"ConnectNodeUndoAction": "",
+"DisconnectNodeUndoAction": "",
 "FilePickerButton": "",
 "MMCurve": "",
 "MMGenBase": "",
@@ -188,8 +232,12 @@ _global_script_class_icons={
 "MMPaths": "",
 "MMPolygon": "",
 "MMType": "",
+"MoveNodeUndoAction": "",
+"ParameterChangeUndoAction": "",
 "PortGroupButton": "",
-"SizeOptionButton": ""
+"RemoveNodeUndoAction": "",
+"SizeOptionButton": "",
+"UndoAction": ""
 }
 
 [application]
@@ -265,17 +313,27 @@ ui_hierarchy_down={
 }
 ui_toggle_docks={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":false,"command":true,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":true,"command":true,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
  ]
 }
 ui_previous_tab={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":true,"control":true,"meta":false,"command":true,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":true,"control":true,"meta":true,"command":true,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
  ]
 }
 ui_next_tab={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":false,"command":true,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":true,"command":true,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ui_undo={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":true,"meta":false,"command":false,"pressed":false,"scancode":90,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ui_redo={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":true,"control":true,"meta":false,"command":false,"pressed":false,"scancode":90,"unicode":0,"echo":false,"script":null)
  ]
 }
 


### PR DESCRIPTION
Added an extensible undo/redo system that currently works with delete, move, connect/disconnect with some issues needing to be addressed.
# How it works
Every action is a UndoAction, which extends Resource. Any type of action that needs to be implemented, can be written as a class that extends UndoAction.
UndoAction contains do, undo, and destroy methods. When an action is performed (moving nodes, for example) a MoveNodeUndoAction is created and added to the stack. When undo command is run, UndoRedo class calls `do` method on the current action, then goes back. For redo, does the same by calling the `undo` method (possible bad naming here)

## Example Usage
```gdscript
func disconnect_node(...):
    ...
    var action = DisconnectNodeUndoAction.new()
    action.graph_edit = self
    action.from = from
    action.from_slot = from_slot
    action.to = to
    action.to_slot = to_slot
    $UndoRedo.add_action(action)
```

- Had to alter `remove_node` function, this might need reviewing. I had to create an alternative function named `destroy_node` When a node is removed, it is not destroyed until `destroy_node` is called, which is done on  `RemoveNodeUndoAction.destroy` method, when it cannot be undone any longer.
- Also had to alter parameter_changed event so that it sends its previous value. 

# TODO

- Limit the number of actions that can be undone
- Merging similar actions to one composite action (e.g. moving the same node, removing nodes with disconnecting connections)
- Issues mentioned below

# Issues

- parameter_changed event is sent multiple times when the user changes a value. I could not find any event that is sent when parameter alteration is complete.
- When a node is removed, its connections are also removed and these operations are sent as separate undo actions. This works, but requires multiple redos to revert to its original state. CompositeUndoAction, which merges multiple actions into one, and added `UndoRedo.begin_composite` and `UndoRedo.end_composite` methods to work around this, but didn't spend much time on that yet. The idea is to call begin_composite when `remove_node` function is called, and call end_composite when at the end. When `begin_composite` method is called, every action is added as a unified action in CompositeUndoAction, so when undone, everything inside this object is undone all together


**Note:** I did not realize there already is a pull request for undo/redo '#349' until this was ready to be sent as a pull request. If it works fine, can be merged. If not, totally fine to ignore it, or can be used to get ideas.