### PR TITLE
Add export support for Qt Quick 3D

### DIFF
--- a/addons/material_maker/nodes/material.mmg
+++ b/addons/material_maker/nodes/material.mmg
@@ -323,7 +323,47 @@
 						"type": "template"
 					}
 				]
-			}
+			},
+			"Qt Quick 3D": {
+				"export_extension":"qml",
+				"files": [
+					{
+						"conditions":"$(connected:albedo_tex)",
+						"file_name":"$(path_prefix)_baseColor.png",
+						"output":0,
+						"type":"texture"
+					},
+					{
+						"conditions":"$(connected:ao_tex) or $(connected:roughness_tex) or $(connected:metallic_tex)",
+						"file_name":"$(path_prefix)_occlusionRoughnessMetallic.png",
+						"output":1,
+						"type":"texture"
+					},
+					{
+						"conditions":"$(connected:emission_tex)",
+						"file_name":"$(path_prefix)_emission.png",
+						"output":2,
+						"type":"texture"
+					},
+					{
+						"conditions":"$(connected:normal_tex)",
+						"file_name":"$(path_prefix)_normal.png",
+						"output":7,
+						"type":"texture"
+					},
+					{
+						"conditions":"$(connected:depth_tex)",
+						"file_name":"$(path_prefix)_height.png",
+						"output":8,
+						"type":"texture"
+					},
+					{
+						"file_name":"$(path_prefix).qml",
+						"template":"qtmaterial.qml.tmpl",
+						"type":"template",
+					}
+				]
+			},
 		},
 		"global": "",
 		"inputs": [

--- a/addons/material_maker/nodes/qtmaterial.qml.tmpl
+++ b/addons/material_maker/nodes/qtmaterial.qml.tmpl
@@ -1,0 +1,73 @@
+import QtQuick
+import QtQuick3D
+
+PrincipledMaterial {
+
+$if $(connected:albedo_tex)
+    Texture {
+        id: baseColorTexture
+        source: "$(file_prefix)_baseColor.png"
+        generateMipmaps: true
+        mipFilter: Texture.Linear
+    }
+$fi
+$if $(connected:ao_tex) or $(connected:roughness_tex) or $(connected:metallic_tex)
+    Texture {
+        id: occlusionRoughnessMetallicTexture
+        source: "$(file_prefix)_occlusionRoughnessMetallic.png"
+        generateMipmaps: true
+        mipFilter: Texture.Linear
+    }
+$fi
+$if $(connected:emission_tex)
+    Texture {
+        id: emissionTexture
+        source: "$(file_prefix)_emission.png"
+        generateMipmaps: true
+        mipFilter: Texture.Linear
+    }
+$fi
+$if $(connected:normal_tex)
+    Texture {
+        id: normalTexture
+        source: "$(file_prefix)_normal.png"
+        generateMipmaps: true
+        mipFilter: Texture.Linear
+    }
+$fi
+$if $(connected:depth_tex)
+    Texture {
+        id: heightTexture
+        source: "$(file_prefix)_height.png"
+        generateMipmaps: true
+        mipFilter: Texture.Linear
+    }
+$fi
+    baseColor: Qt.rgba($(param:albedo_color.r), $(param:albedo_color.g), $(param:albedo_color.b), $(param:albedo_color.a))
+$if $(connected:albedo_tex)
+    baseColorMap: baseColorTexture
+$fi
+    occlusionAmount: $(param:ao)
+$if $(connected:ao_tex)
+    occlusionMap: occlusionRoughnessMetallicTexture
+$fi
+    roughness: $(param:roughness)
+$if $(connected:roughness_tex)
+    roughnessMap: occlusionRoughnessMetallicTexture
+$fi
+    metalness: $(param:metallic)
+$if $(connected:metallic_tex)
+    metalnessMap: occlusionRoughnessMetallicTexture
+$fi
+$if $(connected:emission_tex)
+    emissionMap: emissionTexture
+$fi
+    normalStrength: $(param:normal)
+$if $(connected:normal_tex)
+    normalMap: normalTexture
+$fi
+$if $(connected:depth_tex)
+    heightMap: heightTexture
+    heightAmount: $(expr:0.2*$(param:depth_scale))
+$fi
+}

--- a/material_maker/doc/export.rst
+++ b/material_maker/doc/export.rst
@@ -47,3 +47,12 @@ This will generally consist in:
 
 .. image:: images/unreal_export.png
   :align: center
+
+Qt Quick 3D
+------------
+
+When exporting to Qt Quick 3D, Material Maker will generate a QML file that describes the
+material as well as PNG texture sources. Since Qt Quick components are referenced by the
+name of the QML file, it is important when specifying the name of the file that the
+first letter is a capital letter. Once exported it should be possible to reference the
+generated QML component anywhere in your Qt Quick 3D project that requires a material.


### PR DESCRIPTION
This will export PrincipledMaterial components compatible with Qt 6.2
and greater.