### PR TITLE
Change AO baking algorithm, add ray bias setting

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -125,6 +125,7 @@ const DEFAULT_CONFIG = {
 	ui_3d_preview_sun_shadow = false,
 	bake_ray_count = 64,
 	bake_ao_ray_dist = 128.0,
+	bake_ao_ray_bias = 0.005,
 	bake_denoise_radius = 3
 }
 

--- a/material_maker/tools/map_renderer/map_renderer.tscn
+++ b/material_maker/tools/map_renderer/map_renderer.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=29 format=2]
+[gd_scene load_steps=32 format=2]
 
 [ext_resource path="res://material_maker/tools/map_renderer/curvature_generator.gd" type="Script" id=1]
 [ext_resource path="res://material_maker/tools/map_renderer/map_renderer.gd" type="Script" id=2]
@@ -115,6 +115,7 @@ render_mode cull_disabled, unshaded;
 
 uniform sampler2D bvh_data;
 uniform float max_dist;
+uniform float bias_dist;
 uniform int iteration = 1;
 
 uniform sampler2D prev_iteration_tex;
@@ -349,7 +350,283 @@ void fragment() {
 	vec3 ddy_vert = dFdy(model_vert);
 	vec3 true_normal = normalize(cross(ddy_vert, ddx_vert)) * sign(max_dist);
 
-	vec3 ray_start = model_vert + model_norm * 0.0001;
+	vec3 ray_start = model_vert + model_norm * bias_dist;
+
+	vec3 ray_dir;
+	for(int i = 0; i < 5; i++) {
+		ray_dir = random_hemi_point(vec3(
+			rand(SCREEN_UV + float(iteration)),
+			rand(-SCREEN_UV.yx + float(iteration)),
+			0.0
+		), model_norm);
+		if(dot(ray_dir, true_normal) > 0.0) {
+			break;
+		}
+	}
+	float hit = intersects_bvh(ray_start, ray_dir, NORMAL);
+	if(hit == 65536.0 || hit < 0.0  || hit > max_dist) {
+		hit = 1.0;
+	} else{
+		hit = 1.0 - clamp(dot(model_norm, ray_dir),0.0,1.0);
+	}
+
+	ALBEDO = mix(texture(prev_iteration_tex, SCREEN_UV).rgb, vec3(hit), 1.0/float(iteration));
+}
+"
+
+[sub_resource type="ViewportTexture" id=11]
+viewport_path = NodePath(".")
+
+[sub_resource type="ShaderMaterial" id=12]
+resource_local_to_scene = true
+shader = SubResource( 10 )
+shader_param/max_dist = -2.0
+shader_param/bias_dist = null
+shader_param/iteration = 1
+shader_param/prev_iteration_tex = SubResource( 11 )
+
+[sub_resource type="Shader" id=26]
+code = "shader_type spatial;
+render_mode cull_disabled, unshaded;
+
+uniform sampler2D bvh_data;
+uniform float max_dist;
+uniform float bias_dist;
+uniform int iteration = 1;
+
+uniform sampler2D prev_iteration_tex;
+
+varying vec3 normal;
+varying vec3 model_vert;
+
+void vertex() {
+	model_vert = VERTEX;
+	normal = NORMAL;
+	VERTEX = vec3(UV, 0.5);
+}
+
+float intersect_aabb(vec3 ray_origin, vec3 ray_dir, vec3 box_min, vec3 box_max, bool solid) {
+	vec3 tMin = (box_min - ray_origin) / ray_dir;
+	vec3 tMax = (box_max - ray_origin) / ray_dir;
+	vec3 t1 = min(tMin, tMax);
+	vec3 t2 = max(tMin, tMax);
+	float tNear = max(max(t1.x, t1.y), t1.z);
+	float tFar = min(min(t2.x, t2.y), t2.z);
+
+	if(tNear > tFar || (tFar < 0.0 && tNear < 0.0)) {
+		return -1.0;
+	}
+	if(tNear < 0.0) {
+		float temp = tNear;
+		tNear = tFar;
+		tFar = temp;
+		tNear *= float(!solid);
+	}
+
+	return tNear;
+}
+
+float intersects_triangle(vec3 ray_start, vec3 ray_dir, vec3 v0, vec3 v1, vec3 v2) {
+	vec3 e1 = v1 - v0;
+	vec3 e2 = v2 - v0;
+	vec3 h = cross(ray_dir, e2);
+	float a = dot(e1, h);
+	if (abs(a) < 0.000001) { // Parallel test.
+		return -1.0;
+	}
+
+	float f = 1.0 / a;
+
+	vec3 s = ray_start - v0;
+	float u = f * dot(s, h);
+
+	if (u < 0.0 || u > 1.0) {
+		return -1.0;
+	}
+
+	vec3 q = cross(s, e1);
+	float v = f * dot(ray_dir, q);
+
+	if (v < 0.0 || u + v > 1.0) {
+		return -1.0;
+	}
+
+	// At this stage we can compute t to find out where
+	// the intersection point is on the line.
+	float t = f * dot(e2, q);
+	return t > 0.0000001 ? t : -1.0;
+}
+
+vec4 get_data(int index) {
+	ivec2 data_size = textureSize(bvh_data, 0);
+	return texelFetch(bvh_data, ivec2(
+		index % data_size.x,
+		index / data_size.x
+	), 0);
+}
+
+float intersects_bvh(vec3 ray_start, vec3 ray_dir, out vec3 normal_hit) {
+	int offset_to_nodes = int(get_data(0)[0]);
+	vec4 root_data_0 = get_data(int(get_data(1)[0]) + offset_to_nodes);
+	vec4 root_data_1 = get_data(int(get_data(1)[0]) + offset_to_nodes + 1);
+
+	float t = intersect_aabb(ray_start, ray_dir, root_data_0.xyz, root_data_1.xyz, false);
+	if(t == -1.0) {
+		return 65536.0;
+	}
+
+	float prev_hit = t;
+	t = 65536.0; // Set to large number
+	vec3 tri[3] = vec3[];
+	int min_node_idx = 0;
+
+	int stack_point = 0;
+	ivec3 node_stack[128] = ivec3[]; // ivec3
+
+	int curr_node_idx = 0;
+	bool moving_up = false;
+
+	for(int i = 0; i < 256; i++) {
+		if(moving_up && stack_point <= 0) {
+			break;
+		}
+		int node_data_off = int(get_data(1 + curr_node_idx)[0]) + offset_to_nodes;
+		vec4 node_data_0 = get_data(node_data_off);
+		vec4 node_data_1 = get_data(node_data_off + 1);
+		int level = int(node_data_0[3]);
+
+		if(!moving_up) { // Moving down node hierarchy
+			if(node_data_1[3] > 0.0) { // Is a leaf node
+				for(int j = node_data_off + 2; j < node_data_off + 2 + int(node_data_1[3]) * 3; j+=3) {
+					vec3 tri_a = get_data(j).xyz;
+					vec3 tri_b = get_data(j + 1).xyz;
+					vec3 tri_c = get_data(j + 2).xyz;
+					float tri_t = intersects_triangle(ray_start, ray_dir,
+						tri_a, tri_b, tri_c
+					);
+					if(tri_t != -1.0) {
+						if(tri_t < t) {
+							tri[0] = tri_a;
+							tri[1] = tri_b;
+							tri[2] = tri_c;
+//							print(curr_node_idx)
+							min_node_idx = curr_node_idx;
+						}
+						t = min(t, tri_t);
+					}
+				}
+
+				stack_point -= 1;
+				if(stack_point <= 0) {
+					break;
+				}
+				if(node_stack[stack_point][1] == level) { // next node in stack is sibling
+					if(t < intBitsToFloat(node_stack[stack_point][0])) { // no chance to get better hit from sibling
+						stack_point -= 1;
+						moving_up = true;
+					}
+				} else {
+					moving_up = true;
+				}
+				prev_hit = intBitsToFloat(node_stack[stack_point][0]);
+				curr_node_idx = node_stack[stack_point][2];
+			} else {
+
+				// Push self onto stack
+				node_stack[stack_point] = ivec3(floatBitsToInt(prev_hit), level, curr_node_idx);
+				stack_point += 1;
+
+				ivec2 child_indices = ivec2(get_data(node_data_off + 2).xy);
+				int left_data_off = int(get_data(1 + child_indices[0])[0]) + offset_to_nodes;
+				vec4 left_data_0 = get_data(left_data_off);
+				vec4 left_data_1 = get_data(left_data_off + 1);
+				int right_data_off = int(get_data(1 + child_indices[1])[0]) + offset_to_nodes;
+				vec4 right_data_0 = get_data(right_data_off);
+				vec4 right_data_1 = get_data(right_data_off + 1);
+
+				float t_left = intersect_aabb(ray_start, ray_dir, left_data_0.xyz, left_data_1.xyz, true);
+				float t_right = intersect_aabb(ray_start, ray_dir, right_data_0.xyz, right_data_1.xyz, true);
+
+				if(t_right == -1.0 && t_left != -1.0) { // only left node hit
+					prev_hit = t_left;
+					curr_node_idx = child_indices[0];
+				} else if(t_left == -1.0 && t_right != -1.0) { // only right node hit
+					prev_hit = t_right;
+					curr_node_idx = child_indices[1];
+				} else if(t_left < t_right && t_left != -1.0) { // left node hits closer
+					node_stack[stack_point] = ivec3(floatBitsToInt(t_right), int(right_data_0[3]), child_indices[1]);
+					stack_point += 1;
+					prev_hit = t_left;
+					curr_node_idx = child_indices[0];
+				} else if(t_right <= t_left && t_right != -1.0) { // right node hits closer
+					node_stack[stack_point] = ivec3(floatBitsToInt(t_left), int(left_data_0[3]), child_indices[0]);
+					stack_point += 1;
+					prev_hit = t_right;
+					curr_node_idx = child_indices[1];
+				} else { // no hit
+					stack_point -= 2;
+					if(stack_point <= 0) {
+						break;
+					}
+					if(node_stack[stack_point][1] == level) { // next node in stack is sibling
+						if(t < intBitsToFloat(node_stack[stack_point][0])) { // no chance to get better hit from sibling
+							stack_point -= 1;
+							moving_up = true;
+						}
+					} else {
+						moving_up = true;
+					}
+					prev_hit = intBitsToFloat(node_stack[max(stack_point, 0)][0]);
+					curr_node_idx = node_stack[max(stack_point, 0)][2];
+				}
+			}
+		} else { // Moving up hierarchy
+			stack_point -= 1;
+			if(stack_point <= 0) {
+				break;
+			}
+			if(node_stack[stack_point][1] == level) { // next node in stack is sibling
+				if(t < intBitsToFloat(node_stack[stack_point][0])) { // no chance to get better hit from sibling
+					stack_point -= 1;
+				} else {
+					moving_up = false;
+				}
+			}
+			prev_hit = intBitsToFloat(node_stack[max(stack_point, 0)][0]);
+			curr_node_idx = node_stack[max(stack_point, 0)][2];
+		}
+	}
+
+	normal_hit = normalize(cross(tri[2] - tri[0], tri[1] - tri[0]));
+	return t;
+}
+
+vec3 random_hemi_point(vec3 rand, vec3 norm) {
+	const float PI = 3.141592653;
+
+	float ang1 = (rand.x * 2.0) * PI; // [0..1) -> [0..2*PI)
+	float u = rand.y * 2.0 - 1.0; // [0..1), cos and acos(2v-1) cancel each other out, so we arrive at [-1..1)
+	float u2 = u * u;
+	float sqrt1MinusU2 = sqrt(1.0 - u2);
+	float x = sqrt1MinusU2 * cos(ang1);
+	float y = sqrt1MinusU2 * sin(ang1);
+	float z = u;
+	vec3 v = vec3(x, y, z);
+
+	return v * sign(dot(v, norm));
+}
+
+float rand(vec2 co){
+    return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+}
+
+void fragment() {
+	vec3 model_norm = normalize(normal) * sign(max_dist);
+	vec3 ddx_vert = dFdx(model_vert);
+	vec3 ddy_vert = dFdy(model_vert);
+	vec3 true_normal = normalize(cross(ddy_vert, ddx_vert)) * sign(max_dist);
+
+	vec3 ray_start = model_vert + model_norm * bias_dist;
 
 	vec3 ray_dir;
 	for(int i = 0; i < 5; i++) {
@@ -370,18 +647,18 @@ void fragment() {
 //	float weight = dot(model_norm, ray_dir);
 
 	ALBEDO = mix(texture(prev_iteration_tex, SCREEN_UV).rgb, vec3(hit), 1.0/float(iteration));
-}
-"
+}"
 
-[sub_resource type="ViewportTexture" id=11]
+[sub_resource type="ViewportTexture" id=27]
 viewport_path = NodePath(".")
 
-[sub_resource type="ShaderMaterial" id=12]
+[sub_resource type="ShaderMaterial" id=28]
 resource_local_to_scene = true
-shader = SubResource( 10 )
+shader = SubResource( 26 )
 shader_param/max_dist = -2.0
+shader_param/bias_dist = null
 shader_param/iteration = 1
-shader_param/prev_iteration_tex = SubResource( 11 )
+shader_param/prev_iteration_tex = SubResource( 27 )
 
 [sub_resource type="Shader" id=13]
 code = "shader_type spatial;
@@ -609,6 +886,7 @@ inv_uv_material = SubResource( 5 )
 white_material = SubResource( 7 )
 curvature_material = SubResource( 9 )
 ao_material = SubResource( 12 )
+thickness_material = SubResource( 28 )
 denoise_pass = SubResource( 14 )
 dilate_pass1 = SubResource( 16 )
 dilate_pass2 = SubResource( 18 )

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -6,7 +6,6 @@
 [ext_resource path="res://material_maker/windows/preferences/lang_option.gd" type="Script" id=4]
 
 [node name="Preferences" type="WindowDialog"]
-visible = true
 anchor_left = 0.323
 anchor_top = 0.283
 anchor_right = 0.799
@@ -34,13 +33,14 @@ __meta__ = {
 }
 
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
-margin_right = 304.0
-margin_bottom = 322.0
+margin_right = 302.0
+margin_bottom = 320.0
 rect_min_size = Vector2( 289, 172 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="General" type="VBoxContainer" parent="VBoxContainer/TabContainer"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -275,7 +275,6 @@ float_only = true
 config_variable = "idle_fps_limit"
 
 [node name="Bake" type="GridContainer" parent="VBoxContainer/TabContainer"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -335,10 +334,35 @@ step = 1.0
 float_only = true
 config_variable = "bake_ao_ray_dist"
 
-[node name="LabelDenoiseRadius" type="Label" parent="VBoxContainer/TabContainer/Bake"]
+[node name="LabelRayBias" type="Label" parent="VBoxContainer/TabContainer/Bake"]
 margin_top = 61.0
 margin_right = 100.0
 margin_bottom = 75.0
+rect_pivot_offset = Vector2( -266.571, 61 )
+text = "Ray bias:"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="RayBias" parent="VBoxContainer/TabContainer/Bake" instance=ExtResource( 3 )]
+anchor_left = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 104.0
+margin_top = 56.0
+margin_right = 162.0
+margin_bottom = 80.0
+rect_pivot_offset = Vector2( -336.571, 66 )
+value = 0.005
+max_value = 1024.0
+step = 0.001
+float_only = true
+config_variable = "bake_ao_ray_bias"
+
+[node name="LabelDenoiseRadius" type="Label" parent="VBoxContainer/TabContainer/Bake"]
+margin_top = 89.0
+margin_right = 100.0
+margin_bottom = 103.0
 rect_pivot_offset = Vector2( -266.571, 61 )
 text = "Denoise radius:"
 __meta__ = {
@@ -350,9 +374,9 @@ anchor_left = 0.0
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 104.0
-margin_top = 56.0
+margin_top = 84.0
 margin_right = 162.0
-margin_bottom = 80.0
+margin_bottom = 108.0
 rect_pivot_offset = Vector2( -336.571, 66 )
 value = 3.0
 min_value = 1.0
@@ -362,16 +386,16 @@ float_only = true
 config_variable = "bake_denoise_radius"
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
-margin_top = 326.0
-margin_right = 304.0
-margin_bottom = 326.0
+margin_top = 324.0
+margin_right = 302.0
+margin_bottom = 324.0
 custom_constants/separation = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
-margin_left = 116.0
-margin_top = 330.0
-margin_right = 304.0
-margin_bottom = 350.0
+margin_left = 114.0
+margin_top = 328.0
+margin_right = 302.0
+margin_bottom = 348.0
 size_flags_horizontal = 8
 
 [node name="Apply" type="Button" parent="VBoxContainer/HBoxContainer"]


### PR DESCRIPTION
New algorithm for AO baking. It's more consistent with definition 
![image](https://user-images.githubusercontent.com/1286923/147790661-5ba5830f-91da-4bdf-a582-800e4e983eb9.png)
where V is the visibility function at  p, defined to be zero if  p is occluded in the direction omega and one otherwise. It's also taking the cosine-weighted average of rasterized fragments as a weight factor for rays. 

I also added `Ray bias` setting, with default value of 0.005. It offsets the ray start position along the vertex normal, to avoid intersection with starting vertex. Increasing this value should result in in better quality texture but may produce some artifacts.