### PR TITLE
Fix background Preview2D not showing a preview

### DIFF
--- a/material_maker/panels/preview_2d/preview_2d.gd
+++ b/material_maker/panels/preview_2d/preview_2d.gd
@@ -72,10 +72,12 @@ func set_generator(g : MMGenBase, o : int = 0, force : bool = false) -> void:
 			assert(!(source is GDScriptFunctionState))
 			if source.empty():
 				source = MMGenBase.DEFAULT_GENERATED_SHADER
-		$ContextMenu.set_item_disabled($ContextMenu.get_item_index(MENU_EXPORT_ANIMATION), false)
+		if get_node_or_null("ContextMenu") != null:
+			$ContextMenu.set_item_disabled($ContextMenu.get_item_index(MENU_EXPORT_ANIMATION), false)
 	else:
 		generator = null
-		$ContextMenu.set_item_disabled($ContextMenu.get_item_index(MENU_EXPORT_ANIMATION), true)
+		if get_node_or_null("ContextMenu") != null:
+			$ContextMenu.set_item_disabled($ContextMenu.get_item_index(MENU_EXPORT_ANIMATION), true)
 	update_material(source)
 
 func on_parameter_changed(n : String, v) -> void:


### PR DESCRIPTION
Since commit 29707794bb78a411e0850e4c558da0e69d10f99c, enabling the Preview2D BackgroundPreview shows a white color instead of the preview, and prints the following errors in the console:

    ERROR: (Node not found: "ContextMenu" (relative to "/root/MainWindow/VBoxContainer/Layout/SplitRight/ProjectsPanel/BackgroundPreviews/Preview2D").)
       at: get_node (scene/main/node.cpp:1325)
    ERROR: (Node not found: "ContextMenu" (relative to "/root/MainWindow/VBoxContainer/Layout/SplitRight/ProjectsPanel/BackgroundPreviews/Preview2D").)
       at: get_node (scene/main/node.cpp:1325)
    SCRIPT ERROR: Attempt to call function 'get_item_index' in base 'null instance' on a null instance.
       at: set_generator (res://material_maker/panels/preview_2d/preview_2d.gd:78)

This commit guards the ContextMenu update with a null check.

### Before
![Screenshot_2021-12-31_12-27-51](https://user-images.githubusercontent.com/52548/147838280-0dc855d2-a3c7-497b-8fbb-1c8774e6a309.png)

### After
![Screenshot_2021-12-31_12-28-31](https://user-images.githubusercontent.com/52548/147838282-3bf13063-e5dc-4e12-9bbc-6581c2f59cd4.png)
