### PR TITLE
Fix invalid swizzle in some paint shaders

### DIFF
--- a/material_maker/tools/painter/shaders/paint_mr_pattern.shader
+++ b/material_maker/tools/painter/shaders/paint_mr_pattern.shader
@@ -15,7 +15,7 @@ void fragment() {
 	if (reset) {
 		COLOR = vec4(color.xy, a);
 	} else {
-		vec2 alpha_sum = min(max(a, screen_color.za), a + screen_color.za);
+		vec2 alpha_sum = min(max(a, screen_color.ba), a + screen_color.ba);
 		COLOR = vec4((color.xy*a+screen_color.xy*(alpha_sum-a))/alpha_sum, alpha_sum);
 	}
 }

--- a/material_maker/tools/painter/shaders/paint_mr_stamp.shader
+++ b/material_maker/tools/painter/shaders/paint_mr_stamp.shader
@@ -18,7 +18,7 @@ void fragment() {
 	if (reset) {
 		COLOR = vec4(color.xy, a);
 	} else {
-		vec2 alpha_sum = min(max(a, screen_color.za), a + screen_color.ba);
+		vec2 alpha_sum = min(max(a, screen_color.ba), a + screen_color.ba);
 		COLOR = vec4((color.rg*a+screen_color.rg*(alpha_sum-a))/alpha_sum, alpha_sum);
 	}
 }

--- a/material_maker/tools/painter/shaders/paint_mr_uv_pattern.shader
+++ b/material_maker/tools/painter/shaders/paint_mr_uv_pattern.shader
@@ -15,7 +15,7 @@ void fragment() {
 	if (reset) {
 		COLOR = vec4(color.xy, a);
 	} else {
-		vec2 alpha_sum = min(max(a, screen_color.za), a + screen_color.za);
+		vec2 alpha_sum = min(max(a, screen_color.ba), a + screen_color.ba);
 		COLOR = vec4((color.xy*a+screen_color.xy*(alpha_sum-a))/alpha_sum, alpha_sum);
 	}
 }


### PR DESCRIPTION
Using components from the `xyzw` and `rgba` sets in a single swizzle
operation was causing a shader compilation error when painting:

    error: invalid swizzle / mask `za'