### PR TITLE
Output Alignment Fix

### DIFF
--- a/material_maker/nodes/generic/generic.gd
+++ b/material_maker/nodes/generic/generic.gd
@@ -342,13 +342,13 @@ func update_node() -> void:
 		hsizer = HBoxContainer.new()
 		hsizer.size_flags_horizontal = SIZE_EXPAND | SIZE_FILL
 		add_child(hsizer)
-		if !generator.minimized and label != "":
+		if label != "":
 			var label_widget : Label = Label.new()
 			label_widget.text = label
 			hsizer.add_child(label_widget)
 		else:
 			var control : Control = Control.new()
-			control.rect_min_size.y = 25
+			control.rect_min_size.y = 25 if !generator.minimized else 12
 			hsizer.add_child(control)
 		set_slot(index, enable_left, type_left, color_left, false, 0, Color())
 	var input_names_width : int = 0
@@ -431,7 +431,7 @@ func update_node() -> void:
 			add_child(hsizer)
 		hsizer = get_child(i)
 		if hsizer.get_child_count() == 0:
-			hsizer.rect_min_size.y = 25
+			hsizer.rect_min_size.y = 25 if !generator.minimized else 12
 	# Edit buttons
 	if generator.is_editable():
 		for theme in ["frame", "selectedframe"]:

--- a/material_maker/nodes/generic/generic.gd
+++ b/material_maker/nodes/generic/generic.gd
@@ -348,7 +348,7 @@ func update_node() -> void:
 			hsizer.add_child(label_widget)
 		else:
 			var control : Control = Control.new()
-			control.rect_min_size.y = 12
+			control.rect_min_size.y = 25
 			hsizer.add_child(control)
 		set_slot(index, enable_left, type_left, color_left, false, 0, Color())
 	var input_names_width : int = 0
@@ -431,7 +431,7 @@ func update_node() -> void:
 			add_child(hsizer)
 		hsizer = get_child(i)
 		if hsizer.get_child_count() == 0:
-			hsizer.rect_min_size.y = 12
+			hsizer.rect_min_size.y = 25
 	# Edit buttons
 	if generator.is_editable():
 		for theme in ["frame", "selectedframe"]:


### PR DESCRIPTION
This ensures that outputs are aligned the same even if they don't have a label.

Before:
![image](https://user-images.githubusercontent.com/4955051/148519645-5336d316-a011-45fa-a1c4-6ed7c2d8c344.png)

After:
![image](https://user-images.githubusercontent.com/4955051/148519571-7911199f-17a2-44da-bf4a-6e6e789718a5.png)

NB: I ensured empty label height still got decreased on node minimize.