### PR TITLE
32 bits viewports

### DIFF
--- a/addons/material_maker/engine/gen_buffer.gd
+++ b/addons/material_maker/engine/gen_buffer.gd
@@ -47,6 +47,7 @@ func get_parameter_defs() -> Array:
 		VERSION_OLD:
 			parameter_defs.push_back({ name="lod", type="float", min=0, max=10.0, step=0.01, default=0 })
 		VERSION_COMPLEX:
+			parameter_defs.push_back({ name="highp", type="boolean", default=false })
 			parameter_defs.push_back({ name="filter", type="boolean", default=true })
 			parameter_defs.push_back({ name="mipmap", type="boolean", default=true })
 	return parameter_defs
@@ -147,8 +148,9 @@ func update_buffer() -> void:
 				return
 			current_renderer = renderer
 			update_again = false
+			var highp = parameters.highp if version == VERSION_COMPLEX and parameters.has("highp") else false
 			var time = OS.get_ticks_msec()
-			renderer = renderer.render_material(self, material, pow(2, get_parameter("size")))
+			renderer = renderer.render_material(self, material, pow(2, get_parameter("size")), true, highp)
 			while renderer is GDScriptFunctionState:
 				renderer = yield(renderer, "completed")
 			if !update_again:

--- a/addons/material_maker/engine/renderer.gd
+++ b/addons/material_maker/engine/renderer.gd
@@ -49,7 +49,7 @@ func render_text(object : Object, text : String, font_path : String, font_size :
 	$ColorRect.visible = true
 	return self
 
-func render_material(object : Object, material : Material, render_size, with_hdr = true) -> Object:
+func render_material(object : Object, material : Material, render_size, with_hdr = true, with_32_bits = false) -> Object:
 	assert(render_owner == object, "Invalid renderer use")
 	if mm_renderer.max_buffer_size != 0 and render_size > mm_renderer.max_buffer_size:
 		render_size = mm_renderer.max_buffer_size
@@ -59,6 +59,7 @@ func render_material(object : Object, material : Material, render_size, with_hdr
 	$ColorRect.rect_size = size
 	$ColorRect.material = material
 	hdr = with_hdr
+	use_32_bpc_depth = with_32_bits 
 	render_target_update_mode = Viewport.UPDATE_ONCE
 	update_worlds()
 	yield(get_tree(), "idle_frame")

--- a/material_maker/panels/preview_2d/preview_2d_panel.tscn
+++ b/material_maker/panels/preview_2d/preview_2d_panel.tscn
@@ -253,7 +253,7 @@ margin_bottom = 88.0
 [node name="Accumulate" type="Viewport" parent="." index="11"]
 size = Vector2( 2, 2 )
 handle_input_locally = false
-disable_3d = true
+use_32_bpc_depth = true
 keep_3d_linear = true
 render_target_v_flip = true
 render_target_clear_mode = 1

--- a/material_maker/tools/map_renderer/map_renderer.tscn
+++ b/material_maker/tools/map_renderer/map_renderer.tscn
@@ -782,37 +782,28 @@ render_mode blend_disabled;
 uniform sampler2D tex;
 uniform float size = 512.0;
 
-const int STEPS = 125;
-
-vec4 dilate_distance_h(vec2 uv) {
+void fragment() {
 	vec2 e = vec2(1.0/size, 0.0);
-	float d = size/float(STEPS);
-	float rv = 0.0;
 	float found = 0.0;
 	vec2 source_uv;
 	vec4 source_color;
-	int steps = min(STEPS, int(size)/2);
+	int steps = int(size*0.5);
 	for (int i = 0; i < steps; ++i) {
-		source_uv = uv+float(i)*e;
+		vec2 dx = float(i)*e;
+		source_uv = UV+dx;
 		source_color = texture(tex, source_uv);
 		if (source_color.a >= 0.5) {
-			rv = float(i);
 			found = 1.0;
 			break;
 		}
-		source_uv = uv-float(i)*e;
+		source_uv = UV-dx;
 		source_color = texture(tex, source_uv);
 		if (source_color.a >= 0.5) {
-			rv = -float(i);
 			found = 1.0;
 			break;
 		}
 	}
-	return vec4(vec3(0.5+0.5*rv*e.x*d), found);
-}
-
-void fragment() {
-	COLOR = dilate_distance_h(UV);
+	COLOR = vec4(source_uv, found, 1.0);
 }
 "
 
@@ -827,42 +818,26 @@ render_mode blend_disabled;
 uniform sampler2D tex;
 uniform float size = 512.0;
 
-const int STEPS = 64;
-
-vec4 best(vec4 last, vec2 uv, float dy) {
-	vec2 p = texture(tex, uv+dy).ar;
-	float d = size/float(STEPS);
-	float dx = (p.y-0.5)/d;
-	if (p.x > 0.5) {
-		float d_2 = dx*dx+dy*dy;
-		if (d_2 < last.y) {
-			last = vec4(1.0, d_2, p.y, dy);
-		}
+vec4 best(vec4 last, vec2 uv, vec2 p) {
+	vec4 t = texture(tex, p);
+	if (t.z < 0.5) {
+		return last;
 	}
-	return last;
-}
-
-vec4 dilate_distance_v(vec2 uv) {
-	float e = 1.0/size;
-	float d = size/float(STEPS);
-	vec4 p = vec4(texture(tex, uv).arr, 0.0);
-	if (p.x < 0.5) {
-		p.y = 1.0;
-	} else {
-		p.y = (p.y-0.5)/d;
-		p.y *= p.y;
-	}
-	int steps = min(STEPS, int(size)/2);
-	for (int i = 0; i < steps; ++i) {
-		float dy = float(i)*e;
-		p = best(p, uv, dy);
-		p = best(p, uv, -dy);
-	}
-	return vec4(p.z, 0.5+0.5*p.w*d, 0.0, p.x);
+	vec4 new = vec4(t.xy, length(t.xy-uv), 1.0);
+	return mix(last, new, step(new.z, last.z));
 }
 
 void fragment() {
-	COLOR = dilate_distance_v(UV);
+	vec4 p = vec4(UV, 2.0, 1.0);
+	vec2 e = vec2(0.0, 1.0/size);
+	int steps = int(size*0.5);
+	for (int i = 0; i < steps; ++i) {
+		vec2 dy = float(i)*e;
+		p = best(p, UV, UV+dy);
+		p = best(p, UV, UV-dy);
+	}
+	COLOR = vec4(p.xy, 0.0, 1.0);
+	//COLOR = vec4(texture(tex, UV).xy, 0.0, 1.0);
 }
 "
 
@@ -877,6 +852,7 @@ size = Vector2( 2048, 2048 )
 own_world = true
 world = SubResource( 1 )
 transparent_bg = true
+use_32_bpc_depth = true
 keep_3d_linear = true
 render_target_update_mode = 0
 script = ExtResource( 2 )

--- a/material_maker/tools/painter/shaders/paint_brush_functions.shader
+++ b/material_maker/tools/painter/shaders/paint_brush_functions.shader
@@ -15,6 +15,5 @@ float brush(vec2 uv) {
 }
 
 vec2 seams_uv(vec2 uv) {
-	vec2 seams_value = texture(seams, uv).xy-vec2(0.5);
-	return fract(uv+seams_value*seams_multiplier/texture_size);
+	return texture(seams, uv).xy;
 }

--- a/material_maker/tools/painter/shaders/texture2view_postprocess.tres
+++ b/material_maker/tools/painter/shaders/texture2view_postprocess.tres
@@ -5,20 +5,11 @@ code = "shader_type canvas_item;
 
 uniform sampler2D input_tex;
 uniform sampler2D seams_tex;
-uniform float     seams_multiplier = 256.0;
-uniform float texture_size;
-
-vec2 seams_uv(vec2 uv) {
-	vec2 seams_value = texture(seams_tex, uv).xy-vec2(0.5);
-	return fract(uv+seams_value*seams_multiplier/texture_size);
-}
 
 void fragment() {
-	COLOR = texture(input_tex, seams_uv(UV));
+	COLOR = texture(input_tex, texture(seams_tex, UV).xy);
 }
 "
 
 [resource]
 shader = SubResource( 1 )
-shader_param/seams_multiplier = 256.0
-shader_param/texture_size = null


### PR DESCRIPTION
Use 32 bits viewports from Godot 3.5.

Beware, dev builds for this PR won't work because they still use Godot 3.4.