### PR TITLE
Set the 3D preview debanding property in the scene instead of script

### DIFF
--- a/material_maker/panels/preview_3d/preview_3d.gd
+++ b/material_maker/panels/preview_3d/preview_3d.gd
@@ -42,10 +42,6 @@ var _mouse_start_position : Vector2 = Vector2.ZERO
 
 
 func _ready() -> void:
-	# Enable viewport debanding if running with Godot 3.2.4 or later.
-	# This mostly suppresses banding artifacts at a very small performance cost.
-	$MaterialPreview.set("debanding", true)
-
 	ui = get_node(ui_path)
 	get_node("/root/MainWindow").create_menus(MENU, self, ui)
 	$MaterialPreview/Preview3d/ObjectRotate.play("rotate")
@@ -173,7 +169,7 @@ func on_gui_input(event) -> void:
 				var mask : int = Input.get_mouse_button_mask()
 				var lpressed : bool = (mask & BUTTON_MASK_LEFT) != 0
 				var rpressed : bool = (mask & BUTTON_MASK_RIGHT) != 0
-				
+
 				if event.pressed and lpressed != rpressed: # xor
 					Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 					_mouse_start_position = event.global_position

--- a/material_maker/panels/preview_3d/preview_3d.tscn
+++ b/material_maker/panels/preview_3d/preview_3d.tscn
@@ -29,6 +29,7 @@ own_world = true
 world = SubResource( 1 )
 handle_input_locally = false
 msaa = 1
+debanding = true
 render_target_clear_mode = 1
 render_target_update_mode = 3
 physics_object_picking = true

--- a/start.gd
+++ b/start.gd
@@ -76,10 +76,10 @@ func _ready():
 			resource_path = "res://material_maker/main_window.tscn"
 	else:
 		resource_path = "res://demo/demo.tscn"
-	
+
 	var locale = load("res://material_maker/locale/locale.gd").new()
 	locale.read_translations()
-	
+
 	set_process(true)
 	thread.start(self, "load_resource", resource_path, Thread.PRIORITY_HIGH)
 


### PR DESCRIPTION
Since Godot 3.4 is now used as a baseline for Material Maker, we can assume the debanding property to be always present.