### PR TITLE
Decrease the maximum allowed value for 3D preview resolution to 2.0

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -136,10 +136,10 @@ func _ready() -> void:
 	for k in DEFAULT_CONFIG.keys():
 		if ! config_cache.has_section_key("config", k):
 			config_cache.set_value("config", k, DEFAULT_CONFIG[k])
-	
+
 	if get_config("locale") == "":
 		config_cache.set_value("config", "locale", TranslationServer.get_locale())
-	
+
 	on_config_changed()
 
 	# Restore the window position/size if values are present in the configuration cache
@@ -234,7 +234,7 @@ func on_config_changed() -> void:
 	get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED, SceneTree.STRETCH_ASPECT_IGNORE, Vector2(), scale)
 
 	# Clamp to reasonable values to avoid crashes on startup.
-	preview_rendering_scale_factor = clamp(get_config("ui_3d_preview_resolution"), 1.0, 2.5)
+	preview_rendering_scale_factor = clamp(get_config("ui_3d_preview_resolution"), 1.0, 2.0)
 	preview_tesselation_detail = clamp(get_config("ui_3d_preview_tesselation_detail"), 16, 1024)
 
 func get_panel(panel_name : String) -> Control:


### PR DESCRIPTION
Values above 2.0 actually *decrease* rendering quality due to the renderer not having any mipmapped images of the viewport to work with.

It might be possible to use some kind of real-time mipmap generation, but it would be very slow and would not benefit the output quality much (4× SSAA is pretty good already).

This is based on my findings while working on https://github.com/godotengine/godot/pull/52215.

## Preview

*Click to view at full size. Compare the edges of the beehive material on each screenshot.*

### Resolution scale 2.5 (old maximum value)

![2022-03-14_01 43 02_supersample_2 5](https://user-images.githubusercontent.com/180032/158087459-4b059299-8186-4e71-9eef-2d73a91bf76a.png)

### Resolution scale 2.0 (default and new maximum value)

![2022-03-14_01 43 02_supersample_2](https://user-images.githubusercontent.com/180032/158087463-bdf6d6fb-298b-46bb-a478-95b7076a1522.png)
