### PR TITLE
Fix precission error in voronoi fill output

### DIFF
--- a/addons/material_maker/nodes/voronoi.mmg
+++ b/addons/material_maker/nodes/voronoi.mmg
@@ -8,10 +8,12 @@
 		"intensity": 1,
 		"randomness": 0.85,
 		"scale_x": 4,
-		"scale_y": 5,
+		"scale_y": 4,
 		"stretch_x": 1,
 		"stretch_y": 1
 	},
+	"seed": 0,
+	"seed_locked": false,
 	"shader_model": {
 		"code": "vec4 $(name_uv)_xyzw = voronoi($uv, vec2($scale_x, $scale_y), vec2($stretch_y, $stretch_x), $intensity, $randomness, $seed);",
 		"global": "// Based on https://www.shadertoy.com/view/ldl3W8\n// The MIT License\n// Copyright © 2013 Inigo Quilez\nvec3 iq_voronoi(vec2 x, vec2 size, vec2 stretch, float randomness, vec2 seed) {\n    vec2 n = floor(x);\n    vec2 f = fract(x);\n\n\tvec2 mg, mr, mc;\n    float md = 8.0;\n    for (int j=-1; j<=1; j++)\n    for (int i=-1; i<=1; i++) {\n        vec2 g = vec2(float(i),float(j));\n\t\tvec2 o = randomness*rand2(seed + mod(n + g + size, size));\n\t\tvec2 c = g + o;\n        vec2 r = c - f;\n\t\tvec2 rr = r*stretch;\n        float d = dot(rr,rr);\n\n        if (d<md) {\n\t\t\tmc = c;\n            md = d;\n            mr = r;\n            mg = g;\n        }\n    }\n\n    md = 8.0;\n    for (int j=-2; j<=2; j++)\n    for (int i=-2; i<=2; i++) {\n        vec2 g = mg + vec2(float(i),float(j));\n\t\tvec2 o = randomness*rand2(seed + mod(n + g + size, size));\n        vec2 r = g + o - f;\n\t\tvec2 rr = (mr-r)*stretch;\n        if (dot(rr,rr)>0.00001)\n       \t\tmd = min(md, dot(0.5*(mr+r)*stretch, normalize((r-mr)*stretch)));\n    }\n\n    return vec3(md, mc+n);\n}\n\nvec4 voronoi(vec2 uv, vec2 size, vec2 stretch, float intensity, float randomness, float seed) {\n    uv *= size;\n\tvec3 v = iq_voronoi(uv, size, stretch, randomness, rand2(vec2(seed, 1.0-seed)));\n\treturn vec4(v.yz, intensity*length((uv-v.yz)*stretch), v.x);\n}\n",
@@ -42,7 +44,7 @@
 			},
 			{
 				"longdesc": "An output that should be plugged into a Fill companion node",
-				"rgba": "vec4(fract(($(name_uv)_xyzw.xy-1.0)/vec2($scale_x, $scale_y)), vec2(2.0)/vec2($scale_x, $scale_y))",
+				"rgba": "round( vec4(fract(($(name_uv)_xyzw.xy-1.0)/vec2($scale_x, $scale_y)), vec2(2.0)/vec2($scale_x, $scale_y)) * 4096.0 ) / 4096.0",
 				"shortdesc": "Fill",
 				"type": "rgba"
 			}


### PR DESCRIPTION
I spotted that we had the same kind of precission error in the Voronoi Fill output as we had in the Brick Fill output. Fixed it in the same way by rounding the values.

Before:
![image](https://user-images.githubusercontent.com/4955051/163333608-3730813c-fa7e-424f-90e9-06e841e51906.png)

After:
![image](https://user-images.githubusercontent.com/4955051/163333735-969956b1-52e9-44ca-8062-ba18664a1f0e.png)
