### PR TITLE
Fix tiling for fill output of running bond 3

### DIFF
--- a/addons/material_maker/nodes/bricks2.mmg
+++ b/addons/material_maker/nodes/bricks2.mmg
@@ -57,7 +57,7 @@
 			},
 			{
 				"longdesc": "An output that should be plugged into a Fill companion node",
-				"rgba": "vec4(round(fract($(name_uv)_rect.xy)*4096.0)/4096.0, $(name_uv)_rect.zw - $(name_uv)_rect.xy)",
+				"rgba": "round(vec4(fract($(name_uv)_rect.xy), $(name_uv)_rect.zw - $(name_uv)_rect.xy)*4096.0)/4096.0",
 				"shortdesc": "Brick Fill",
 				"type": "rgba"
 			},


### PR DESCRIPTION
Turns out there still was a precision error in fill output, for some reason only for running bond 3. Rounding the values for sizes as well as positions fixed the issue.