### PR TITLE
Remove node's control when aborting link creation

### DIFF
--- a/material_maker/widgets/linked_widgets/link.gd
+++ b/material_maker/widgets/linked_widgets/link.gd
@@ -76,6 +76,8 @@ func _input(event: InputEvent) -> void:
 					node.link_parameter(param_name, control.node.generator, control.widget.name)
 				elif creating:
 					node.generator.remove_parameter(param_name)
+			else:
+				node.generator.remove_parameter(param_name)
 			set_process_input(false)
 			queue_free()
 	get_tree().set_input_as_handled()


### PR DESCRIPTION
Fixes [Crash After Canceled Add Parameter #451](https://github.com/RodZill4/material-maker/issues/451)

The program crashes due to the link object trying to call an function of a non-existing object. This object is supposed to be set by the node the link is coming from.

Removes the control from the node when the link creation has been aborted.
The same thing happens when the user hits the `escape` key on their keyboard.