### PR TITLE
created new fbm noise node

### DIFF
--- a/addons/material_maker/nodes/fbm3.mmg
+++ b/addons/material_maker/nodes/fbm3.mmg
@@ -1,0 +1,212 @@
+{
+	"name": "fbm3",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"parameters": {
+		"folds": 0,
+		"iterations": 5,
+		"noise": 0,
+		"offset": 0,
+		"persistence": 0.5,
+		"scale_x": 2,
+		"scale_y": 2,
+        "x_coord": 0,
+        "y_coord": 0
+	},
+	"seed": 0,
+	"seed_locked": false,
+	"shader_model": {
+		"code": "",
+		"global": "float fbm_value(vec2 coord, vec2 size, float offset, float seed) {\n\tvec2 o = floor(coord)+rand2(vec2(seed, 1.0-seed))+size;\n\tvec2 f = fract(coord);\n\tfloat p00 = rand(mod(o, size));\n\tfloat p01 = rand(mod(o + vec2(0.0, 1.0), size));\n\tfloat p10 = rand(mod(o + vec2(1.0, 0.0), size));\n\tfloat p11 = rand(mod(o + vec2(1.0, 1.0), size));\n\tp00 = sin(p00 * 6.28318530718 + offset * 6.28318530718) / 2.0 + 0.5;\n\tp01 = sin(p01 * 6.28318530718 + offset * 6.28318530718) / 2.0 + 0.5;\n\tp10 = sin(p10 * 6.28318530718 + offset * 6.28318530718) / 2.0 + 0.5;\n\tp11 = sin(p11 * 6.28318530718 + offset * 6.28318530718) / 2.0 + 0.5;\n\tvec2 t =  f * f * f * (f * (f * 6.0 - 15.0) + 10.0);\n\treturn mix(mix(p00, p10, t.x), mix(p01, p11, t.x), t.y);\n}\n\nfloat fbm_perlin(vec2 coord, vec2 size, float offset, float seed) {\n\tvec2 o = floor(coord)+rand2(vec2(seed, 1.0-seed))+size;\n\tvec2 f = fract(coord);\n\tfloat a00 = rand(mod(o, size)) * 6.28318530718 + offset * 6.28318530718;\n\tfloat a01 = rand(mod(o + vec2(0.0, 1.0), size)) * 6.28318530718 + offset * 6.28318530718;\n\tfloat a10 = rand(mod(o + vec2(1.0, 0.0), size)) * 6.28318530718 + offset * 6.28318530718;\n\tfloat a11 = rand(mod(o + vec2(1.0, 1.0), size)) * 6.28318530718 + offset * 6.28318530718;\n\tvec2 v00 = vec2(cos(a00), sin(a00));\n\tvec2 v01 = vec2(cos(a01), sin(a01));\n\tvec2 v10 = vec2(cos(a10), sin(a10));\n\tvec2 v11 = vec2(cos(a11), sin(a11));\n\tfloat p00 = dot(v00, f);\n\tfloat p01 = dot(v01, f - vec2(0.0, 1.0));\n\tfloat p10 = dot(v10, f - vec2(1.0, 0.0));\n\tfloat p11 = dot(v11, f - vec2(1.0, 1.0));\n\tvec2 t =  f * f * f * (f * (f * 6.0 - 15.0) + 10.0);\n\treturn 0.5 + mix(mix(p00, p10, t.x), mix(p01, p11, t.x), t.y);\n}\n\nfloat fbm_perlinabs(vec2 coord, vec2 size, float offset, float seed) {\n\treturn abs(2.0*fbm_perlin(coord, size, offset, seed)-1.0);\n}\n\nfloat mod289(float x) {\n    return x - floor(x * (1.0 / 289.0)) * 289.0;\n}\n\nfloat permute(float x) {\n    return mod289(((x * 34.0) + 1.0) * x);\n}\n\nvec2 rgrad2(vec2 p, float rot, float seed) {\n\tfloat u = permute(permute(p.x) + p.y) * 0.0243902439 + rot; // Rotate by shift\n\tu = fract(u) * 6.28318530718; // 2*pi\n\treturn vec2(cos(u), sin(u));\n}\n\nfloat fbm_simplex(vec2 coord, vec2 size, float offset, float seed) {\n\tcoord *= 2.0; // needed for it to tile\n\tcoord += rand2(vec2(seed, 1.0-seed)) + size;\n\tsize *= 2.0; // needed for it to tile\n\tcoord.y += 0.001;\n    vec2 uv = vec2(coord.x + coord.y*0.5, coord.y);\n    vec2 i0 = floor(uv);\n    vec2 f0 = fract(uv);\n    vec2 i1 = (f0.x > f0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);\n    vec2 p0 = vec2(i0.x - i0.y * 0.5, i0.y);\n    vec2 p1 = vec2(p0.x + i1.x - i1.y * 0.5, p0.y + i1.y);\n    vec2 p2 = vec2(p0.x + 0.5, p0.y + 1.0);\n    i1 = i0 + i1;\n    vec2 i2 = i0 + vec2(1.0, 1.0);\n    vec2 d0 = coord - p0;\n    vec2 d1 = coord - p1;\n    vec2 d2 = coord - p2;\n    vec3 xw = mod(vec3(p0.x, p1.x, p2.x), size.x);\n    vec3 yw = mod(vec3(p0.y, p1.y, p2.y), size.y);\n    vec3 iuw = xw + 0.5 * yw;\n    vec3 ivw = yw;\n    vec2 g0 = rgrad2(vec2(iuw.x, ivw.x), offset, seed);\n    vec2 g1 = rgrad2(vec2(iuw.y, ivw.y), offset, seed);\n    vec2 g2 = rgrad2(vec2(iuw.z, ivw.z), offset, seed);\n    vec3 w = vec3(dot(g0, d0), dot(g1, d1), dot(g2, d2));\n    vec3 t = 0.8 - vec3(dot(d0, d0), dot(d1, d1), dot(d2, d2));\n    t = max(t, vec3(0.0));\n    vec3 t2 = t * t;\n    vec3 t4 = t2 * t2;\n    float n = dot(t4, w);\n    return 0.5 + 5.5 * n;\n}\n\nfloat fbm_cellular(vec2 coord, vec2 size, float offset, float seed) {\n\tvec2 o = floor(coord)+rand2(vec2(seed, 1.0-seed))+size;\n\tvec2 f = fract(coord);\n\tfloat min_dist = 2.0;\n\tfor(float x = -1.0; x <= 1.0; x++) {\n\t\tfor(float y = -1.0; y <= 1.0; y++) {\n\t\t\tvec2 neighbor = vec2(float(x),float(y));\n\t\t\tvec2 node = rand2(mod(o + vec2(x, y), size)) + vec2(x, y);\n\t\t\tnode =  0.5 + 0.25 * sin(offset * 6.28318530718 + 6.28318530718 * node);\n\t\t\tvec2 diff = neighbor + node - f;\n\t\t\tfloat dist = length(diff);\n\t\t\tmin_dist = min(min_dist, dist);\n\t\t}\n\t}\n\treturn min_dist;\n}\n\nfloat fbm_cellular2(vec2 coord, vec2 size, float offset, float seed) {\n\tvec2 o = floor(coord)+rand2(vec2(seed, 1.0-seed))+size;\n\tvec2 f = fract(coord);\n\tfloat min_dist1 = 2.0;\n\tfloat min_dist2 = 2.0;\n\tfor(float x = -1.0; x <= 1.0; x++) {\n\t\tfor(float y = -1.0; y <= 1.0; y++) {\n\t\t\tvec2 neighbor = vec2(float(x),float(y));\n\t\t\tvec2 node = rand2(mod(o + vec2(x, y), size)) + vec2(x, y);\n\t\t\tnode = 0.5 + 0.25 * sin(offset * 6.28318530718 + 6.28318530718*node);\n\t\t\tvec2 diff = neighbor + node - f;\n\t\t\tfloat dist = length(diff);\n\t\t\tif (min_dist1 > dist) {\n\t\t\t\tmin_dist2 = min_dist1;\n\t\t\t\tmin_dist1 = dist;\n\t\t\t} else if (min_dist2 > dist) {\n\t\t\t\tmin_dist2 = dist;\n\t\t\t}\n\t\t}\n\t}\n\treturn min_dist2-min_dist1;\n}\n\nfloat fbm_cellular3(vec2 coord, vec2 size, float offset, float seed) {\n\tvec2 o = floor(coord)+rand2(vec2(seed, 1.0-seed))+size;\n\tvec2 f = fract(coord);\n\tfloat min_dist = 2.0;\n\tfor(float x = -1.0; x <= 1.0; x++) {\n\t\tfor(float y = -1.0; y <= 1.0; y++) {\n\t\t\tvec2 neighbor = vec2(float(x),float(y));\n\t\t\tvec2 node = rand2(mod(o + vec2(x, y), size)) + vec2(x, y);\n\t\t\tnode = 0.5 + 0.25 * sin(offset * 6.28318530718 + 6.28318530718*node);\n\t\t\tvec2 diff = neighbor + node - f;\n\t\t\tfloat dist = abs((diff).x) + abs((diff).y);\n\t\t\tmin_dist = min(min_dist, dist);\n\t\t}\n\t}\n\treturn min_dist;\n}\n\nfloat fbm_cellular4(vec2 coord, vec2 size, float offset, float seed) {\n\tvec2 o = floor(coord)+rand2(vec2(seed, 1.0-seed))+size;\n\tvec2 f = fract(coord);\n\tfloat min_dist1 = 2.0;\n\tfloat min_dist2 = 2.0;\n\tfor(float x = -1.0; x <= 1.0; x++) {\n\t\tfor(float y = -1.0; y <= 1.0; y++) {\n\t\t\tvec2 neighbor = vec2(float(x),float(y));\n\t\t\tvec2 node = rand2(mod(o + vec2(x, y), size)) + vec2(x, y);\n\t\t\tnode = 0.5 + 0.25 * sin(offset * 6.28318530718 + 6.28318530718*node);\n\t\t\tvec2 diff = neighbor + node - f;\n\t\t\tfloat dist = abs((diff).x) + abs((diff).y);\n\t\t\tif (min_dist1 > dist) {\n\t\t\t\tmin_dist2 = min_dist1;\n\t\t\t\tmin_dist1 = dist;\n\t\t\t} else if (min_dist2 > dist) {\n\t\t\t\tmin_dist2 = dist;\n\t\t\t}\n\t\t}\n\t}\n\treturn min_dist2-min_dist1;\n}\n\nfloat fbm_cellular5(vec2 coord, vec2 size, float offset, float seed) {\n\tvec2 o = floor(coord)+rand2(vec2(seed, 1.0-seed))+size;\n\tvec2 f = fract(coord);\n\tfloat min_dist = 2.0;\n\tfor(float x = -1.0; x <= 1.0; x++) {\n\t\tfor(float y = -1.0; y <= 1.0; y++) {\n\t\t\tvec2 neighbor = vec2(float(x),float(y));\n\t\t\tvec2 node = rand2(mod(o + vec2(x, y), size)) + vec2(x, y);\n\t\t\tnode = 0.5 + 0.5 * sin(offset * 6.28318530718 + 6.28318530718*node);\n\t\t\tvec2 diff = neighbor + node - f;\n\t\t\tfloat dist = max(abs((diff).x), abs((diff).y));\n\t\t\tmin_dist = min(min_dist, dist);\n\t\t}\n\t}\n\treturn min_dist;\n}\n\nfloat fbm_cellular6(vec2 coord, vec2 size, float offset, float seed) {\n\tvec2 o = floor(coord)+rand2(vec2(seed, 1.0-seed))+size;\n\tvec2 f = fract(coord);\n\tfloat min_dist1 = 2.0;\n\tfloat min_dist2 = 2.0;\n\tfor(float x = -1.0; x <= 1.0; x++) {\n\t\tfor(float y = -1.0; y <= 1.0; y++) {\n\t\t\tvec2 neighbor = vec2(float(x),float(y));\n\t\t\tvec2 node = rand2(mod(o + vec2(x, y), size)) + vec2(x, y);\n\t\t\tnode = 0.5 + 0.25 * sin(offset * 6.28318530718 + 6.28318530718*node);\n\t\t\tvec2 diff = neighbor + node - f;\n\t\t\tfloat dist = max(abs((diff).x), abs((diff).y));\n\t\t\tif (min_dist1 > dist) {\n\t\t\t\tmin_dist2 = min_dist1;\n\t\t\t\tmin_dist1 = dist;\n\t\t\t} else if (min_dist2 > dist) {\n\t\t\t\tmin_dist2 = dist;\n\t\t\t}\n\t\t}\n\t}\n\treturn min_dist2-min_dist1;\n}\n\n// MIT License Inigo Quilez - https://www.shadertoy.com/view/Xd23Dh\nfloat fbm_voronoise( vec2 coord, vec2 size, float offset, float seed) {\n    vec2 i = floor(coord) + rand2(vec2(seed, 1.0-seed)) + size;\n    vec2 f = fract(coord);\n    \n\tvec2 a = vec2(0.0);\n\t\n    for( int y=-2; y<=2; y++ ) {\n    \tfor( int x=-2; x<=2; x++ ) {\n        \tvec2  g = vec2( float(x), float(y) );\n\t\t\tvec3  o = rand3( mod(i + g, size) + vec2(seed) );\n\t\t\to.xy += 0.25 * sin(offset * 6.28318530718 + 6.28318530718*o.xy);\n\t\t\tvec2  d = g - f + o.xy;\n\t\t\tfloat w = pow( 1.0-smoothstep(0.0, 1.414, length(d)), 1.0 );\n\t\t\ta += vec2(o.z*w,w);\n\t\t}\n    }\n\t\n    return a.x/a.y;\n}",
+		"inputs": [
+            {
+				"default": "$(uv).x",
+				"label": "1:",
+				"longdesc": "An optional X coord to sample the noise function",
+				"name": "x_coord_in",
+				"shortdesc": "X coord",
+				"type": "f"
+			},
+            {
+				"default": "$(uv).y",
+				"label": "2:",
+				"longdesc": "An optional Y coord to sample the noise function",
+				"name": "y_coord_in",
+				"shortdesc": "Y Coord",
+				"type": "f"
+			},
+			{
+				"default": "$offset",
+				"label": "7:",
+				"longdesc": "An optional input to drive the offset",
+				"name": "offset_in",
+				"shortdesc": "Offset Input",
+				"type": "f"
+			},
+            
+		],
+		"instance": "float $(name)_fbm(vec2 coord, vec2 size, int folds, int octaves, float persistence, float offset, float seed) {\n\tfloat normalize_factor = 0.0;\n\tfloat value = 0.0;\n\tfloat scale = 1.0;\n\tfor (int i = 0; i < octaves; i++) {\n\t\tfloat noise = fbm_$noise(coord*size, size, offset, seed);\n\t\tfor (int f = 0; f < folds; ++f) {\n\t\t\tnoise = abs(2.0*noise-1.0);\n\t\t}\n\t\tvalue += noise * scale;\n\t\tnormalize_factor += scale;\n\t\tsize *= 2.0;\n\t\tscale *= persistence;\n\t}\n\treturn value / normalize_factor;\n}\n",
+		"longdesc": "Generates a noise made of several octaves of a simple noise",
+		"name": "FBM Noise",
+		"outputs": [
+			{
+				"f": "$(name)_fbm(vec2($x_coord_in($uv)+$(x_coord), $y_coord_in($uv)+($y_coord)), vec2($(scale_x), $(scale_y)), int($(folds)), int($(iterations)), $(persistence), $offset_in($uv), $(seed))",
+				"longdesc": "Shows a greyscale image of the generated noise",
+				"shortdesc": "Output",
+				"type": "f"
+			}
+		],
+		"parameters": [
+            {
+				"control": "None",
+				"default": 0.0,
+				"label": "X Coord",
+				"longdesc": "",
+				"max": 1,
+				"min": 0,
+				"name": "x_coord",
+				"shortdesc": "X coord",
+				"step": 0.01,
+				"type": "float"
+			},
+            {
+				"control": "None",
+				"default": 0.0,
+				"label": "Y Coord",
+				"longdesc": "",
+				"max": 1,
+				"min": 0,
+				"name": "y_coord",
+				"shortdesc": "Y coord",
+				"step": 0.01,
+				"type": "float"
+			},
+			{
+				"default": 2,
+				"label": "Noise",
+				"longdesc": "The simple noise type",
+				"name": "noise",
+				"shortdesc": "Noise type",
+				"type": "enum",
+				"values": [
+					{
+						"name": "Value",
+						"value": "value"
+					},
+					{
+						"name": "Perlin",
+						"value": "perlin"
+					},
+					{
+						"name": "Simplex",
+						"value": "simplex"
+					},
+					{
+						"name": "Cellular",
+						"value": "cellular"
+					},
+					{
+						"name": "Cellular2",
+						"value": "cellular2"
+					},
+					{
+						"name": "Cellular3",
+						"value": "cellular3"
+					},
+					{
+						"name": "Cellular4",
+						"value": "cellular4"
+					},
+					{
+						"name": "Cellular5",
+						"value": "cellular5"
+					},
+					{
+						"name": "Cellular6",
+						"value": "cellular6"
+					},
+					{
+						"name": "Voronoise",
+						"value": "voronoise"
+					}
+				]
+			},
+			{
+				"control": "None",
+				"default": 4,
+				"label": "Scale X",
+				"longdesc": "The scale of the first octave along the X axis",
+				"max": 32,
+				"min": 1,
+				"name": "scale_x",
+				"shortdesc": "Scale.x",
+				"step": 1,
+				"type": "float"
+			},
+			{
+				"control": "None",
+				"default": 4,
+				"label": "Scale Y",
+				"longdesc": "The scale of the first octave along the Y axis",
+				"max": 32,
+				"min": 1,
+				"name": "scale_y",
+				"shortdesc": "Scale.y",
+				"step": 1,
+				"type": "float"
+			},
+			{
+				"control": "None",
+				"default": 0,
+				"label": "Folds",
+				"longdesc": "The number of times the basic noise is folded",
+				"max": 5,
+				"min": 0,
+				"name": "folds",
+				"shortdesc": "Folds",
+				"step": 1,
+				"type": "float"
+			},
+			{
+				"control": "None",
+				"default": 3,
+				"label": "Iterations",
+				"longdesc": "The number of noise octaves",
+				"max": 10,
+				"min": 1,
+				"name": "iterations",
+				"shortdesc": "Octaves",
+				"step": 1,
+				"type": "float"
+			},
+			{
+				"control": "None",
+				"default": 0.5,
+				"label": "Persistence",
+				"longdesc": "The persistence between two consecutive octaves",
+				"max": 1,
+				"min": 0,
+				"name": "persistence",
+				"shortdesc": "Persistence",
+				"step": 0.01,
+				"type": "float"
+			},
+			{
+				"control": "None",
+				"default": 0,
+				"label": "Offset",
+				"longdesc": "Offsets the points of the noise, can be used to animate the noise with \"$time\"",
+				"max": 1,
+				"min": 0,
+				"name": "offset",
+				"shortdesc": "Offset",
+				"step": 0.01,
+				"type": "float"
+			}
+		],
+		"shortdesc": "Fractional Brownian Motion Noise"
+	},
+	"type": "shader"
+}


### PR DESCRIPTION
Added a new fbm noise node that takes an x,y coordinate to for input to the noise function instead of just using uv. You can see this being used [here](https://thebookofshaders.com/13/). the coordinate input default to uv so that it can be used in place of the current fbm node

here is an attempt to recreate the same effect in MM
![fbm_test](https://user-images.githubusercontent.com/5156663/177844040-fe4e422c-453b-4b12-a66b-a06f714bc001.png)

