### PR TITLE
Fix screenshot size in AppStream metadata

### DIFF
--- a/material_maker/misc/linux/io.github.RodZill4.Material-Maker.appdata.xml
+++ b/material_maker/misc/linux/io.github.RodZill4.Material-Maker.appdata.xml
@@ -17,7 +17,7 @@
   <url type="bugtracker">https://github.com/RodZill4/material-maker/issues</url>
   <screenshots>
     <screenshot type="default">
-      <image type="source" width="1282" height="752">https://raw.githubusercontent.com/RodZill4/material-maker/master/material_maker/doc/images/screenshot.png</image>
+      <image type="source" width="1257" height="680">https://raw.githubusercontent.com/RodZill4/material-maker/master/material_maker/doc/images/screenshot.png</image>
       <caption>Editing a procedurally generated texture</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
This caused `appstream-util-validate` to fail. It's valid now:

```
❯ appstream-util validate material_maker/misc/linux/io.github.RodZill4.Material-Maker.appdata.xml 
material_maker/misc/linux/io.github.RodZill4.Material-Maker.appdata.xml: OK
```

This is required for https://github.com/flathub/io.github.RodZill4.Material-Maker/pull/6. I'll point to the commit with the fixed AppStream metadata once this PR is merged :slightly_smiling_face: 