### PR TITLE
Add vec3 math operations

### DIFF
--- a/addons/material_maker/nodes/math_v3.mmg
+++ b/addons/material_maker/nodes/math_v3.mmg
@@ -12,7 +12,7 @@
 		"d_in2_x": 0,
 		"d_in2_y": 0,
 		"d_in2_z": 0,
-		"op": 19
+		"op": 24
 	},
 	"shader_model": {
 		"code": "vec3 $(name_uv)_clamp_false = $op;\nvec3 $(name_uv)_clamp_true = clamp($(name_uv)_clamp_false, vec3(0.0), vec3(1.0));\n",
@@ -48,7 +48,7 @@
 		],
 		"parameters": [
 			{
-				"default": 19,
+				"default": 24,
 				"label": "",
 				"longdesc": "The operation to be performed",
 				"name": "op",
@@ -134,6 +134,26 @@
 					{
 						"name": "sqrt(1-A²)",
 						"value": "sqrt(vec3(1.0)-$in1($uv)*$in1($uv))"
+					},
+					{
+						"name": "length(A)",
+						"value": "vec3(length($in1($uv)))"
+					},
+					{
+						"name": "distance(A,B)",
+						"value": "vec3(distance($in1($uv),$in2($uv)))"
+					},
+					{
+						"name": "dot(A,B)",
+						"value": "vec3(dot($in1(uv),$in2($uv)))"
+					},
+					{
+						"name": "cross(A,B)",
+						"value": "cross($in1($uv),$in2($uv))"
+					},
+					{
+						"name": "normalize(A)",
+						"value": "normalize($in1($uv))"
 					}
 				]
 			},

--- a/addons/material_maker/nodes/math_v3.mmg
+++ b/addons/material_maker/nodes/math_v3.mmg
@@ -48,7 +48,7 @@
 		],
 		"parameters": [
 			{
-				"default": 24,
+				"default": 0,
 				"label": "",
 				"longdesc": "The operation to be performed",
 				"name": "op",
@@ -154,6 +154,14 @@
 					{
 						"name": "normalize(A)",
 						"value": "normalize($in1($uv))"
+					},
+					{
+						"name": "sign(A)",
+						"value": "sign($in1($uv))"
+					},
+					{
+						"name": "mod(A, B)",
+						"value": "mod($in1($uv),$in2($uv))"
 					}
 				]
 			},

--- a/addons/material_maker/nodes/math_v3.mmg
+++ b/addons/material_maker/nodes/math_v3.mmg
@@ -12,7 +12,7 @@
 		"d_in2_x": 0,
 		"d_in2_y": 0,
 		"d_in2_z": 0,
-		"op": 24
+		"op": 0
 	},
 	"shader_model": {
 		"code": "vec3 $(name_uv)_clamp_false = $op;\nvec3 $(name_uv)_clamp_true = clamp($(name_uv)_clamp_false, vec3(0.0), vec3(1.0));\n",

--- a/material_maker/doc/node_filter_vec3_math.rst
+++ b/material_maker/doc/node_filter_vec3_math.rst
@@ -1,0 +1,28 @@
+Vec3 Math node
+~~~~~~~~~~~~~~
+
+The **Vec3 Math** node performs various vector math operations between its inputs.
+
+.. image:: images/node_filter_math_vec3.png
+	:align: center
+
+Inputs
+++++++
+
+The **Vec3 Math** node accepts two color inputs. Those inputs are optional, and when
+left unconnected, the corresponding parameter value is used
+
+Outputs
++++++++
+
+The **Vec3 Math** node generates a single color texture that contains the result
+of the vector math operation.
+
+Parameters
+++++++++++
+
+The **Vec3 Math** node accepts the following parameters:
+
+* the *operation* to be performed
+* *default values* to be used in place of the inputs when left unconnected
+* a boolean that specifies if the result must be clamped between 0 and 1

--- a/material_maker/doc/nodes_filter.rst
+++ b/material_maker/doc/nodes_filter.rst
@@ -46,6 +46,7 @@ The filter nodes accept one or several inputs and generate one or several images
 	node_filter_fill_to_orientation
 	node_filter_fill_to_gradient
 	node_filter_math
+	node_filter_vec3_math
 	node_filter_smooth_minmax
 	node_filter_maketileable
 	node_filter_pixelize

--- a/material_maker/library/base.json
+++ b/material_maker/library/base.json
@@ -6279,7 +6279,7 @@
 				"d_in2_x": 0,
 				"d_in2_y": 0,
 				"d_in2_z": 0,
-				"op": 24
+				"op": 0
 			},
 			"seed": 0,
 			"seed_locked": false,

--- a/material_maker/library/base.json
+++ b/material_maker/library/base.json
@@ -6279,7 +6279,7 @@
 				"d_in2_x": 0,
 				"d_in2_y": 0,
 				"d_in2_z": 0,
-				"op": 19
+				"op": 24
 			},
 			"seed": 0,
 			"seed_locked": false,


### PR DESCRIPTION
This adds additional vector math operations for the vec3 math node:
Length, Distance, Dot Product, Cross Product and Normalize

I am following the convention from the current node so it defaults to the last operation, though should it be following the regular math node which selects the first operation by default instead?

![image](https://user-images.githubusercontent.com/830253/183392852-63924101-abaa-454d-85a3-a747130025dc.png)
![image](https://user-images.githubusercontent.com/830253/183393208-5d76fa72-d339-4da1-872b-48fd2f99e088.png)
