### PR TITLE
Add additional modes for math node

### DIFF
--- a/addons/material_maker/nodes/math.mmg
+++ b/addons/material_maker/nodes/math.mmg
@@ -136,6 +136,46 @@
 					{
 						"name": "smoothstep(0.0, 1.0, A)",
 						"value": "smoothstep(0.0, 1.0, $in1($uv))"
+					},
+					{
+						"name": "sign(A)",
+						"value": "sign($in1($uv))"
+					},
+					{
+						"name": "mod(A,B)",
+						"value": "mod($in1($uv), $in2($uv))"
+					},
+					{
+						"name": "atan2(A,B)",
+						"value": "atan($in1($uv),$in2($uv))"
+					},
+					{
+						"name": "asin(A)",
+						"value": "asin($in1($uv))"
+					},
+					{
+						"name": "acos(A)",
+						"value": "acos($in1($uv))"
+					},
+					{
+						"name": "atan(A)",
+						"value": "atan($in1($uv))"
+					},
+					{
+						"name": "sinh(A)",
+						"value": "sinh($in1($uv))"
+					},
+					{
+						"name": "cosh(A)",
+						"value": "cosh($in1($uv))"
+					},
+					{
+						"name": "tanh(A)",
+						"value": "tanh($in1($uv))"
+					},
+					{
+						"name": "exp(A)",
+						"value": "exp($in1($uv))"
 					}
 				]
 			},

--- a/addons/material_maker/nodes/math.mmg
+++ b/addons/material_maker/nodes/math.mmg
@@ -14,7 +14,7 @@
 	"seed_locked": false,
 	"shader_model": {
 		"code": "float $(name_uv)_clamp_false = $op;\nfloat $(name_uv)_clamp_true = clamp($(name_uv)_clamp_false, 0.0, 1.0);\n",
-		"global": "",
+		"global": "float pingpong(float a, float b)\n{\n  return (b != 0.0) ? abs(fract((a - b) / (b * 2.0)) * b * 2.0 - b) : 0.0;\n}",
 		"inputs": [
 			{
 				"default": "$default_in1",
@@ -136,6 +136,10 @@
 					{
 						"name": "smoothstep(0.0, 1.0, A)",
 						"value": "smoothstep(0.0, 1.0, $in1($uv))"
+					},
+					{
+						"name": "ping-pong(A, B)",
+						"value": "pingpong($in1($uv),$in2($uv))"
 					},
 					{
 						"name": "sign(A)",


### PR DESCRIPTION
Additional modes for the math node, currently this adds 10 new modes:

![math_nodes_sample](https://user-images.githubusercontent.com/830253/185100410-a60e974c-c633-4acd-b379-8c077d1ddda5.png)
![expression_sample](https://user-images.githubusercontent.com/830253/185100554-75ff498a-79c3-4247-ac26-2b841366d33d.png)
