### PR TITLE
Remove redundant entry in nodes_simple.rst

### DIFF
--- a/material_maker/doc/nodes_simple.rst
+++ b/material_maker/doc/nodes_simple.rst
@@ -17,4 +17,3 @@ The simple nodes are nodes that do not accept any input and generate one or seve
 	node_simple_profile
 	node_simple_polycurve
 	node_simple_easysdf
-	node_simple_seven_segment_display


### PR DESCRIPTION
This removes the redundant entry in `nodes_simple.rst`:

`node_simple_seven_segment_display`