### PR TITLE
Don't stop automatic rotation when rotating Preview3D

### DIFF
--- a/material_maker/panels/preview_3d/preview_3d.gd
+++ b/material_maker/panels/preview_3d/preview_3d.gd
@@ -152,7 +152,6 @@ func zoom(amount : float):
 
 func on_gui_input(event) -> void:
 	if event is InputEventPanGesture:
-		$MaterialPreview/Preview3d/ObjectRotate.stop(false)
 		var camera_basis = camera.global_transform.basis
 		var rotation : Vector2 = event.delta
 		camera_stand.rotate(camera_basis.x.normalized(), -rotation.y)
@@ -160,10 +159,6 @@ func on_gui_input(event) -> void:
 	elif event is InputEventMagnifyGesture:
 		zoom(event.factor)
 	elif event is InputEventMouseButton:
-		if event.button_index == BUTTON_LEFT or event.button_index == BUTTON_RIGHT or event.button_index == BUTTON_MIDDLE:
-			# Don't stop rotating the preview on mouse wheel usage (zoom change).
-			$MaterialPreview/Preview3d/ObjectRotate.stop(false)
-
 		match event.button_index:
 			BUTTON_WHEEL_UP:
 				if event.command:


### PR DESCRIPTION
This has come up on Discord a couple of times ([1](https://discord.com/channels/784201835334074389/789821738669572137/1013547310950662305), [2](https://discord.com/channels/784201835334074389/789948291517382759/1007279107492548618)) and I happened to have a local patch for this already :smile: