### PR TITLE
Add Depth output to Normal Map node

### DIFF
--- a/addons/material_maker/nodes/normal_map2.mmg
+++ b/addons/material_maker/nodes/normal_map2.mmg
@@ -41,6 +41,24 @@
 			"from_port": 0,
 			"to": "switch",
 			"to_port": 1
+		},
+		{
+			"from": "math",
+			"from_port": 0,
+			"to": "gen_outputs",
+			"to_port": 1
+		},
+		{
+			"from": "gen_inputs",
+			"from_port": 0,
+			"to": "math_2",
+			"to_port": 1
+		},
+		{
+			"from": "math_2",
+			"from_port": 0,
+			"to": "math",
+			"to_port": 0
 		}
 	],
 	"label": "Normal Map",
@@ -117,6 +135,10 @@
 						{
 							"node": "edge_detect_1",
 							"widget": "amount"
+						},
+						{
+							"node": "math",
+							"widget": "default_in2"
 						}
 					],
 					"longdesc": "The strength of the normal map filter",
@@ -158,8 +180,8 @@
 		{
 			"name": "gen_outputs",
 			"node_position": {
-				"x": -445.663818,
-				"y": 75.047363
+				"x": -414.663818,
+				"y": 77.047363
 			},
 			"parameters": {
 
@@ -169,8 +191,14 @@
 					"group_size": 0,
 					"longdesc": "Shows the generated normal map",
 					"name": "Normal",
-					"shortdesc": "Output",
+					"shortdesc": "Normal",
 					"type": "rgb"
+				},
+				{
+					"longdesc": "The corresponding depth map ready to be connected to the material",
+					"name": "Depth",
+					"shortdesc": "Depth",
+					"type": "f"
 				}
 			],
 			"seed": -6314,
@@ -180,8 +208,8 @@
 		{
 			"name": "gen_inputs",
 			"node_position": {
-				"x": -1094.910156,
-				"y": 74.047363
+				"x": -1119.910156,
+				"y": 81.047363
 			},
 			"parameters": {
 
@@ -319,6 +347,38 @@
 			"seed": 0,
 			"seed_locked": false,
 			"type": "pack_2x16_to_1x32"
+		},
+		{
+			"name": "math",
+			"node_position": {
+				"x": -581.165161,
+				"y": 334.908386
+			},
+			"parameters": {
+				"clamp": false,
+				"default_in1": 0,
+				"default_in2": 1,
+				"op": 2
+			},
+			"seed": 0,
+			"seed_locked": false,
+			"type": "math"
+		},
+		{
+			"name": "math_2",
+			"node_position": {
+				"x": -808.220703,
+				"y": 334.130615
+			},
+			"parameters": {
+				"clamp": false,
+				"default_in1": 1,
+				"default_in2": 1,
+				"op": 1
+			},
+			"seed": 0,
+			"seed_locked": false,
+			"type": "math"
 		}
 	],
 	"parameters": {


### PR DESCRIPTION
Adds a "Depth" output whose scale is linked to the strength of the normal map, to streamline height-only workflows.


Intended usage:
![1666807922](https://user-images.githubusercontent.com/103326468/198105986-0faa8700-1b6f-41e3-9c4a-a726d85777ac.jpg)


The Normal Map node being proposed by this pull request:
![1666808881](https://user-images.githubusercontent.com/103326468/198106984-b79def31-e057-463d-9ef6-f8ef77ee4b4d.png)
