### PR TITLE
Add a basic regression test that operates via checksums

### DIFF
--- a/addons/material_maker/engine/renderer.gd
+++ b/addons/material_maker/engine/renderer.gd
@@ -96,7 +96,7 @@ func render_material(object : Object, material : Material, render_size : int, wi
 	return self
 
 func render_shader(object : Object, shader : String, textures : Dictionary, render_size : int, with_hdr : bool = true) -> Object:
-	var shader_material = $ColorRect.material
+	var shader_material = $ColorRect.material.duplicate(true)
 	shader_material.shader.code = shader
 	if textures != null:
 		for k in textures.keys():

--- a/material_maker/doc/command_line.rst
+++ b/material_maker/doc/command_line.rst
@@ -9,7 +9,7 @@ extension so double-clicking on them will directly open them.
 
 Material Maker can also be used to export several .ptex file with the following command line:
 
- material_maker --export -t <engine> -o <output_path> <input_files>
+ material_maker --export-material --target <engine> -o <output_path> <input_files>
 
 Where:
 

--- a/start.gd
+++ b/start.gd
@@ -22,7 +22,7 @@ func _ready():
 					OS.execute(bat_file_path, [], true, output)
 					dir.remove(bat_file_path)
 					dir.change_dir(output[0].split("\n")[2])
-			var target : String = "Godot"
+			var target : String = "Godot/Godot 4 Standard"
 			var output_dir : String = dir.get_current_dir()
 			var size : int = 0
 			var files : Array = []
@@ -113,9 +113,11 @@ func export_files(files, output_dir, target, size) -> void:
 				if c.has_method("export_material"):
 					if c.has_method("get_export_profiles"):
 						if c.get_export_profiles().find(target) == -1:
-							show_error("ERROR: Unsupported target %s"+target)
+							show_error("ERROR: Unsupported target '%s', please select from the following:\n%s" % [target, "\n".join(c.get_export_profiles())])
 							continue
-					$VBoxContainer/Label.text = "Exporting "+f.get_file()
+					var export_msg = "Exporting %s to %s..." % [f.get_file(), output_dir]
+					$VBoxContainer/Label.text = export_msg
+					print(export_msg)
 					var prefix : String = output_dir+"/"+f.get_file().get_basename()
 					var result = c.export_material(prefix, target, size)
 					while result is GDScriptFunctionState:
@@ -125,5 +127,6 @@ func export_files(files, output_dir, target, size) -> void:
 	get_tree().quit()
 
 func show_error(message : String):
+	print(message)
 	$ErrorPanel.show()
 	$ErrorPanel/Label.text = message

--- a/tests/regression_export.sh
+++ b/tests/regression_export.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+testdir=/tmp/material_maker_test
+outputdir=$testdir/$(date +%s)/
+mm_command="godot --no-window --path ."
+
+
+if [[ $# -lt 1 ]]; then
+	echo "Example Usage:"
+	echo
+	echo "	$0 --size 512 material_maker/examples/*.ptex"
+	echo
+	echo "The --size argument is optional but highly recommended to speed up testing."
+	echo
+	exit
+fi
+
+
+mkdir -p $outputdir
+$mm_command --export-material -o $outputdir "$@"
+cd $outputdir
+
+echo
+
+if [[ -e $testdir/mm.sha ]]; then
+	echo "Checksums found, testing for regressions..."
+	echo
+	shasum -c $testdir/mm.sha
+	result=$?
+	echo
+	if [[ $result -eq 0 ]]; then
+		echo "Done! No regressions found."
+		echo "To start a new test, you can remove the testing directory:"
+		echo
+		echo "	rm -r $testdir"
+		echo
+	else
+		exit $result
+	fi
+else
+	echo "Creating checksums..."
+	echo
+	shasum * | tee $testdir/mm.sha
+	echo
+	echo "Done! Rerun this script after making your changes to test for regressions."
+	echo "Please be sure to use the exact same arguments to avoid triggering any false positives."
+	echo "You may want to double check the exported textures for rendering errors:"
+	echo
+	echo "	xdg-open $outputdir"
+	echo
+fi
+
+


### PR DESCRIPTION
Adds a shell script that tests for regressions in the given materials by exporting and then checksumming them. If even a single pixel changes after the script is rerun, the checksums will be different and you will be alerted.
Right now, the intended use case is manually testing for regressions when doing large invasive changes like mass refactors, and maybe basic sanity checking between version releases.

Also includes fixes to various problems with command line exporting that I encountered along the way.

Adding this into CI may be possible if software rasterization can guarantee consistent results across platforms, but is outside the scope of this PR.