### PR TITLE
Remove file from recent list if it fails to load

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -497,6 +497,9 @@ func do_load_project(file_name) -> bool:
 			hierarchy.update_from_graph_edit(get_current_graph_edit())
 		"mmpp":
 			status = do_load_painting(file_name)
+	var dir = Directory.new()
+	if !dir.file_exists(file_name):
+		status = false
 	if status:
 		add_recent(file_name)
 	else:


### PR DESCRIPTION
If you move or delete a file on your system, it will fail to load from the recent list and stay in the list. This removes the path from the recent list if it's failed to load.