### PR TITLE
Adjust mmg format to make shader code more diffable

### DIFF
--- a/addons/material_maker/engine/loader.gd
+++ b/addons/material_maker/engine/loader.gd
@@ -78,42 +78,6 @@ func generator_name_from_path(path : String) -> String:
 	print(path.get_base_dir())
 	return path.get_basename().get_file()
 
-static func string_to_dict_tree_old(string_data : String) -> Dictionary:
-	var file_data = string_data.split("\n########################################")
-	var data = parse_json(file_data[0])
-	file_data.remove(0)
-
-	if not data:
-		return data
-
-	var re = RegEx.new()
-	re.compile("^(?<type>.+?):(?<path>.+)\n(?<val>(.|\n)*)")
-
-	for f in file_data:
-		var result = re.search(f)
-		if not result:
-			print("File appears to be corrupt, some data will be missing")
-			break
-
-		var val = result.get_string("val")
-		match result.get_string("type"):
-			"string":
-				val = val.replace("    ", "    ") #TODO: Pick tab vs space
-			var path_type:
-				print("Unrecognized type %s, this file may have been written by a newer version of Material Maker" % path_type)
-
-		var data_dict = data
-		var path = result.get_string("path")
-		while true:
-			var path_split = path.split(".", true, 1)
-			if path_split.size() == 1:
-				break
-			data_dict = data_dict[path_split[0]]
-			path = path_split[1]
-		data_dict[path] = val
-
-	return data
-
 const REPLACE_MULTILINE_STRINGS_PROCESS_ITEMS : Array = [ "code", "instance", "global", "preview_shader", "template" ]
 const REPLACE_MULTILINE_STRINGS_WALK_ITEMS : Array = [ "shader_model", "nodes", "template", "files" ]
 const REPLACE_MULTILINE_STRINGS_WALK_CHILDREN : Array = [ "exports" ]

--- a/addons/material_maker/nodes/beehive.mmg
+++ b/addons/material_maker/nodes/beehive.mmg
@@ -8,8 +8,26 @@
 		"sx": 4,
 		"sy": 4
 	},
-	"seed_int": 0,
 	"shader_model": {
+		"code": [
+			"vec2 $(name_uv)_uv = $uv*vec2($sx, $sy*1.73205080757);",
+			"vec4 $(name_uv)_center = beehive_center($(name_uv)_uv);"
+		],
+		"global": [
+			"float beehive_dist(vec2 p){",
+			"\tvec2 s = vec2(1.0, 1.73205080757);",
+			"\tp = abs(p);",
+			"\treturn max(dot(p, s*.5), p.x);",
+			"}",
+			"",
+			"vec4 beehive_center(vec2 p) {",
+			"\tvec2 s = vec2(1.0, 1.73205080757);",
+			"\tvec4 hC = floor(vec4(p, p - vec2(.5, 1))/vec4(s,s)) + .5;",
+			"\tvec4 h = vec4(p - hC.xy*s, p - (hC.zw + .5)*s);",
+			"\treturn dot(h.xy, h.xy)<dot(h.zw, h.zw) ? vec4(h.xy, hC.xy) : vec4(h.zw, hC.zw + 9.73);",
+			"}",
+			""
+		],
 		"inputs": [
 
 		],
@@ -65,21 +83,4 @@
 		"shortdesc": "Hexagonal tiles pattern"
 	},
 	"type": "shader"
-}
-
-########################################string:shader_model.code
-vec2 $(name_uv)_uv = $uv*vec2($sx, $sy*1.73205080757);
-vec4 $(name_uv)_center = beehive_center($(name_uv)_uv);
-########################################string:shader_model.global
-float beehive_dist(vec2 p){
-	vec2 s = vec2(1.0, 1.73205080757);
-    p = abs(p);
-    return max(dot(p, s*.5), p.x);
-}
-
-vec4 beehive_center(vec2 p) {
-	vec2 s = vec2(1.0, 1.73205080757);
-    vec4 hC = floor(vec4(p, p - vec2(.5, 1))/vec4(s,s)) + .5;
-    vec4 h = vec4(p - hC.xy*s, p - (hC.zw + .5)*s);
-    return dot(h.xy, h.xy)<dot(h.zw, h.zw) ? vec4(h.xy, hC.xy) : vec4(h.zw, hC.zw + 9.73);
 }

--- a/addons/material_maker/nodes/beehive.mmg
+++ b/addons/material_maker/nodes/beehive.mmg
@@ -8,9 +8,8 @@
 		"sx": 4,
 		"sy": 4
 	},
+	"seed_int": 0,
 	"shader_model": {
-		"code": "vec2 $(name_uv)_uv = $uv*vec2($sx, $sy*1.73205080757);\nvec4 $(name_uv)_center = beehive_center($(name_uv)_uv);",
-		"global": "float beehive_dist(vec2 p){\n\tvec2 s = vec2(1.0, 1.73205080757);\n    p = abs(p);\n    return max(dot(p, s*.5), p.x);\n}\n\nvec4 beehive_center(vec2 p) {\n\tvec2 s = vec2(1.0, 1.73205080757);\n    vec4 hC = floor(vec4(p, p - vec2(.5, 1))/vec4(s,s)) + .5;\n    vec4 h = vec4(p - hC.xy*s, p - (hC.zw + .5)*s);\n    return dot(h.xy, h.xy)<dot(h.zw, h.zw) ? vec4(h.xy, hC.xy) : vec4(h.zw, hC.zw + 9.73);\n}\n",
 		"inputs": [
 
 		],
@@ -66,4 +65,21 @@
 		"shortdesc": "Hexagonal tiles pattern"
 	},
 	"type": "shader"
+}
+
+########################################string:shader_model.code
+vec2 $(name_uv)_uv = $uv*vec2($sx, $sy*1.73205080757);
+vec4 $(name_uv)_center = beehive_center($(name_uv)_uv);
+########################################string:shader_model.global
+float beehive_dist(vec2 p){
+	vec2 s = vec2(1.0, 1.73205080757);
+    p = abs(p);
+    return max(dot(p, s*.5), p.x);
+}
+
+vec4 beehive_center(vec2 p) {
+	vec2 s = vec2(1.0, 1.73205080757);
+    vec4 hC = floor(vec4(p, p - vec2(.5, 1))/vec4(s,s)) + .5;
+    vec4 h = vec4(p - hC.xy*s, p - (hC.zw + .5)*s);
+    return dot(h.xy, h.xy)<dot(h.zw, h.zw) ? vec4(h.xy, hC.xy) : vec4(h.zw, hC.zw + 9.73);
 }

--- a/material_maker/nodes/generic/generic.gd
+++ b/material_maker/nodes/generic/generic.gd
@@ -512,30 +512,9 @@ static func extract_verbose_values(path : String, data : Dictionary) -> Array:
 				rv.append_array(extract_verbose_values(mpath, v))
 	return rv
 
-static func dict_tree_to_string(data : Dictionary) -> String:
-	data = data.duplicate(true)
-
-	var rv = ""
-	if OS.get_environment("MM_WRITE_NEW_FORMAT") != "":
-		var keyvals = extract_verbose_values("", data)
-		keyvals.push_front("")
-		rv = PoolStringArray(keyvals).join("\n########################################")
-
-	return JSON.print(data, "\t", true) + "\n" + rv
-
-static func do_save_generator(file_name : String, _generator : MMGenBase) -> void:
+static func do_save_generator(file_name : String, gen : MMGenBase) -> void:
 	mm_globals.config.set_value("path", "template", file_name.get_base_dir())
-	var file = File.new()
-	if file.open(file_name, File.WRITE) == OK:
-		var data = _generator.serialize()
-		data.name = file_name.get_file().get_basename()
-		data.node_position = { x=0, y=0 }
-		for k in [ "uids", "export_paths" ]:
-			if data.has(k):
-				data.erase(k)
-		file.store_string(dict_tree_to_string(data))
-		file.close()
-		mm_loader.update_predefined_generators()
+	mm_loader.save_gen(file_name, gen)
 
 func on_clicked_output(index : int, with_shift : bool) -> bool:
 	if .on_clicked_output(index, with_shift):

--- a/scripts/fixup.gd
+++ b/scripts/fixup.gd
@@ -1,23 +1,21 @@
-#!/usr/bin/env -S godot --no-window -s
+tool
+extends EditorScript
 
-extends SceneTree
-
-func _init():
-	var show_help = true
-	for mmg_filename in OS.get_cmdline_args():
-		if mmg_filename.ends_with('.mmg'):
-			print(mmg_filename)
-			var gen = load("res://addons/material_maker/engine/loader.gd").new().load_gen(mmg_filename)
-			var graph_node_generic = load("res://material_maker/nodes/generic/generic.gd")
-			graph_node_generic.do_save_generator(mmg_filename, gen)
-
-			show_help = false
-
-	if show_help:
-		print("To use, run this command from the project directory:")
-		print()
-		print("	MM_WRITE_NEW_FORMAT=1 ./scripts/fixup.gd addons/material_maker/nodes/*.mmg")
-		print()
-
-	quit()
-
+func _run():
+	var dir : Directory = Directory.new()
+	dir.open("res://addons/material_maker/nodes")
+	dir.list_dir_begin()
+	var file_name = dir.get_next()
+	var loader = load("res://addons/material_maker/engine/loader.gd").new()
+	while file_name != "":
+		if file_name.ends_with('.mmg'):
+			print("converting "+file_name)
+			var file_path : String = "res://addons/material_maker/nodes".plus_file(file_name)
+			var file : File = File.new()
+			if file.open(file_path, File.READ) == OK:
+				var generator = loader.string_to_dict_tree(file.get_as_text())
+				file.close()
+				file.open(file_path, File.WRITE)
+				file.store_string(loader.dict_tree_to_string(generator)+"\n")
+				file.close()
+		file_name = dir.get_next()

--- a/scripts/fixup.gd
+++ b/scripts/fixup.gd
@@ -1,0 +1,23 @@
+#!/usr/bin/env -S godot --no-window -s
+
+extends SceneTree
+
+func _init():
+	var show_help = true
+	for mmg_filename in OS.get_cmdline_args():
+		if mmg_filename.ends_with('.mmg'):
+			print(mmg_filename)
+			var gen = load("res://addons/material_maker/engine/loader.gd").new().load_gen(mmg_filename)
+			var graph_node_generic = load("res://material_maker/nodes/generic/generic.gd")
+			graph_node_generic.do_save_generator(mmg_filename, gen)
+
+			show_help = false
+
+	if show_help:
+		print("To use, run this command from the project directory:")
+		print()
+		print("	MM_WRITE_NEW_FORMAT=1 ./scripts/fixup.gd addons/material_maker/nodes/*.mmg")
+		print()
+
+	quit()
+


### PR DESCRIPTION
Right now, code blocks in shader nodes are bunched up into one giant string with \n literals when serialized. This PR proposes a new format where code blocks are instead split into arrays of strings, one per line, so that json formatting can make them more readable when viewed directly from github.

The proposed new format has been applied to beehive.mmg as a demonstration, see its diff for details. This also automatically adds a trailing newline for quality of life purposes, as mentioned in #51 and #119

Reading will be able to handle both the old and new formats, but writing will default to the old format unless the MM_WRITE_NEW_FORMAT environment variable is set. This way, the nodes inside the repo can be reformatted to get the benefits immediately, while backwards compatibility is kept between nodes and materials generated and shared by users. Presumably this can be removed in a later release once everyone has upgraded.

Includes a short gdscript that can bulk update .mmg files from the command line, eliminating the need to do it manually via gui.
