### PR TITLE
Fix memory leak in dependency tracker

### DIFF
--- a/addons/material_maker/engine/dependencies.gd
+++ b/addons/material_maker/engine/dependencies.gd
@@ -55,6 +55,7 @@ func delete_buffer(buffer_name : String):
 	if dependencies.has(buffer_name):
 		for b in dependencies[buffer_name]:
 			buffers[b].dependencies.erase(buffer_name)
+	dependencies_values.erase(buffer_name)
 
 func delete_buffers_from_object(object : Object):
 	var remove_buffers : Array = []


### PR DESCRIPTION
`delete_buffer()` was deleting `buffer_name` from `buffers`, but not `dependencies_values`