### PR TITLE
Sets default uv size for cylinder to 3 on x axis

### DIFF
--- a/material_maker/panels/preview_3d/preview_objects.tscn
+++ b/material_maker/panels/preview_3d/preview_objects.tscn
@@ -33,7 +33,7 @@ visible = false
 mesh = SubResource( 2 )
 material/0 = null
 script = ExtResource( 3 )
-uv_scale = Vector2( 2, 2 )
+uv_scale = Vector2( 3, 2 )
 
 [node name="Sphere" type="MeshInstance" parent="."]
 visible = false


### PR DESCRIPTION
Makes the uv mapping less stretched on the cylinder by default