### PR TITLE
Add snap operation for math nodes

### DIFF
--- a/addons/material_maker/nodes/math.mmg
+++ b/addons/material_maker/nodes/math.mmg
@@ -180,6 +180,10 @@
 					{
 						"name": "exp(A)",
 						"value": "exp($in1($uv))"
+					},
+					{
+						"name": "snap(A,B)",
+						"value": "floor($in1($uv)/$in2($uv))*$in2($uv)"
 					}
 				]
 			},

--- a/addons/material_maker/nodes/math_v3.mmg
+++ b/addons/material_maker/nodes/math_v3.mmg
@@ -162,6 +162,10 @@
 					{
 						"name": "mod(A, B)",
 						"value": "mod($in1($uv),$in2($uv))"
+					},
+					{
+						"name": "snap(A,B)",
+						"value": "floor($in1($uv)/$in2($uv))*$in2($uv)"
 					}
 				]
 			},


### PR DESCRIPTION
This adds a new "snap" operation for the math/vec3 math nodes:

Math

![snap_op_sample](https://user-images.githubusercontent.com/830253/206617623-5385fc85-61b1-4300-8667-890755e7c361.gif)

Vec3 Math

![snap_op_sample_vec3](https://user-images.githubusercontent.com/830253/206618691-6e650b1e-c5ab-4324-b96a-a3495c6e657a.gif)
