### PR TITLE
Bug fix: Comment node selects wrong nodes when zoomed in or out

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -847,9 +847,18 @@ func highlight_connections() -> void:
 
 func _on_GraphEdit_node_selected(node : GraphNode) -> void:
 	if node.comment:
+		# Need to account for zoom level when checking for contained nodes within comment
+		var current_zoom = get_zoom()
+		var node_rect = node.get_rect()
+		node_rect.size = node_rect.size * current_zoom
+		
 		for c in get_children():
-			if c is GraphNode and c != node and node.get_rect().encloses(c.get_rect()):
-				c.selected = true
+			if c is GraphNode and c != node:
+				var c_rect = c.get_rect()
+				c_rect.size = c_rect.size * current_zoom
+				
+				if node_rect.encloses(c_rect):
+					c.selected = true
 	else:
 		highlight_connections()
 		yield(get_tree(), "idle_frame")


### PR DESCRIPTION
# Overview
When selecting and then dragging the comment node, wrong nodes might be selected depending on the current zoom level of the graph. When zoomed out, nodes outside of the comment node will be wrongly selected. When zoomed in, only nodes close to the top-left corner of the comment node will be selected.

This PR fixes this problem so that comment node selects the correct nodes regardless of zoom level.

![CommentNode-ZoomInSelection](https://user-images.githubusercontent.com/16468844/209904404-ecee6345-9bb8-45b5-aadd-05b36f80be74.gif)

![CommentNode-ZoomOutSelection](https://user-images.githubusercontent.com/16468844/209904408-ecc1c276-f391-4563-b66a-07d6e39d069a.gif)

# Reproduction steps
## (Zoom Out)
1. Create a comment node around some nodes
2. Place one or more nodes outside of the comment node, but very close to it
3. Zoom out
4. Left-click on comment node once, then left-click drag the comment node so contents are also selected and moved
5. Notice that nodes outside of the comment node that are very close to it will be also selected

## (Zoom In)
1. Create a comment node around some nodes
2. Zoom in
3. Left-click on comment node once, then left-click drag the comment node so contents are also selected and moved
4. Notice that nodes far from the top-left corner of the comment node won't be selected, even though they are inside the comment node

# Implementation Details
## Cause
It seems that the [get_rect](https://docs.godotengine.org/en/stable/classes/class_control.html#class-control-method-get-rect) function always returns the same size for the [GraphNode](https://docs.godotengine.org/en/stable/classes/class_graphnode.html) regardless of zoom level, but position is correctly updated to reflect the current zoom level.

## Fix
On graph_edit.gd, instead of checking the contained nodes by using the get_rect function directly, a new [Rect2](https://docs.godotengine.org/en/stable/classes/class_rect2.html) is calculated and multiplied against the current zoom level so that the correct node size for the current zoom level is used for the [encloses](https://docs.godotengine.org/en/stable/classes/class_rect2.html?#class-rect2-method-encloses) function check.