### PR TITLE
Fix triangle voronoi random color output

### DIFF
--- a/addons/material_maker/nodes/voronoi_triangle.mmg
+++ b/addons/material_maker/nodes/voronoi_triangle.mmg
@@ -182,7 +182,7 @@
 			},
 			{
 				"longdesc": "Shows a random color for each cell",
-				"rgb": "rand3(fract($(name_uv)_m3[2].xy/vec2($scale_x,$scale_y)))",
+				"rgb": "rand3(floor(fract($(name_uv)_m3[2].xy/vec2($scale_x,$scale_y))*vec2($scale_x,$scale_y)))",
 				"shortdesc": "Random color",
 				"type": "rgb"
 			},


### PR DESCRIPTION
This fixes the Triangle Voronoi node's random color output which at certain scales it doesn't tile

![sample_before_after](https://user-images.githubusercontent.com/830253/212008597-9be33a13-8afe-4fd0-bd1b-e2de001e268d.gif)

![out](https://user-images.githubusercontent.com/830253/212008693-05b4deeb-9fd0-43ef-b23b-db1e80803c47.png)