### PR TITLE
Consistent math function names(space between params)

### DIFF
--- a/addons/material_maker/nodes/math.mmg
+++ b/addons/material_maker/nodes/math.mmg
@@ -154,11 +154,11 @@
 						"value": "sign($in1($uv))"
 					},
 					{
-						"name": "mod(A,B)",
+						"name": "mod(A, B)",
 						"value": "mod($in1($uv), $in2($uv))"
 					},
 					{
-						"name": "atan2(A,B)",
+						"name": "atan2(A, B)",
 						"value": "atan($in1($uv),$in2($uv))"
 					},
 					{
@@ -190,7 +190,7 @@
 						"value": "exp($in1($uv))"
 					},
 					{
-						"name": "snap(A,B)",
+						"name": "snap(A, B)",
 						"value": "floor($in1($uv)/$in2($uv))*$in2($uv)"
 					}
 				]

--- a/addons/material_maker/nodes/math_v3.mmg
+++ b/addons/material_maker/nodes/math_v3.mmg
@@ -145,15 +145,15 @@
 						"value": "vec3(length($in1($uv)))"
 					},
 					{
-						"name": "distance(A,B)",
+						"name": "distance(A, B)",
 						"value": "vec3(distance($in1($uv),$in2($uv)))"
 					},
 					{
-						"name": "dot(A,B)",
+						"name": "dot(A, B)",
 						"value": "vec3(dot($in1(uv),$in2($uv)))"
 					},
 					{
-						"name": "cross(A,B)",
+						"name": "cross(A, B)",
 						"value": "cross($in1($uv),$in2($uv))"
 					},
 					{
@@ -169,7 +169,7 @@
 						"value": "mod($in1($uv),$in2($uv))"
 					},
 					{
-						"name": "snap(A,B)",
+						"name": "snap(A, B)",
 						"value": "floor($in1($uv)/$in2($uv))*$in2($uv)"
 					}
 				]


### PR DESCRIPTION
This addresses inconsistencies in math function names with parameters ( i.e. func(a,b) vs func(a, b) ) in the math / vec3 math node(s):

**Before**

![before](https://user-images.githubusercontent.com/830253/218238400-e5941ac9-6bb7-40f2-91d0-e03b4acd2fca.png)


**After**

![after](https://user-images.githubusercontent.com/830253/218238403-daf17ac8-9b26-4b24-8ee2-498db6149a06.png)
