### PR TITLE
Add radians and degrees math operations

### DIFF
--- a/addons/material_maker/nodes/math.mmg
+++ b/addons/material_maker/nodes/math.mmg
@@ -192,7 +192,15 @@
 					{
 						"name": "snap(A, B)",
 						"value": "floor($in1($uv)/$in2($uv))*$in2($uv)"
-					}
+					},
+					{
+						"name": "radians(A)",
+						"value": "radians($in1($uv))"
+					},
+					{
+						"name": "degrees(A)",
+						"value": "degrees($in1($uv))"
+					},
 				]
 			},
 			{


### PR DESCRIPTION
Adds math operations for conversion between radians to degrees and vice versa

![radians_degrees](https://github.com/RodZill4/material-maker/assets/830253/09df4127-c18b-4f9a-a786-3274a97e3aaf)
