### PR TITLE
Nearest neighbor filtering and QoL keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-### Nothke's improvements:
-
-- Material preview textures now without filtering (in all resolutions). Ideal for big pixel art sheets
-- Delete nodes on X (just like in blender!)
-- Move nodes on G (just like in blender!)
-
 # Material Maker
 
 This is a tool based on [Godot Engine](https://godotengine.org/) that can

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+### Nothke's improvements:
+
+- Material preview textures now without filtering (in all resolutions). Ideal for big pixel art sheets
+- Delete nodes on X (just like in blender!)
+- Move nodes on G (just like in blender!)
+
 # Material Maker
 
 This is a tool based on [Godot Engine](https://godotengine.org/) that can

--- a/addons/material_maker/engine/gen_material.gd
+++ b/addons/material_maker/engine/gen_material.gd
@@ -31,7 +31,7 @@ const TEXTURE_SIZE_MAX : int = 13  # 8192x8192
 const TEXTURE_SIZE_DEFAULT : int = 10  # 1024x1024
 
 # The minimum allowed texture size as a power-of-two exponent
-const TEXTURE_FILTERING_LIMIT : int = 8192
+#const TEXTURE_FILTERING_LIMIT : int = 8192
 
 const EXPORT_OUTPUT_DEF_INDEX : int = 12345
 
@@ -148,7 +148,7 @@ func on_dep_update_buffer(buffer_name) -> bool:
 	renderer.copy_to_texture(preview_textures[texture_name].texture)
 	renderer.release(self)
 	mm_deps.dependency_update(preview_textures[texture_name].buffer, preview_textures[texture_name].texture, true)
-	if size <= TEXTURE_FILTERING_LIMIT:
+	if !mm_globals.get_config("ui_3d_preview_texture_filtering"):
 		preview_textures[texture_name].texture.flags &= ~Texture.FLAG_FILTER
 	else:
 		preview_textures[texture_name].texture.flags |= Texture.FLAG_FILTER

--- a/addons/material_maker/engine/gen_material.gd
+++ b/addons/material_maker/engine/gen_material.gd
@@ -31,7 +31,7 @@ const TEXTURE_SIZE_MAX : int = 13  # 8192x8192
 const TEXTURE_SIZE_DEFAULT : int = 10  # 1024x1024
 
 # The minimum allowed texture size as a power-of-two exponent
-const TEXTURE_FILTERING_LIMIT : int = 256
+const TEXTURE_FILTERING_LIMIT : int = 8192
 
 const EXPORT_OUTPUT_DEF_INDEX : int = 12345
 

--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -20,6 +20,7 @@ const DEFAULT_CONFIG = {
 	ui_3d_preview_resolution = 2.0,
 	ui_3d_preview_tesselation_detail = 256,
 	ui_3d_preview_sun_shadow = false,
+	ui_3d_preview_texture_filtering = true,
 	ui_3d_preview_tonemap = 0,
 	bake_ray_count = 64,
 	bake_ao_ray_dist = 128.0,

--- a/material_maker/nodes/minimal.gd
+++ b/material_maker/nodes/minimal.gd
@@ -4,6 +4,7 @@ class_name MMGraphNodeMinimal
 
 var generator : MMGenBase = null setget set_generator
 var disable_undoredo_for_offset : bool = false
+var grab_offset : Vector2
 
 
 func _ready() -> void:

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -185,7 +185,7 @@ func _gui_input(event) -> void:
 		if event.pressed:
 			var scancode_with_modifiers = event.get_scancode_with_modifiers()
 			match scancode_with_modifiers:
-				KEY_DELETE,KEY_BACKSPACE:
+				KEY_DELETE,KEY_BACKSPACE,KEY_X:
 					remove_selection()
 				KEY_LEFT:
 					scroll_offset.x -= 0.5*rect_size.x

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -202,6 +202,15 @@ Changes to this setting are only applied on application restart."
 text = "3D preview sun shadow (requires restart)"
 config_variable = "ui_3d_preview_sun_shadow"
 
+[node name="Gui3DPreviewFiltering" parent="VBoxContainer/TabContainer/General" instance=ExtResource( 1 )]
+margin_top = 192.0
+margin_right = 296.0
+margin_bottom = 216.0
+hint_tooltip = "If disabled, the preview will be shown with nearest neighbor (point) filtering. Useful to disable when working on pixel art."
+pressed = true
+text = "3D preview use texture filtering"
+config_variable = "ui_3d_preview_texture_filtering"
+
 [node name="Space2" type="Control" parent="VBoxContainer/TabContainer/General"]
 margin_top = 220.0
 margin_right = 296.0

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -208,7 +208,7 @@ margin_right = 296.0
 margin_bottom = 216.0
 hint_tooltip = "If disabled, the preview will be shown with nearest neighbor (point) filtering. Useful to disable when working on pixel art."
 pressed = true
-text = "3D preview use texture filtering"
+text = "3D preview use texture filtering (requires restart)"
 config_variable = "ui_3d_preview_texture_filtering"
 
 [node name="Space2" type="Control" parent="VBoxContainer/TabContainer/General"]


### PR DESCRIPTION
I added a few QoL improvements:
- Texture filtering is now an option in preferences (enabled by default). Disabling it makes the texture have nearest neighbor filtering, instead of only happening <= 256x256 resolution. Useful when making pixel art.
- Added G to move (grab), like in blender. Less miss-click prone than click and drag.
- Added X to delete, like in blender. Faster than reaching for delete button.