### PR TITLE
Make sure graph edit background doesn't darken preview

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.tscn
+++ b/material_maker/panels/graph_edit/graph_edit.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=9 format=3 uid="uid://dy1u50we7gtru"]
+[gd_scene load_steps=10 format=3 uid="uid://dy1u50we7gtru"]
 
 [ext_resource type="Script" path="res://material_maker/panels/graph_edit/graph_edit.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://c0j4px4n72di5" path="res://material_maker/icons/icons.tres" id="2"]
 [ext_resource type="Script" path="res://material_maker/tools/undo_redo/undo_redo.gd" id="3"]
 [ext_resource type="PackedScene" uid="uid://buj231c2gxm4o" path="res://material_maker/widgets/desc_button/desc_button.tscn" id="4"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_kr3pt"]
 
 [sub_resource type="Theme" id="1"]
 GraphEdit/colors/activity = Color(1, 1, 1, 1)
@@ -21,6 +23,7 @@ GraphEdit/icons/more = null
 GraphEdit/icons/reset = null
 GraphEdit/icons/snap = null
 GraphEdit/styles/bg = null
+GraphEdit/styles/panel = SubResource("StyleBoxEmpty_kr3pt")
 
 [sub_resource type="AtlasTexture" id="3"]
 atlas = ExtResource("2")


### PR DESCRIPTION
This adds a "StyleBoxEmpty" override to the graph edit node. Previously the preview was slightly darkened due to the background.