### PR TITLE
Improve spherize node

### DIFF
--- a/addons/material_maker/nodes/spherize.mmg
+++ b/addons/material_maker/nodes/spherize.mmg
@@ -33,17 +33,17 @@
 		"outputs": [
 			{
 				"longdesc": "Shows the distorted image",
-				"rgba": "clamp(mix($in#($(name_uv)_co-($(name_uv)_co-$uv)/(sqrt($r-$(name_uv)_f)*max($a,0.0)+1.0)),$in#($uv),step($r,$(name_uv)_f)),0.0,1.0)",
+				"rgba": "mix($in#($(name_uv)_co-($(name_uv)_co-$uv)/(sqrt(abs($r-$(name_uv)_f))*max($a,0.0)+1.0)),$in#($uv),step($r,$(name_uv)_f))",
 				"shortdesc": "Output#",
 				"type": "rgba"
 			},
 			{
-				"f": "clamp(step($(name_uv)_f,$r),0.0,1.0)",
+				"f": "step($(name_uv)_f,$r)",
 				"shortdesc": "Mask",
 				"type": "f"
 			},
 			{
-				"f": "clamp($r-$(name_uv)_f,0.0,1.0)",
+				"f": "$r-$(name_uv)_f",
 				"shortdesc": "Falloff",
 				"type": "f"
 			}
@@ -74,7 +74,7 @@
 				"type": "float"
 			},
 			{
-				"control": "None",
+				"control": "P1.x",
 				"default": 0,
 				"label": "Center X",
 				"longdesc": "Location of the sphere center",
@@ -86,7 +86,7 @@
 				"type": "float"
 			},
 			{
-				"control": "None",
+				"control": "P1.y",
 				"default": 0,
 				"label": "Center Y",
 				"longdesc": "Location of the sphere center",


### PR DESCRIPTION

![sph_demo](https://github.com/RodZill4/material-maker/assets/830253/3322861c-1b76-40c6-b0c2-6fdcdb04eb0f)

Some improvements for the Spherize node, mainly:
- Add center x/y control widgets
- Don't clamp input image values
- Prevent taking square root with negative values(this now takes the absolute before sqrt), which caused some visual issue on Mac OS - I previously made the node on 12.6.x which works fine but it worked differently in 14.3