### PR TITLE
Fix missing short/long description for some nodes

### DIFF
--- a/addons/material_maker/nodes/circular_gradient.mmg
+++ b/addons/material_maker/nodes/circular_gradient.mmg
@@ -36,6 +36,7 @@
 		],
 		"instance": "",
 		"name": "Circular Gradient",
+		"shortdesc": "Circular Gradient",
 		"outputs": [
 			{
 				"longdesc": "Number of repetitions of the gradient",

--- a/addons/material_maker/nodes/convert_from_rgb.mmg
+++ b/addons/material_maker/nodes/convert_from_rgb.mmg
@@ -14,7 +14,7 @@
 		}
 	],
 	"label": "Convert from RGB",
-	"longdesc": "",
+	"longdesc": "Converts from RGB to a specified color space",
 	"name": "convert_from_rgb",
 	"node_position": {
 		"x": 0,
@@ -110,6 +110,6 @@
 	},
 	"seed": 0,
 	"seed_locked": false,
-	"shortdesc": "",
+	"shortdesc": "Convert from RGB",
 	"type": "graph"
 }

--- a/addons/material_maker/nodes/convert_to_rgb.mmg
+++ b/addons/material_maker/nodes/convert_to_rgb.mmg
@@ -14,7 +14,7 @@
 		}
 	],
 	"label": "Convert to RGB",
-	"longdesc": "",
+	"longdesc": "Converts from a specified color space to RGB",
 	"name": "convert_to_rgb",
 	"node_position": {
 		"x": 0,
@@ -110,6 +110,6 @@
 	},
 	"seed": 0,
 	"seed_locked": false,
-	"shortdesc": "",
+	"shortdesc": "Convert to RGB",
 	"type": "graph"
 }

--- a/addons/material_maker/nodes/fast_blur.mmg
+++ b/addons/material_maker/nodes/fast_blur.mmg
@@ -44,7 +44,7 @@
 		}
 	],
 	"label": "Fast Blur",
-	"longdesc": "",
+	"longdesc": "Applies an approximated gaussian blur",
 	"name": "fast_blur",
 	"node_position": {
 		"x": 0,
@@ -265,6 +265,6 @@
 		"param3": 1
 	},
 	"seed_int": 0,
-	"shortdesc": "",
+	"shortdesc": "Fast Blur",
 	"type": "graph"
 }

--- a/addons/material_maker/nodes/hbao.mmg
+++ b/addons/material_maker/nodes/hbao.mmg
@@ -38,7 +38,7 @@
 		}
 	],
 	"label": "HBAO",
-	"longdesc": "",
+	"longdesc": "Generates a horizon based ambient occlusion texture from a height map",
 	"name": "hbao",
 	"node_position": {
 		"x": 0,
@@ -562,6 +562,6 @@
 		"param5": 1
 	},
 	"seed": 6741,
-	"shortdesc": "",
+	"shortdesc": "Horizon Based Ambient Occulusion",
 	"type": "graph"
 }

--- a/addons/material_maker/nodes/morphology2.mmg
+++ b/addons/material_maker/nodes/morphology2.mmg
@@ -98,7 +98,7 @@
 		}
 	],
 	"label": "Morphology",
-	"longdesc": "",
+	"longdesc": "Applies a morphology dilation or erosion on its input",
 	"name": "morphology2",
 	"node_position": {
 		"x": 0,
@@ -603,6 +603,6 @@
 		"resolution": 10
 	},
 	"seed_int": 0,
-	"shortdesc": "",
+	"shortdesc": "Morphology",
 	"type": "graph"
 }

--- a/addons/material_maker/nodes/normal2height.mmg
+++ b/addons/material_maker/nodes/normal2height.mmg
@@ -62,7 +62,7 @@
 		}
 	],
 	"label": "Normal to Height",
-	"longdesc": "",
+	"longdesc": "Generates a height map from a normal map in Material Maker's internal format",
 	"name": "normal2height",
 	"node_position": {
 		"x": 0,
@@ -350,6 +350,6 @@
 	},
 	"seed": 0,
 	"seed_locked": false,
-	"shortdesc": "",
+	"shortdesc": "Normal to Height",
 	"type": "graph"
 }

--- a/addons/material_maker/nodes/normal_blend2.mmg
+++ b/addons/material_maker/nodes/normal_blend2.mmg
@@ -58,6 +58,8 @@
 			}
 		],
 		"instance": "",
+		"shortdesc": "Normal Blend",
+		"longdesc": "Blends normal maps using an optional mask",
 		"name": "Normal Blend",
 		"outputs": [
 			{

--- a/addons/material_maker/nodes/radial_gradient.mmg
+++ b/addons/material_maker/nodes/radial_gradient.mmg
@@ -36,6 +36,7 @@
 		],
 		"instance": "",
 		"name": "Radial Gradient",
+		"shortdesc": "Radial Gradient",
 		"outputs": [
 			{
 				"longdesc": "An image showing the gradient",

--- a/addons/material_maker/nodes/sd_mask_to_sdf.mmg
+++ b/addons/material_maker/nodes/sd_mask_to_sdf.mmg
@@ -68,7 +68,7 @@
 		}
 	],
 	"label": "Mask to SDF",
-	"longdesc": "",
+	"longdesc": "Generates a signed distance image from an image mask",
 	"name": "sd_mask_to_sdf",
 	"node_position": {
 		"x": 0,
@@ -1269,6 +1269,6 @@
 		"param3": 0
 	},
 	"seed_int": 0,
-	"shortdesc": "",
+	"shortdesc": "Mask to SDF",
 	"type": "graph"
 }

--- a/addons/material_maker/nodes/smooth_minmax.mmg
+++ b/addons/material_maker/nodes/smooth_minmax.mmg
@@ -48,6 +48,8 @@
 		],
 		"instance": "",
 		"name": "Smooth MinMax",
+		"longdesc": "Performs a smooth minimum/maximum math operation between its inputs",
+		"shortdesc": "Smooth MinMax",
 		"outputs": [
 			{
 				"f": "$(name_uv)_clamp_$clamp",

--- a/addons/material_maker/nodes/spiral_gradient.mmg
+++ b/addons/material_maker/nodes/spiral_gradient.mmg
@@ -46,6 +46,7 @@
 		],
 		"instance": "",
 		"name": "Spiral Gradient",
+		"shortdesc": "Spiral Gradient",
 		"outputs": [
 			{
 				"longdesc": "Number of repetitions of the gradient",

--- a/addons/material_maker/nodes/wavelet_noise.mmg
+++ b/addons/material_maker/nodes/wavelet_noise.mmg
@@ -58,12 +58,12 @@
 
 		],
 		"instance": "",
-		"longdesc": "Generates several octaves of greyscale value noise",
+		"longdesc": "Generates several octaves of greyscale wavelet noise",
 		"name": "Wavelet Noise",
 		"outputs": [
 			{
 				"f": "wavelet_noise($(uv), vec2($(scale_x), $(scale_y)), int($(iterations)), $(persistence), $(seed), $frequency, $offset, $type)",
-				"longdesc": "Shows a greyscale value noise",
+				"longdesc": "Shows a greyscale wavelet noise",
 				"shortdesc": "Output",
 				"type": "f"
 			}
@@ -166,7 +166,7 @@
 				"type": "float"
 			}
 		],
-		"shortdesc": "Value Noise"
+		"shortdesc": "Wavelet Noise"
 	},
 	"type": "shader"
 }


### PR DESCRIPTION
I've noticed some nodes have missing descriptions.

Most of these are group nodes and they don't have a proper name so the internal name is used for the tooltip instead (e.g. fast_blur, morphology2, sd_mask_to_sdf). This PR adds the missing short and long descriptions (based on the documentation) for them.

Before

![before](https://github.com/RodZill4/material-maker/assets/830253/c09a104f-6e42-4bf8-a89c-2170b611d0c5)

After

![after](https://github.com/RodZill4/material-maker/assets/830253/15220c06-0163-4c89-9942-2378e9ea6fbf)


