### PR TITLE
Fix math node backward compatibility

### DIFF
--- a/addons/material_maker/nodes/math.mmg
+++ b/addons/material_maker/nodes/math.mmg
@@ -82,10 +82,6 @@
 						"value": "log($in1($uv))"
 					},
 					{
-						"name": "log(A, B)",
-						"value": "log($in1($uv))/log($in2($uv))"
-					},
-					{
 						"name": "log2(A)",
 						"value": "log2($in1($uv))"
 					},
@@ -205,6 +201,10 @@
 						"name": "degrees(A)",
 						"value": "degrees($in1($uv))"
 					},
+					{
+						"name": "log(A, B)",
+						"value": "log($in1($uv))/log($in2($uv))"
+					}
 				]
 			},
 			{

--- a/addons/material_maker/nodes/math_v3.mmg
+++ b/addons/material_maker/nodes/math_v3.mmg
@@ -81,10 +81,6 @@
 						"value": "log($in1($uv))"
 					},
 					{
-						"name": "log(A, B)",
-						"value": "log($in1($uv))/log($in2($uv))"
-					},
-					{
 						"name": "log2(A)",
 						"value": "log2($in1($uv))"
 					},
@@ -188,6 +184,10 @@
 						"name": "tanh(A)",
 						"value": "tanh($in1($uv))"
 					},
+					{
+						"name": "log(A, B)",
+						"value": "log($in1($uv))/log($in2($uv))"
+					}
 				]
 			},
 			{


### PR DESCRIPTION
In https://github.com/RodZill4/material-maker/pull/669 the new operation `log(A, B)` is added after `log(A)` in math nodes which causes math nodes' selected operation from v1.3 to shift by one when opened in v1.4a. Moving this operation to the end of the list fixes this.

Before

![before](https://github.com/RodZill4/material-maker/assets/830253/6ee876c1-d583-435f-b89f-7c2bba56365f)

After

![after](https://github.com/RodZill4/material-maker/assets/830253/1b687e77-206d-433c-a651-eecf2bfeac94)

