### PR TITLE
More UI adjustments (inspired by Heytibos design)

### DIFF
--- a/addons/flexible_layout/flexible_tab.gd
+++ b/addons/flexible_layout/flexible_tab.gd
@@ -29,6 +29,7 @@ func update():
 		add_theme_stylebox_override("panel", get_theme_stylebox("tab_selected" if is_current else "tab_unselected", "MM_FlexibleTab"))
 		$Container/Undock.visible = is_current and get_flex_layout().main_control.allow_undock
 		$Container/Close.visible = is_current
+		$Container/Label.add_theme_color_override("font_color", get_theme_color("font_selected_color" if is_current else "font_unselected_color", "MM_FlexibleTab") )
 		updating = false
 
 func _on_undock_pressed():

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -119,35 +119,35 @@ func _ready() -> void:
 	get_window().transparent = false
 	get_window().move_to_foreground()
 	get_window().gui_embed_subwindows = false
-	
+
 	get_window().close_requested.connect(self.on_close_requested)
-	
+
 	get_tree().set_auto_accept_quit(false)
-	
+
 	if mm_globals.get_config("locale") == "":
 		mm_globals.set_config("locale", TranslationServer.get_locale())
-	
+
 	on_config_changed()
-	
+
 	# Restore the window position/size if values are present in the configuration cache
 	if mm_globals.config.has_section_key("window", "screen"):
 		get_window().current_screen = mm_globals.config.get_value("window", "screen")
-	
+
 	if mm_globals.config.has_section_key("window", "maximized"):
 		get_window().mode = Window.MODE_MAXIMIZED if (mm_globals.config.get_value("window", "maximized")) else Window.MODE_WINDOWED
-	
+
 	if get_window().mode != Window.MODE_MAXIMIZED:
 		if mm_globals.config.has_section_key("window", "position"):
 			get_window().position = mm_globals.config.get_value("window", "position")
 		if mm_globals.config.has_section_key("window", "size"):
 			get_window().size = mm_globals.config.get_value("window", "size")
-			
+
 	# Restore the theme
 	var theme_name : String = "default"
 	if mm_globals.config.has_section_key("window", "theme"):
 		theme_name = mm_globals.config.get_value("window", "theme")
 	change_theme(theme_name)
-	
+
 	# In HTML5 export, copy all examples to the filesystem
 	if OS.get_name() == "HTML5":
 		print("Copying samples")
@@ -161,13 +161,13 @@ func _ready() -> void:
 			if f.ends_with(".ptex"):
 				print(f)
 				dir.copy("res://material_maker/examples/"+f, "/examples/"+f)
-	
+
 	# Set a minimum window size to prevent UI elements from collapsing on each other.
 	get_window().min_size = Vector2(1024, 600)
-	
+
 	# Set window title
 	get_window().set_title(ProjectSettings.get_setting("application/config/name")+" v"+ProjectSettings.get_setting("application/config/actual_release"))
-	
+
 	layout.load_panels()
 	library = get_panel("Library")
 	preview_2d = [ get_panel("Preview2D"), get_panel("Preview2D (2)") ]
@@ -177,12 +177,12 @@ func _ready() -> void:
 	hierarchy = get_panel("Hierarchy")
 	hierarchy.connect("group_selected", self.on_group_selected)
 	brushes = get_panel("Brushes")
-	
+
 	# Load recent projects
 	load_recents()
-	
+
 	get_window().connect("files_dropped", self.on_files_dropped)
-	
+
 	var args : PackedStringArray = OS.get_cmdline_args()
 	for a in args:
 		if a.get_extension() == "ptex":
@@ -198,7 +198,7 @@ func _ready() -> void:
 				continue
 			var project_filename : String = mesh_filename.get_basename()+".mmpp"
 			create_paint_project(mesh, mesh_filename, 1024, project_filename)
-	
+
 	# Rescue unsaved projects
 	if true:
 		var dir : DirAccess = DirAccess.open("user://unsaved_projects")
@@ -223,16 +223,16 @@ func _ready() -> void:
 					"delete":
 						for f in files:
 							DirAccess.remove_absolute(f)
-	
+
 	if get_current_graph_edit() == null:
 		await get_tree().process_frame
 		new_material()
-	
+
 	size = get_window().size
 	position = Vector2.ZERO
 	set_anchors_preset(Control.PRESET_FULL_RECT)
 	update_menus()
-	
+
 	mm_logger.message("Material Maker "+ProjectSettings.get_setting("application/config/actual_release"))
 
 var menu_update_requested : bool = false
@@ -288,7 +288,7 @@ func on_config_changed() -> void:
 		ui_scale = 2 if DisplayServer.screen_get_dpi() >= 192 and DisplayServer.screen_get_size().x >= 2048 else 1
 	get_viewport().content_scale_factor = ui_scale
 	#ProjectSettings.set_setting("display/window/stretch/scale", scale)
-	
+
 	# Clamp to reasonable values to avoid crashes on startup.
 	preview_rendering_scale_factor = clamp(mm_globals.get_config("ui_3d_preview_resolution"), 1.0, 2.0)
 # warning-ignore:narrowing_conversion
@@ -566,7 +566,7 @@ func get_file_absolute_path(filename : String) -> String:
 	if file == null:
 		return ""
 	return file.get_path_absolute()
-		
+
 func do_load_projects(filenames) -> void:
 	var file_name : String = ""
 	for f in filenames:
@@ -1194,8 +1194,8 @@ func set_tip_text(tip : String, timeout : float = 0.0):
 	tip = tip.replace("#LMB", "[img]res://material_maker/icons/lmb.tres[/img]")
 	tip = tip.replace("#RMB", "[img]res://material_maker/icons/rmb.tres[/img]")
 	tip = tip.replace("#MMB", "[img]res://material_maker/icons/mmb.tres[/img]")
-	$VBoxContainer/StatusBar/Tip.text = tip
-	var tip_timer : Timer = $VBoxContainer/StatusBar/Tip/Timer
+	$VBoxContainer/StatusBar/HBox/Tip.text = tip
+	var tip_timer : Timer = $VBoxContainer/StatusBar/HBox/Tip/Timer
 	tip_timer.stop()
 	if timeout > 0.0:
 		tip_timer.one_shot = true
@@ -1203,7 +1203,7 @@ func set_tip_text(tip : String, timeout : float = 0.0):
 		tip_timer.start()
 
 func _on_Tip_Timer_timeout():
-	$VBoxContainer/StatusBar/Tip.text = ""
+	$VBoxContainer/StatusBar/HBox/Tip.text = ""
 
 # Add dialog
 

--- a/material_maker/main_window.tscn
+++ b/material_maker/main_window.tscn
@@ -15,39 +15,6 @@
 [ext_resource type="Script" path="res://material_maker/tools/library_manager/library_manager.gd" id="14"]
 [ext_resource type="Texture2D" path="res://material_maker/icons/paste_none.tres" id="15"]
 
-[sub_resource type="AtlasTexture" id="8"]
-atlas = ExtResource("8")
-region = Rect2(96, 128, 16, 16)
-
-[sub_resource type="GDScript" id="9"]
-script/source = "extends HBoxContainer
-
-
-const PASTE_TYPE_ICON : Dictionary = {
-	none=preload(\"res://material_maker/icons/paste_none.tres\"),
-	color=preload(\"res://material_maker/icons/paste_none.tres\"),
-	palette=preload(\"res://material_maker/icons/paste_palette.tres\"),
-	newgraph=preload(\"res://material_maker/icons/paste_newgraph.tres\"),
-	graph=preload(\"res://material_maker/icons/paste_graph.tres\")
-}
-
-func _on_Timer_timeout():
-	var data : String = DisplayServer.clipboard_get().strip_edges()
-	var parsed_data = await mm_globals.parse_paste_data(data)
-	$Contents.texture = PASTE_TYPE_ICON[parsed_data.type]
-	var hint : String
-	match parsed_data.type:
-		\"none\",\"color\":
-			hint = \"The clipboard cannot be pasted\"
-		\"palette\":
-			hint = \"The clipboard contains a color palette and can be pasted\\ninto a graph view as a colorize node\"
-		\"newgraph\":
-			hint = \"The clipboard can be pasted as a new graph view\\nand contains %d nodes and %d connections\" % [ parsed_data.graph.nodes.size(), parsed_data.graph.connections.size() ]
-		\"graph\":
-			hint = \"The clipboard can be pasted into a graph view\\nand contains %d nodes and %d connections\" % [ parsed_data.graph.nodes.size(), parsed_data.graph.connections.size() ]
-	tooltip_text = hint
-"
-
 [sub_resource type="GDScript" id="6"]
 script/source = "extends Label
 
@@ -91,6 +58,39 @@ tracks/1/keys = {
 _data = {
 "show": SubResource("7")
 }
+
+[sub_resource type="AtlasTexture" id="8"]
+atlas = ExtResource("8")
+region = Rect2(96, 128, 16, 16)
+
+[sub_resource type="GDScript" id="9"]
+script/source = "extends HBoxContainer
+
+
+const PASTE_TYPE_ICON : Dictionary = {
+	none=preload(\"res://material_maker/icons/paste_none.tres\"),
+	color=preload(\"res://material_maker/icons/paste_none.tres\"),
+	palette=preload(\"res://material_maker/icons/paste_palette.tres\"),
+	newgraph=preload(\"res://material_maker/icons/paste_newgraph.tres\"),
+	graph=preload(\"res://material_maker/icons/paste_graph.tres\")
+}
+
+func _on_Timer_timeout():
+	var data : String = DisplayServer.clipboard_get().strip_edges()
+	var parsed_data = await mm_globals.parse_paste_data(data)
+	$Contents.texture = PASTE_TYPE_ICON[parsed_data.type]
+	var hint : String
+	match parsed_data.type:
+		\"none\",\"color\":
+			hint = \"The clipboard cannot be pasted\"
+		\"palette\":
+			hint = \"The clipboard contains a color palette and can be pasted\\ninto a graph view as a colorize node\"
+		\"newgraph\":
+			hint = \"The clipboard can be pasted as a new graph view\\nand contains %d nodes and %d connections\" % [ parsed_data.graph.nodes.size(), parsed_data.graph.connections.size() ]
+		\"graph\":
+			hint = \"The clipboard can be pasted into a graph view\\nand contains %d nodes and %d connections\" % [ parsed_data.graph.nodes.size(), parsed_data.graph.connections.size() ]
+	tooltip_text = hint
+"
 
 [node name="MainWindow" type="PanelContainer" groups=["preview"]]
 anchors_preset = 15
@@ -192,6 +192,19 @@ scroll_active = false
 
 [node name="Timer" type="Timer" parent="VBoxContainer/StatusBar/HBox/Tip"]
 
+[node name="UndoRedoLabel" type="Label" parent="VBoxContainer/StatusBar/HBox"]
+unique_name_in_owner = true
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Undo/Redo action added"
+script = SubResource("6")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="VBoxContainer/StatusBar/HBox/UndoRedoLabel"]
+libraries = {
+"": SubResource("AnimationLibrary_kxf7t")
+}
+
 [node name="ConsoleButton" type="TextureButton" parent="VBoxContainer/StatusBar/HBox"]
 layout_mode = 2
 size_flags_horizontal = 4
@@ -241,17 +254,6 @@ script = ExtResource("9")
 
 [node name="AddNodePopup" parent="." instance=ExtResource("7")]
 visible = false
-
-[node name="UndoRedoLabel" type="Label" parent="."]
-modulate = Color(1, 1, 1, 0)
-layout_mode = 2
-text = "Undo/Redo action added"
-script = SubResource("6")
-
-[node name="AnimationPlayer" type="AnimationPlayer" parent="UndoRedoLabel"]
-libraries = {
-"": SubResource("AnimationLibrary_kxf7t")
-}
 
 [connection signal="layout_changed" from="VBoxContainer/Layout/FlexibleLayout" to="." method="update_menus"]
 [connection signal="meta_clicked" from="VBoxContainer/Console/RichTextLabel" to="VBoxContainer/Console" method="_on_rich_text_label_meta_clicked"]

--- a/material_maker/main_window.tscn
+++ b/material_maker/main_window.tscn
@@ -98,8 +98,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -160.0
 offset_top = -21.0
-offset_right = 160.0
-offset_bottom = 15.0
+offset_right = 430.0
+offset_bottom = 311.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 3
@@ -175,10 +175,14 @@ size_flags_horizontal = 3
 bbcode_enabled = true
 scroll_following = true
 
-[node name="StatusBar" type="HBoxContainer" parent="VBoxContainer"]
+[node name="StatusBar" type="PanelContainer" parent="VBoxContainer"]
+layout_mode = 2
+theme_type_variation = &"MM_StatusBarBackground"
+
+[node name="HBox" type="HBoxContainer" parent="VBoxContainer/StatusBar"]
 layout_mode = 2
 
-[node name="Tip" type="RichTextLabel" parent="VBoxContainer/StatusBar"]
+[node name="Tip" type="RichTextLabel" parent="VBoxContainer/StatusBar/HBox"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
@@ -186,50 +190,50 @@ bbcode_enabled = true
 fit_content = true
 scroll_active = false
 
-[node name="Timer" type="Timer" parent="VBoxContainer/StatusBar/Tip"]
+[node name="Timer" type="Timer" parent="VBoxContainer/StatusBar/HBox/Tip"]
 
-[node name="ConsoleButton" type="TextureButton" parent="VBoxContainer/StatusBar"]
+[node name="ConsoleButton" type="TextureButton" parent="VBoxContainer/StatusBar/HBox"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 tooltip_text = "Show console"
 texture_normal = SubResource("8")
 
-[node name="VSeparator1" type="VSeparator" parent="VBoxContainer/StatusBar"]
+[node name="VSeparator1" type="VSeparator" parent="VBoxContainer/StatusBar/HBox"]
 layout_mode = 2
 
-[node name="Share" parent="VBoxContainer/StatusBar" instance=ExtResource("12")]
+[node name="Share" parent="VBoxContainer/StatusBar/HBox" instance=ExtResource("12")]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="VSeparator2" type="VSeparator" parent="VBoxContainer/StatusBar"]
+[node name="VSeparator2" type="VSeparator" parent="VBoxContainer/StatusBar/HBox"]
 layout_mode = 2
 
-[node name="ClipBoardAnalyzer" type="HBoxContainer" parent="VBoxContainer/StatusBar"]
+[node name="ClipBoardAnalyzer" type="HBoxContainer" parent="VBoxContainer/StatusBar/HBox"]
 layout_mode = 2
 script = SubResource("9")
 
-[node name="Clipboard" type="TextureRect" parent="VBoxContainer/StatusBar/ClipBoardAnalyzer"]
+[node name="Clipboard" type="TextureRect" parent="VBoxContainer/StatusBar/HBox/ClipBoardAnalyzer"]
 visible = false
 layout_mode = 2
 size_flags_vertical = 4
 mouse_filter = 2
 texture = SubResource("8")
 
-[node name="Contents" type="TextureRect" parent="VBoxContainer/StatusBar/ClipBoardAnalyzer"]
+[node name="Contents" type="TextureRect" parent="VBoxContainer/StatusBar/HBox/ClipBoardAnalyzer"]
 layout_mode = 2
 size_flags_vertical = 4
 mouse_filter = 2
 texture = ExtResource("15")
 
-[node name="Timer" type="Timer" parent="VBoxContainer/StatusBar/ClipBoardAnalyzer"]
+[node name="Timer" type="Timer" parent="VBoxContainer/StatusBar/HBox/ClipBoardAnalyzer"]
 wait_time = 0.5
 autostart = true
 
-[node name="VSeparator3" type="VSeparator" parent="VBoxContainer/StatusBar"]
+[node name="VSeparator3" type="VSeparator" parent="VBoxContainer/StatusBar/HBox"]
 layout_mode = 2
 
-[node name="RenderCounter" parent="VBoxContainer/StatusBar" instance=ExtResource("11")]
+[node name="RenderCounter" parent="VBoxContainer/StatusBar/HBox" instance=ExtResource("11")]
 layout_mode = 2
 
 [node name="NodeFactory" type="Node" parent="."]
@@ -251,6 +255,6 @@ libraries = {
 
 [connection signal="layout_changed" from="VBoxContainer/Layout/FlexibleLayout" to="." method="update_menus"]
 [connection signal="meta_clicked" from="VBoxContainer/Console/RichTextLabel" to="VBoxContainer/Console" method="_on_rich_text_label_meta_clicked"]
-[connection signal="timeout" from="VBoxContainer/StatusBar/Tip/Timer" to="." method="_on_Tip_Timer_timeout"]
-[connection signal="pressed" from="VBoxContainer/StatusBar/ConsoleButton" to="VBoxContainer/Console" method="toggle"]
-[connection signal="timeout" from="VBoxContainer/StatusBar/ClipBoardAnalyzer/Timer" to="VBoxContainer/StatusBar/ClipBoardAnalyzer" method="_on_Timer_timeout"]
+[connection signal="timeout" from="VBoxContainer/StatusBar/HBox/Tip/Timer" to="." method="_on_Tip_Timer_timeout"]
+[connection signal="pressed" from="VBoxContainer/StatusBar/HBox/ConsoleButton" to="VBoxContainer/Console" method="toggle"]
+[connection signal="timeout" from="VBoxContainer/StatusBar/HBox/ClipBoardAnalyzer/Timer" to="VBoxContainer/StatusBar/HBox/ClipBoardAnalyzer" method="_on_Timer_timeout"]

--- a/material_maker/panels/graph_edit/graph_edit.tscn
+++ b/material_maker/panels/graph_edit/graph_edit.tscn
@@ -25,7 +25,9 @@ offset_top = -1.49829
 offset_bottom = -1.49829
 theme_override_constants/port_hotzone_inner_extent = 4
 theme_override_constants/port_hotzone_outer_extent = 4
+grid_pattern = 1
 right_disconnects = true
+show_zoom_label = true
 script = ExtResource("1")
 
 [node name="Timer" type="Timer" parent="."]

--- a/material_maker/panels/library/library.gd
+++ b/material_maker/panels/library/library.gd
@@ -13,6 +13,7 @@ var category_buttons = {}
 @onready var filter_line_edit : LineEdit = %Filter
 @onready var item_menu : PopupMenu = %ItemMenu
 
+const MINIMUM_ITEM_HEIGHT : int = 30
 
 const MENU_CREATE_LIBRARY : int = 1000
 const MENU_LOAD_LIBRARY : int =   1001
@@ -113,7 +114,8 @@ func update_tree() -> void:
 	tree.clear()
 	tree.create_item()
 	for i in library_manager.get_items(filter):
-		add_item(i.item, i.library_index, i.name, i.icon, null, filter != "")
+		var item := add_item(i.item, i.library_index, i.name, i.icon, null, filter != "")
+
 	tree.queue_redraw()
 
 func add_item(item, library_index : int, item_name : String, item_icon = null, item_parent = null, force_expand = false) -> TreeItem:
@@ -129,10 +131,11 @@ func add_item(item, library_index : int, item_name : String, item_icon = null, i
 				break
 		if new_item == null:
 			new_item = tree.create_item(item_parent)
+			new_item.custom_minimum_height = MINIMUM_ITEM_HEIGHT
 			new_item.set_text(0, TranslationServer.translate(item_name))
 		new_item.collapsed = !force_expand and expanded_items.find(item.tree_item) == -1
 		new_item.set_icon(1, item_icon)
-		new_item.set_icon_max_width(1, 32)
+		new_item.set_icon_max_width(1, 28)
 		if item.has("type") || item.has("nodes"):
 			new_item.set_metadata(0, item)
 			new_item.set_metadata(1, library_index)
@@ -147,6 +150,7 @@ func add_item(item, library_index : int, item_name : String, item_icon = null, i
 				break
 		if new_parent == null:
 			new_parent = tree.create_item(item_parent)
+			new_parent.custom_minimum_height = MINIMUM_ITEM_HEIGHT
 			new_parent.set_text(0, TranslationServer.translate(prefix))
 			new_parent.collapsed = !force_expand and expanded_items.find(get_item_path(new_parent)) == -1
 		return add_item(item, library_index, suffix, item_icon, new_parent, force_expand)

--- a/material_maker/panels/library/library.tscn
+++ b/material_maker/panels/library/library.tscn
@@ -1,20 +1,16 @@
-[gd_scene load_steps=7 format=3 uid="uid://drbpisn5f3h8y"]
+[gd_scene load_steps=5 format=3 uid="uid://drbpisn5f3h8y"]
 
 [ext_resource type="Script" path="res://material_maker/panels/library/library_tree.gd" id="1"]
 [ext_resource type="Script" path="res://material_maker/panels/library/library.gd" id="1_748nq"]
 [ext_resource type="Texture2D" uid="uid://c0j4px4n72di5" path="res://material_maker/icons/icons.tres" id="3"]
-[ext_resource type="Texture2D" uid="uid://cvorvnes6fiq7" path="res://material_maker/icons/icons.svg" id="3_el42x"]
 
 [sub_resource type="AtlasTexture" id="1"]
 atlas = ExtResource("3")
 region = Rect2(0, 0, 16, 16)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_m5x46"]
-atlas = ExtResource("3_el42x")
-region = Rect2(48, 0, 16, 16)
-
 [node name="Library" type="PanelContainer"]
-offset_right = 132.0
+offset_right = 323.0
+offset_bottom = 391.0
 theme_type_variation = &"MM_PanelBackground"
 script = ExtResource("1_748nq")
 library_manager_name = "NodeLibraryManager"
@@ -28,23 +24,9 @@ size_flags_vertical = 3
 [node name="HBoxContainer" type="HBoxContainer" parent="Library"]
 layout_mode = 2
 
-[node name="Libraries" type="MenuButton" parent="Library/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 0
-text = "Manage"
-icon = SubResource("1")
-
 [node name="Control" type="Control" parent="Library/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-
-[node name="GetFromWebsite" type="TextureButton" parent="Library/HBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 4
-tooltip_text = "Get more nodes from website"
-texture_normal = SubResource("AtlasTexture_m5x46")
 
 [node name="SectionButtons" type="HFlowContainer" parent="Library"]
 unique_name_in_owner = true
@@ -62,37 +44,50 @@ theme_type_variation = &"MM_FilterLineEdit"
 placeholder_text = "Filter"
 clear_button_enabled = true
 
+[node name="Libraries" type="MenuButton" parent="Library/Filter"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+icon = SubResource("1")
+flat = false
+
 [node name="Tree" type="Tree" parent="Library"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(50, 50)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+theme_override_constants/v_separation = 1
 columns = 2
 allow_rmb_select = true
 hide_root = true
 select_mode = 1
 script = ExtResource("1")
 
+[node name="GetFromWebsite" type="Button" parent="Library"]
+layout_mode = 2
+size_flags_vertical = 4
+tooltip_text = "Get more nodes from website"
+text = "Browser Community Nodes "
+clip_text = true
+
 [node name="ItemMenu" type="PopupMenu" parent="."]
 unique_name_in_owner = true
 item_count = 5
 item_0/text = "Rename item"
-item_0/id = 0
 item_1/text = "Update thumbnail"
 item_1/id = 1
 item_2/text = "Remove item"
 item_2/id = 2
-item_3/text = ""
 item_3/id = 3
 item_3/separator = true
 item_4/text = "Define aliases"
 item_4/id = 4
 
-[connection signal="about_to_popup" from="Library/HBoxContainer/Libraries" to="." method="_on_Libraries_about_to_show"]
-[connection signal="pressed" from="Library/HBoxContainer/GetFromWebsite" to="." method="_on_GetFromWebsite_pressed"]
 [connection signal="text_changed" from="Library/Filter/Filter" to="." method="_on_Filter_text_changed"]
+[connection signal="about_to_popup" from="Library/Filter/Libraries" to="." method="_on_Libraries_about_to_show"]
 [connection signal="item_collapsed" from="Library/Tree" to="." method="_on_Tree_item_collapsed"]
 [connection signal="item_mouse_selected" from="Library/Tree" to="." method="_on_tree_item_mouse_selected"]
+[connection signal="pressed" from="Library/GetFromWebsite" to="." method="_on_GetFromWebsite_pressed"]
 [connection signal="about_to_popup" from="ItemMenu" to="Library" method="_on_PopupMenu_about_to_show"]
 [connection signal="index_pressed" from="ItemMenu" to="Library" method="_on_PopupMenu_index_pressed"]

--- a/material_maker/panels/library/library.tscn
+++ b/material_maker/panels/library/library.tscn
@@ -68,7 +68,7 @@ script = ExtResource("1")
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "Get more nodes from website"
-text = "Browser Community Nodes "
+text = "Browse Community Nodes "
 clip_text = true
 
 [node name="ItemMenu" type="PopupMenu" parent="."]

--- a/material_maker/panels/library/library_tree.gd
+++ b/material_maker/panels/library/library_tree.gd
@@ -34,7 +34,7 @@ func _draw():
 				var last_item : TreeItem = get_last_item(item)
 				if last_item != null:
 					last_rect = get_item_area_rect(last_item)
-			draw_rect(Rect2(1, rect.position.y+6-sp, 4, last_rect.position.y-rect.position.y+last_rect.size.y), color)
+			draw_rect(Rect2(1, rect.position.y-sp, 4, last_rect.position.y-rect.position.y+last_rect.size.y), color)
 		item = item.get_next()
 
 func _get_drag_data(_position):

--- a/material_maker/theme/modern.tres
+++ b/material_maker/theme/modern.tres
@@ -224,7 +224,7 @@ content_margin_left = 10.0
 content_margin_top = 10.0
 content_margin_right = 10.0
 content_margin_bottom = 10.0
-bg_color = Color(0.0784314, 0.0784314, 0.0823529, 1)
+bg_color = Color(0.0427646, 0.0427646, 0.0456467, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_k2ns1"]
 bg_color = Color(0.8, 0.8, 0.8, 1)
@@ -367,7 +367,7 @@ content_margin_left = 7.0
 content_margin_top = 5.0
 content_margin_right = 7.0
 content_margin_bottom = 5.0
-bg_color = Color(0.157074, 0.161861, 0.176218, 1)
+bg_color = Color(0.129412, 0.137255, 0.152941, 1)
 corner_radius_top_left = 3
 corner_radius_top_right = 3
 
@@ -376,7 +376,7 @@ content_margin_left = 7.0
 content_margin_top = 5.0
 content_margin_right = 7.0
 content_margin_bottom = 5.0
-bg_color = Color(0.0680024, 0.0730968, 0.0833106, 1)
+bg_color = Color(0.109804, 0.113725, 0.12549, 1)
 corner_radius_top_left = 3
 corner_radius_top_right = 3
 

--- a/material_maker/theme/modern.tres
+++ b/material_maker/theme/modern.tres
@@ -192,9 +192,9 @@ corner_radius_bottom_left = 5
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dyhk7"]
 content_margin_left = 10.0
-content_margin_top = 5.0
+content_margin_top = 2.0
 content_margin_right = 10.0
-content_margin_bottom = 5.0
+content_margin_bottom = 2.0
 bg_color = Color(0.168627, 0.176471, 0.192157, 1)
 border_width_left = 1
 border_width_top = 1
@@ -209,9 +209,9 @@ corner_detail = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_mv8c7"]
 content_margin_left = 10.0
-content_margin_top = 5.0
+content_margin_top = 2.0
 content_margin_right = 10.0
-content_margin_bottom = 5.0
+content_margin_bottom = 2.0
 bg_color = Color(0.168627, 0.176471, 0.192157, 1)
 corner_radius_top_left = 5
 corner_radius_top_right = 5
@@ -407,7 +407,7 @@ Button/styles/hover = SubResource("StyleBoxFlat_2qiie")
 Button/styles/normal = SubResource("StyleBoxFlat_rxikb")
 Button/styles/pressed = SubResource("StyleBoxFlat_rxikb")
 GraphEdit/colors/grid_major = Color(0.137255, 0.141176, 0.152941, 1)
-GraphEdit/colors/grid_minor = Color(0.104085, 0.107345, 0.117127, 1)
+GraphEdit/colors/grid_minor = Color(0.137255, 0.141176, 0.152941, 1)
 GraphEdit/styles/menu_panel = SubResource("StyleBoxFlat_pxlc8")
 GraphEdit/styles/panel = SubResource("StyleBoxEmpty_62l4s")
 GraphNode/colors/portpreview_color = Color(0.89059, 0.89059, 0.89059, 1)

--- a/material_maker/theme/modern.tres
+++ b/material_maker/theme/modern.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=45 format=3 uid="uid://b628lwfk6ig2c"]
+[gd_resource type="Theme" load_steps=46 format=3 uid="uid://b628lwfk6ig2c"]
 
 [ext_resource type="FontFile" uid="uid://dgkwr5jydtk6p" path="res://material_maker/theme/font_rubik/Rubik-VariableFont_wght.ttf" id="1_hqoqt"]
 [ext_resource type="FontFile" uid="uid://btybkvkb8rtol" path="res://material_maker/fonts/DroidSansFallback.ttf" id="2_1xp11"]
@@ -74,7 +74,7 @@ content_margin_left = 28.0
 content_margin_top = 4.0
 content_margin_right = 28.0
 content_margin_bottom = 4.0
-bg_color = Color(0.168627, 0.176471, 0.192157, 1)
+bg_color = Color(0.0666667, 0.0705882, 0.0784314, 1)
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 corner_detail = 4
@@ -84,7 +84,7 @@ content_margin_left = 28.0
 content_margin_top = 4.0
 content_margin_right = 28.0
 content_margin_bottom = 4.0
-bg_color = Color(0.168627, 0.176471, 0.192157, 1)
+bg_color = Color(0.0666667, 0.0705882, 0.0784314, 1)
 border_width_left = 1
 border_width_right = 1
 border_width_bottom = 1
@@ -224,7 +224,7 @@ content_margin_left = 10.0
 content_margin_top = 10.0
 content_margin_right = 10.0
 content_margin_bottom = 10.0
-bg_color = Color(0.0401277, 0.0432053, 0.0493515, 1)
+bg_color = Color(0.0784314, 0.0784314, 0.0823529, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_k2ns1"]
 bg_color = Color(0.8, 0.8, 0.8, 1)
@@ -240,16 +240,28 @@ content_margin_left = 6.0
 content_margin_top = 6.0
 content_margin_right = 6.0
 content_margin_bottom = 6.0
-bg_color = Color(0.113725, 0.113725, 0.113725, 1)
+bg_color = Color(0.0941176, 0.0980392, 0.101961, 1)
 corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1k0sx"]
-bg_color = Color(0.0846134, 0.0883864, 0.0997054, 1)
+bg_color = Color(0.0941176, 0.0980392, 0.101961, 1)
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7hrav"]
+content_margin_left = 3.0
+content_margin_top = 3.0
+content_margin_right = 3.0
+content_margin_bottom = 3.0
+bg_color = Color(0.129412, 0.137255, 0.152941, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+corner_detail = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dscxc"]
 content_margin_left = 6.0
@@ -368,31 +380,11 @@ bg_color = Color(0.0680024, 0.0730968, 0.0833106, 1)
 corner_radius_top_left = 3
 corner_radius_top_right = 3
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_d7p6f"]
-bg_color = Color(0.168627, 0.176471, 0.192157, 1)
-draw_center = false
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color(0.266667, 0.278431, 0.301961, 1)
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
-corner_detail = 4
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_iwtn1"]
+content_margin_left = 4.0
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_e18lx"]
-content_margin_left = 10.0
-content_margin_top = 5.0
-content_margin_right = 10.0
-content_margin_bottom = 5.0
-bg_color = Color(0.168627, 0.176471, 0.192157, 1)
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
-corner_detail = 4
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_yrroa"]
+content_margin_left = 4.0
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_x5l5s"]
 content_margin_left = 3.0
@@ -454,6 +446,8 @@ MM_PanelBackground/base_type = &"PanelContainer"
 MM_PanelBackground/styles/panel = SubResource("StyleBoxFlat_uujf1")
 MM_ProjectsBackground/base_type = &"Panel"
 MM_ProjectsBackground/styles/panel = SubResource("StyleBoxFlat_1k0sx")
+MM_StatusBarBackground/base_type = &"PanelContainer"
+MM_StatusBarBackground/styles/panel = SubResource("StyleBoxFlat_7hrav")
 Panel/styles/panel = SubResource("StyleBoxFlat_dscxc")
 PopupMenu/styles/hover = SubResource("StyleBoxFlat_fq0uc")
 PopupMenu/styles/panel = SubResource("StyleBoxFlat_8p2hu")
@@ -499,7 +493,7 @@ TabBar/styles/tab_selected = SubResource("StyleBoxFlat_r4jxv")
 TabBar/styles/tab_unselected = SubResource("StyleBoxFlat_w1kc3")
 Tree/constants/draw_guides = 0
 Tree/constants/draw_relationship_lines = 0
-Tree/styles/focus = SubResource("StyleBoxFlat_d7p6f")
-Tree/styles/panel = SubResource("StyleBoxFlat_e18lx")
+Tree/styles/focus = SubResource("StyleBoxEmpty_iwtn1")
+Tree/styles/panel = SubResource("StyleBoxEmpty_yrroa")
 Tree/styles/selected = SubResource("StyleBoxFlat_x5l5s")
 Tree/styles/selected_focus = SubResource("StyleBoxFlat_x5l5s")

--- a/material_maker/tools/undo_redo/undo_redo.gd
+++ b/material_maker/tools/undo_redo/undo_redo.gd
@@ -118,5 +118,5 @@ func add(action_name : String, undo_actions : Array, redo_actions : Array, merge
 		if group_level > 0:
 			group = undo_redo
 	if OS.is_debug_build():
-		get_node("/root/MainWindow/UndoRedoLabel").show_step(step)
+		get_node("/root/MainWindow").get_node("%UndoRedoLabel").show_step(step)
 	mm_globals.main_window.update_menus()


### PR DESCRIPTION
Does the following changes:
- Library Panel
   - Move Manage button next to Filter
   - Move Add Nodes button to the bottom
   - Remove background of the tree, reduces margins
   - Reduce V-Separation of Tree items
   - Make Previews slightly smaller
   - Add minimum height to TreeItems, for more consistent look

- Main
   - Adds Panel to StatusBar
   - Moves UndoRedo label to StatusBar
   - Slightly adjust BG color and Panel colors

- FlexibleTab
   - Makes unselected tabs use a different font color

- Graph Area
   - Use Dotted Grid
   - Use darker bg on nodes
   
Here is the final look:
![grafik](https://github.com/RodZill4/material-maker/assets/42868150/63f3760e-d0b8-472e-b272-f508fe5b218e)

