### PR TITLE
Fix seams on tiled textures when using certain nodes

### DIFF
--- a/addons/material_maker/engine/pipeline/pipeline.gd
+++ b/addons/material_maker/engine/pipeline/pipeline.gd
@@ -319,6 +319,8 @@ func get_texture_uniforms(rd : RenderingDevice, shader : RID, rids : RIDs) -> RI
 	sampler_state.mag_filter = RenderingDevice.SAMPLER_FILTER_NEAREST
 	sampler_state.min_filter = RenderingDevice.SAMPLER_FILTER_NEAREST
 	sampler_state.mip_filter = RenderingDevice.SAMPLER_FILTER_NEAREST
+	sampler_state.repeat_u = RenderingDevice.SAMPLER_REPEAT_MODE_REPEAT
+	sampler_state.repeat_v = RenderingDevice.SAMPLER_REPEAT_MODE_REPEAT
 	var sampler : RID = rd.sampler_create(sampler_state)
 	rids.add(sampler, "sampler")
 	var sampler_uniform_array : Array = []


### PR DESCRIPTION
Changes the texture samplers' repeat properties to repeat by default to make them function the same way they did in previous versions. This fixes the seams that appear when using most processing nodes:

| 1.3 | 1.4a | 1.4 PR |
|----|------|--------|
|![1_3](https://github.com/user-attachments/assets/0cc318f9-fc12-4c83-a967-7a2b292c1790)|![1_4](https://github.com/user-attachments/assets/46f741fd-baff-4782-aa2e-f000354c1321)|![1_4PR](https://github.com/user-attachments/assets/9b078d09-a9fb-4578-bb62-ca3733e4db65)|




