### PR TITLE
Adjust height of preview cylinder

### DIFF
--- a/material_maker/panels/preview_3d/preview_objects.tscn
+++ b/material_maker/panels/preview_3d/preview_objects.tscn
@@ -7,7 +7,7 @@
 [sub_resource type="ArrayMesh" id="ArrayMesh_iqcsj"]
 
 [sub_resource type="CylinderMesh" id="2"]
-height = 1.25
+height = 1.5707963267948966
 radial_segments = 32
 rings = 1
 


### PR DESCRIPTION
Changes the cylinder height to `PI / 2`, which eliminates the UV stretching seen in the current model.

### Before/After:
![1730937460](https://github.com/user-attachments/assets/b44e2e1c-eeec-432d-b7df-20b74fc231f7)
