### PR TITLE
Fix nonexistent library dir

### DIFF
--- a/material_maker/tools/library_manager/library.gd
+++ b/material_maker/tools/library_manager/library.gd
@@ -108,7 +108,7 @@ func get_sections() -> Array:
 	return Array(sections)
 
 func save_library() -> void:
-	DirAccess.open("res://").make_dir_recursive(library_path.get_base_dir())
+	DirAccess.make_dir_recursive_absolute(library_path.get_base_dir())
 	var file : FileAccess = FileAccess.open(library_path, FileAccess.WRITE)
 	if file != null:
 		file.store_string(JSON.stringify({name=library_name, lib=library_items}, "\t", true))

--- a/material_maker/tools/library_manager/library_manager.gd
+++ b/material_maker/tools/library_manager/library_manager.gd
@@ -40,7 +40,7 @@ func _ready():
 func _exit_tree():
 	if item_usage_file == "":
 		return
-	DirAccess.open("res://").make_dir_recursive(item_usage_file.get_base_dir())
+	DirAccess.make_dir_recursive_absolute(item_usage_file.get_base_dir())
 	var file = FileAccess.open(item_usage_file, FileAccess.WRITE)
 	if file != null:
 		file.store_string(JSON.stringify(item_usage, "\t", true))
@@ -55,6 +55,7 @@ func init_libraries() -> void:
 		add_child(library)
 		library.generate_node_sections(node_sections)
 	library = LIBRARY.new()
+	DirAccess.make_dir_recursive_absolute(user_lib.get_base_dir())
 	if library.load_library(user_lib):
 		if library.library_name == "":
 			library.library_name = user_lib_name


### PR DESCRIPTION
Currently, item_usage history and nodes saved to the user library are not being stored between sessions on fresh installs due to the "user://library" directory not existing. (bug can be checked by deleting the directory and attempting to save a node to user library on latest alpha)
This PR fixes that by creating the directory on startup, and making sure that a directory exists before trying to save a library file

Changes were tested on Windows 11 and seem to work fine