### PR TITLE
Fix splashscreen position

### DIFF
--- a/splash_screen/splash_screen.gd
+++ b/splash_screen/splash_screen.gd
@@ -61,7 +61,8 @@ func _enter_tree():
 				screen = randi() % BACKGROUNDS.size()
 	set_screen(screen)
 	var window : Window = get_window()
-	window.position = (DisplayServer.screen_get_size(window.current_screen)-Vector2i(size))/2
+	var current_screen_index = window.current_screen
+	window.position = (DisplayServer.screen_get_size(current_screen_index)-Vector2i(size))/2 + DisplayServer.screen_get_position(current_screen_index)
 	window.size = size
 
 func set_screen(bi : int) -> void:


### PR DESCRIPTION
On multi-monitor setups, the 0.0 point of the desktop can be different from the 0.0 point of a screen, as shown [here](https://docs.godotengine.org/en/stable/classes/class_displayserver.html#class-displayserver-method-screen-get-position).
This quirk was causing the initial splash screen to show up on weird places if the user had multiple screens.
This PR fixes the problem by taking the current screen position into account.

Before:
https://github.com/user-attachments/assets/453e40ae-975a-418d-a44c-036243a333f7

After:
https://github.com/user-attachments/assets/e36b184d-0eef-4652-a40b-801c5097d26a

Changes were tested on Windows 11 with a dual monitor setup with 2 1920x1080 monitors, would be nice if people with different setups could test it aswell, but from what i've read in the godot docs, it should work regardless
