### PR TITLE
Add a basic default layout for the material mode

### DIFF
--- a/material_maker/main_window_layout.gd
+++ b/material_maker/main_window_layout.gd
@@ -13,6 +13,21 @@ const PANELS = [
 	{ name="Layers", scene=preload("res://material_maker/panels/layers/layers.tscn"), position="BottomRight" },
 	{ name="Parameters", scene=preload("res://material_maker/panels/parameters/parameters.tscn"), position="TopRight" },
 ]
+
+var default_material_layout := {
+	&"main": { &"type": "FlexTop", &"w": 1900.0, &"h": 939.0, &"children": [
+		{ &"type": "FlexSplit", &"w": 1900.0, &"h": 939.0, &"children": [
+			{ &"type": "FlexTab", &"w": 373.0, &"h": 939.0, &"children": [], &"tabs": [
+				&"Library", &"Hierarchy"], &"current": 0 },
+			{ &"type": "FlexMain", &"w": 1073.0, &"h": 939.0, &"children": [] },
+			{ &"type": "FlexSplit", &"w": 434.0, &"h": 939.0, &"children": [
+				{ &"type": "FlexTab", &"w": 434.0, &"h": 501.0, &"children": [], &"tabs": [
+					&"Preview2D", &"Histogram"], &"current": 0 },
+				{ &"type": "FlexTab", &"w": 434.0, &"h": 427.0, &"children": [], &"tabs": [
+					&"Preview3D", &"Preview2D (2)", &"Reference"], &"current": 0 }
+			], &"dir": "v" }], &"dir": "h" }]}, &"windows": [] }
+
+
 const HIDE_PANELS = {
 	material=[ "Brushes", "Layers", "Parameters" ],
 	paint=[ "Preview3D", "Histogram", "Hierarchy" ]
@@ -41,17 +56,21 @@ func load_panels() -> void:
 				node.set(p, panel.parameters[p])
 		panels[panel.name] = node
 		$FlexibleLayout.add(panel.name, node)
-	var current_config = null
+
 	for mode in [ "material", "paint" ]:
 		if mm_globals.config.has_section_key("layout", mode):
 			layout[mode] = JSON.parse_string(mm_globals.config.get_value("layout", mode))
+		elif mode == "material":
+			layout[mode] = default_material_layout
 	$FlexibleLayout.init(layout[current_mode] if layout.has(current_mode) else null)
+
 
 func save_config() -> void:
 	layout[current_mode] = $FlexibleLayout.serialize()
 	for mode in [ "material", "paint" ]:
 		if layout.has(mode):
 			mm_globals.config.set_value("layout", mode, JSON.stringify(layout[mode]))
+
 
 func get_panel(n) -> Control:
 	if panels.has(n):

--- a/material_maker/main_window_layout.gd
+++ b/material_maker/main_window_layout.gd
@@ -27,6 +27,7 @@ var default_material_layout := {
 					&"Preview3D", &"Preview2D (2)", &"Reference"], &"current": 0 }
 			], &"dir": "v" }], &"dir": "h" }]}, &"windows": [] }
 
+var default_paint_layout : Dictionary = { main={ children=[ { children=[ { children=[], current=0, h=766.0, tabs=["Brushes"], type="FlexTab", w=279.0 }, { children=[], h=766.0, type="FlexMain", w=844.0 }, { children=[ { children=[], current=0, h=370.0, tabs=["Parameters"], type="FlexTab", w=240.0 }, { children=[], current=0, h=386.0, tabs=["Layers"], type="FlexTab", w=240.0 }], dir="v", h=766.0, type="FlexSplit", w=240.0 }], dir="h", h=766.0, type="FlexSplit", w=1383.0 }], h=766.0, type="FlexTop", w=1383.0 }, windows=[] }
 
 const HIDE_PANELS = {
 	material=[ "Brushes", "Layers", "Parameters" ],
@@ -62,6 +63,8 @@ func load_panels() -> void:
 			layout[mode] = JSON.parse_string(mm_globals.config.get_value("layout", mode))
 		elif mode == "material":
 			layout[mode] = default_material_layout
+		elif mode == "paint":
+			layout[mode] = default_paint_layout
 	$FlexibleLayout.init(layout[current_mode] if layout.has(current_mode) else null)
 
 

--- a/material_maker/widgets/tabs/tabs.gd
+++ b/material_maker/widgets/tabs/tabs.gd
@@ -1,6 +1,6 @@
 extends Panel
 
-var current_tab : int = -1 : 
+var current_tab : int = -1 :
 	get:
 		return current_tab
 	set(new_value):
@@ -31,6 +31,7 @@ func add_tab(control, legible_unique_name = false) -> void:
 	move_child(control, $TabBar.get_tab_count())
 	$TabBar.add_tab(control.name)
 	control.visible = false
+	_on_Projects_resized()
 
 func set_current_tab(t : int):
 	current_tab = t


### PR DESCRIPTION
This is far from perfect, but should make the first impression a bit better.

Also fixes the issue where the graph would be incorrectly positioned on load until you resized the projects panel.

This is how it looks:
![grafik](https://github.com/user-attachments/assets/97a7adb4-466e-42d7-9ff2-9b00b181f248)

