### PR TITLE
Force image node uv to tile when clamp is deselected

### DIFF
--- a/addons/material_maker/engine/nodes/gen_image.gd
+++ b/addons/material_maker/engine/nodes/gen_image.gd
@@ -46,6 +46,8 @@ func get_adjusted_uv(uv : String) -> String:
 
 	if get_parameter("clamp"):
 		uv = "clamp(%s, 0.0, 1.0)" % uv
+	else:
+		uv = "mod(%s, 1.0)" % uv
 
 	return uv
 


### PR DESCRIPTION
The image node was always outputting a clamped result in 1.4a. this PR fixes that by forcing a tiled UV when clamp is not selected.

Before:
![image](https://github.com/user-attachments/assets/fb3d1cee-2588-48f9-87f6-c617feecddbd)
After:
![image](https://github.com/user-attachments/assets/a865a29d-fbb0-455c-8c34-c05a299f5916)
