### PR TITLE
Overhaul custom library creation window

### DIFF
--- a/material_maker/panels/library/create_lib_dialog.gd
+++ b/material_maker/panels/library/create_lib_dialog.gd
@@ -68,3 +68,4 @@ func enter_info(value : String = "") -> Dictionary:
 
 func _on_VBoxContainer_minimum_size_changed():
 	min_size = $MarginContainer.get_combined_minimum_size()
+	max_size = Vector2(max_size.x, $MarginContainer.get_minimum_size().y)

--- a/material_maker/panels/library/create_lib_dialog.gd
+++ b/material_maker/panels/library/create_lib_dialog.gd
@@ -1,19 +1,17 @@
 extends Window
 
-var file_path_line_edit: LineEdit
-var file_path = ""
-var file_name_line_edit: LineEdit
+@onready var file_name_line_edit : LineEdit = %LibraryNameLineEdit
+@onready var file_path_line_edit : LineEdit = %LibraryPathLineEdit
 var file_name = ""
+var file_path = ""
 
 
 signal return_info(status)
 
 
 func _ready():
-	$VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton.set_mode(FileDialog.FILE_MODE_OPEN_DIR)
-	$VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton.icon = get_parent().get_theme_icon("folder", "MM_Icons")
-	file_name_line_edit = $VBoxContainer/GridContainer/LineEdit
-	file_path_line_edit = $VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2
+	%FilePickerButton.set_mode(FileDialog.FILE_MODE_OPEN_DIR)
+	%FilePickerButton.icon = get_parent().get_theme_icon("folder", "MM_Icons")
 	popup_centered()
 
 func set_value(v) -> void:
@@ -27,7 +25,7 @@ func _on_LineEdit_text_entered(_new_text) -> void:
 	pass
 
 func validate_ok_button(fpath: String, fname: String):
-	$VBoxContainer/HBoxContainer/OK.disabled = ((fpath == "") || (fname == ""))
+	%OK.disabled = ((fpath == "") || (fname == ""))
 
 func _on_line_edit_text_changed(new_text: String) -> void:
 	file_name = new_text
@@ -69,4 +67,4 @@ func enter_info(value : String = "") -> Dictionary:
 	return result
 
 func _on_VBoxContainer_minimum_size_changed():
-	size = $VBoxContainer.size+Vector2(4, 4)
+	min_size = $MarginContainer.get_combined_minimum_size()

--- a/material_maker/panels/library/create_lib_dialog.gd
+++ b/material_maker/panels/library/create_lib_dialog.gd
@@ -2,13 +2,14 @@ extends Window
 
 
 var file_path = ""
+var file_name = ""
 
 
 signal return_info(status)
 
 
 func _ready():
-	$VBoxContainer/GridContainer/FilePickerButton.set_mode(FileDialog.FILE_MODE_OPEN_DIR)
+	$VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton.set_mode(FileDialog.FILE_MODE_OPEN_DIR)
 	popup_centered()
 
 func set_value(v) -> void:
@@ -21,12 +22,30 @@ func popup_centered_(window_size : Vector2i = Vector2i(0, 0)) -> void:
 func _on_LineEdit_text_entered(_new_text) -> void:
 	pass
 
+func _on_line_edit_text_changed(new_text: String) -> void:
+	file_name = $VBoxContainer/GridContainer/LineEdit.text
+	$VBoxContainer/HBoxContainer/OK.disabled = ((file_path == "") || (file_name == ""))
+
+func _on_line_edit_2_text_changed(new_text: String) -> void:
+	file_path = new_text
+	$VBoxContainer/HBoxContainer/OK.disabled = ((file_path == "") || (file_name == ""))
+	
 func _on_FilePickerButton_file_selected(f):
-	file_path = f
-	$VBoxContainer/HBoxContainer/OK.disabled = (file_path == "")
+	if file_name == "":
+		$VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2.text = f + "/"
+	else:
+		$VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2.text = f + "/" + file_name.validate_filename() + ".json"
+	file_path = $VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2.text
+	$VBoxContainer/HBoxContainer/OK.disabled = ((file_path == "") || (file_name == ""))
+	
 
 func _on_OK_pressed() -> void:
-	emit_signal("return_info", { ok=true, name=$VBoxContainer/GridContainer/LineEdit.text, path=file_path })
+	var fp
+	if file_path.ends_with(".json"):
+		fp = file_path
+	else:
+		fp = file_path + "/" + file_name.validate_filename() + ".json"
+	emit_signal("return_info", { ok=true, name=$VBoxContainer/GridContainer/LineEdit.text, path=fp })
 
 func _on_Cancel_pressed():
 	emit_signal("return_info", { ok=false })

--- a/material_maker/panels/library/create_lib_dialog.gd
+++ b/material_maker/panels/library/create_lib_dialog.gd
@@ -51,6 +51,9 @@ func _on_OK_pressed() -> void:
 func _on_Cancel_pressed():
 	emit_signal("return_info", { ok=false })
 
+func _on_close_requested() -> void:
+	emit_signal("return_info", { ok=false })
+
 func enter_info(value : String = "") -> Dictionary:
 	set_value(value)
 	$VBoxContainer/GridContainer/LineEdit.grab_focus()

--- a/material_maker/panels/library/create_lib_dialog.gd
+++ b/material_maker/panels/library/create_lib_dialog.gd
@@ -8,8 +8,7 @@ signal return_info(status)
 
 
 func _ready():
-	$VBoxContainer/GridContainer/FilePickerButton.set_mode(FileDialog.FILE_MODE_SAVE_FILE)
-	$VBoxContainer/GridContainer/FilePickerButton.add_filter("*.json;Material Maker library")
+	$VBoxContainer/GridContainer/FilePickerButton.set_mode(FileDialog.FILE_MODE_OPEN_DIR)
 	popup_centered()
 
 func set_value(v) -> void:

--- a/material_maker/panels/library/create_lib_dialog.gd
+++ b/material_maker/panels/library/create_lib_dialog.gd
@@ -1,7 +1,8 @@
 extends Window
 
-
+var file_path_line_edit: LineEdit
 var file_path = ""
+var file_name_line_edit: LineEdit
 var file_name = ""
 
 
@@ -11,34 +12,38 @@ signal return_info(status)
 func _ready():
 	$VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton.set_mode(FileDialog.FILE_MODE_OPEN_DIR)
 	$VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton.icon = get_parent().get_theme_icon("folder", "MM_Icons")
+	file_name_line_edit = $VBoxContainer/GridContainer/LineEdit
+	file_path_line_edit = $VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2
 	popup_centered()
 
 func set_value(v) -> void:
-	$VBoxContainer/GridContainer/LineEdit.text = v
+	file_name_line_edit.text = v
 
 func popup_centered_(window_size : Vector2i = Vector2i(0, 0)) -> void:
 	super.popup_centered(window_size)
-	$VBoxContainer/GridContainer/LineEdit.grab_focus()
+	file_name_line_edit.grab_focus()
 
 func _on_LineEdit_text_entered(_new_text) -> void:
 	pass
 
+func validate_ok_button(fpath: String, fname: String):
+	$VBoxContainer/HBoxContainer/OK.disabled = ((fpath == "") || (fname == ""))
+
 func _on_line_edit_text_changed(new_text: String) -> void:
-	file_name = $VBoxContainer/GridContainer/LineEdit.text
-	$VBoxContainer/HBoxContainer/OK.disabled = ((file_path == "") || (file_name == ""))
+	file_name = new_text
+	validate_ok_button(file_path, file_name)
 
 func _on_line_edit_2_text_changed(new_text: String) -> void:
 	file_path = new_text
-	$VBoxContainer/HBoxContainer/OK.disabled = ((file_path == "") || (file_name == ""))
+	validate_ok_button(file_path, file_name)
 	
 func _on_FilePickerButton_file_selected(f):
 	if file_name == "":
-		$VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2.text = f + "/"
+		file_path_line_edit.text = f + "/"
 	else:
-		$VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2.text = f + "/" + file_name.validate_filename() + ".json"
-	file_path = $VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2.text
-	$VBoxContainer/HBoxContainer/OK.disabled = ((file_path == "") || (file_name == ""))
-	
+		file_path_line_edit.text = f + "/" + file_name.validate_filename() + ".json"
+	file_path = file_path_line_edit.text
+	validate_ok_button(file_path, file_name)
 
 func _on_OK_pressed() -> void:
 	var fp
@@ -46,7 +51,7 @@ func _on_OK_pressed() -> void:
 		fp = file_path
 	else:
 		fp = file_path + "/" + file_name.validate_filename() + ".json"
-	emit_signal("return_info", { ok=true, name=$VBoxContainer/GridContainer/LineEdit.text, path=fp })
+	emit_signal("return_info", { ok=true, name=file_name, path=fp })
 
 func _on_Cancel_pressed():
 	emit_signal("return_info", { ok=false })
@@ -56,8 +61,8 @@ func _on_close_requested() -> void:
 
 func enter_info(value : String = "") -> Dictionary:
 	set_value(value)
-	$VBoxContainer/GridContainer/LineEdit.grab_focus()
-	$VBoxContainer/GridContainer/LineEdit.grab_click_focus()
+	file_name_line_edit.grab_focus()
+	file_name_line_edit.grab_click_focus()
 	popup_centered()
 	var result = await self.return_info
 	queue_free()

--- a/material_maker/panels/library/create_lib_dialog.gd
+++ b/material_maker/panels/library/create_lib_dialog.gd
@@ -10,6 +10,7 @@ signal return_info(status)
 
 func _ready():
 	$VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton.set_mode(FileDialog.FILE_MODE_OPEN_DIR)
+	$VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton.icon = get_parent().get_theme_icon("folder", "MM_Icons")
 	popup_centered()
 
 func set_value(v) -> void:

--- a/material_maker/panels/library/create_lib_dialog.tscn
+++ b/material_maker/panels/library/create_lib_dialog.tscn
@@ -6,6 +6,7 @@
 [sub_resource type="ImageTexture" id="ImageTexture_8pecb"]
 
 [node name="CreateLibDialog" type="Window"]
+position = Vector2i(0, 36)
 size = Vector2i(600, 100)
 exclusive = true
 script = ExtResource("1")
@@ -55,6 +56,7 @@ size_flags_horizontal = 8
 size_flags_vertical = 4
 text = ""
 icon = SubResource("ImageTexture_8pecb")
+icon_alignment = 1
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2

--- a/material_maker/panels/library/create_lib_dialog.tscn
+++ b/material_maker/panels/library/create_lib_dialog.tscn
@@ -74,6 +74,7 @@ custom_minimum_size = Vector2(60, 0)
 layout_mode = 2
 text = "Cancel"
 
+[connection signal="close_requested" from="." to="." method="_on_close_requested"]
 [connection signal="minimum_size_changed" from="VBoxContainer" to="." method="_on_VBoxContainer_minimum_size_changed"]
 [connection signal="text_changed" from="VBoxContainer/GridContainer/LineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="text_submitted" from="VBoxContainer/GridContainer/LineEdit" to="." method="_on_LineEdit_text_entered"]

--- a/material_maker/panels/library/create_lib_dialog.tscn
+++ b/material_maker/panels/library/create_lib_dialog.tscn
@@ -8,49 +8,55 @@
 [node name="CreateLibDialog" type="Window"]
 title = "Create Library"
 position = Vector2i(0, 36)
-size = Vector2i(600, 100)
+size = Vector2i(400, 1)
 exclusive = true
 script = ExtResource("1")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="."]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 5.0
-offset_top = 5.0
-offset_right = -9.0
-offset_bottom = 8.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 3
+theme_override_constants/margin_top = 3
+theme_override_constants/margin_right = 3
+theme_override_constants/margin_bottom = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
 theme_override_constants/separation = 5
 
-[node name="GridContainer" type="GridContainer" parent="VBoxContainer"]
+[node name="GridContainer" type="GridContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 columns = 2
 
-[node name="Label1" type="Label" parent="VBoxContainer/GridContainer"]
+[node name="LibraryNameLabel" type="Label" parent="MarginContainer/VBoxContainer/GridContainer"]
 layout_mode = 2
 text = "Library name:"
 
-[node name="LineEdit" type="LineEdit" parent="VBoxContainer/GridContainer"]
+[node name="LibraryNameLineEdit" type="LineEdit" parent="MarginContainer/VBoxContainer/GridContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Label2" type="Label" parent="VBoxContainer/GridContainer"]
+[node name="LibraryPathLabel" type="Label" parent="MarginContainer/VBoxContainer/GridContainer"]
 layout_mode = 2
 text = "Library path:"
 
-[node name="HBoxContainerPath" type="HBoxContainer" parent="VBoxContainer/GridContainer"]
+[node name="HBoxContainerPath" type="HBoxContainer" parent="MarginContainer/VBoxContainer/GridContainer"]
 layout_mode = 2
 size_flags_vertical = 0
 
-[node name="LineEdit2" type="LineEdit" parent="VBoxContainer/GridContainer/HBoxContainerPath"]
+[node name="LibraryPathLineEdit" type="LineEdit" parent="MarginContainer/VBoxContainer/GridContainer/HBoxContainerPath"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 emoji_menu_enabled = false
 
-[node name="FilePickerButton" parent="VBoxContainer/GridContainer/HBoxContainerPath" instance=ExtResource("2")]
+[node name="FilePickerButton" parent="MarginContainer/VBoxContainer/GridContainer/HBoxContainerPath" instance=ExtResource("2")]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
 size_flags_horizontal = 8
@@ -59,27 +65,28 @@ text = ""
 icon = SubResource("ImageTexture_8pecb")
 icon_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 
-[node name="OK" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="OK" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(60, 0)
 layout_mode = 2
 disabled = true
 text = "OK"
 
-[node name="Cancel" type="Button" parent="VBoxContainer/HBoxContainer"]
+[node name="Cancel" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(60, 0)
 layout_mode = 2
 text = "Cancel"
 
 [connection signal="close_requested" from="." to="." method="_on_close_requested"]
-[connection signal="minimum_size_changed" from="VBoxContainer" to="." method="_on_VBoxContainer_minimum_size_changed"]
-[connection signal="text_changed" from="VBoxContainer/GridContainer/LineEdit" to="." method="_on_line_edit_text_changed"]
-[connection signal="text_submitted" from="VBoxContainer/GridContainer/LineEdit" to="." method="_on_LineEdit_text_entered"]
-[connection signal="text_changed" from="VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2" to="." method="_on_line_edit_2_text_changed"]
-[connection signal="file_selected" from="VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton" to="." method="_on_FilePickerButton_file_selected"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/OK" to="." method="_on_OK_pressed"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/Cancel" to="." method="_on_Cancel_pressed"]
+[connection signal="minimum_size_changed" from="MarginContainer/VBoxContainer" to="." method="_on_VBoxContainer_minimum_size_changed"]
+[connection signal="text_changed" from="MarginContainer/VBoxContainer/GridContainer/LibraryNameLineEdit" to="." method="_on_line_edit_text_changed"]
+[connection signal="text_submitted" from="MarginContainer/VBoxContainer/GridContainer/LibraryNameLineEdit" to="." method="_on_LineEdit_text_entered"]
+[connection signal="text_changed" from="MarginContainer/VBoxContainer/GridContainer/HBoxContainerPath/LibraryPathLineEdit" to="." method="_on_line_edit_2_text_changed"]
+[connection signal="file_selected" from="MarginContainer/VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton" to="." method="_on_FilePickerButton_file_selected"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/OK" to="." method="_on_OK_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/Cancel" to="." method="_on_Cancel_pressed"]

--- a/material_maker/panels/library/create_lib_dialog.tscn
+++ b/material_maker/panels/library/create_lib_dialog.tscn
@@ -1,91 +1,81 @@
-[gd_scene load_steps=3 format=3 uid="uid://c0ir88hj07hh5"]
+[gd_scene load_steps=4 format=3 uid="uid://c0ir88hj07hh5"]
 
-[ext_resource type="Script" path="res://material_maker/panels/library/create_lib_dialog.gd" id="1"]
+[ext_resource type="Script" uid="uid://4b20sg0x1nvu" path="res://material_maker/panels/library/create_lib_dialog.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://cfyio0a1b27t0" path="res://material_maker/widgets/file_picker_button/file_picker_button.tscn" id="2"]
 
+[sub_resource type="ImageTexture" id="ImageTexture_8pecb"]
+
 [node name="CreateLibDialog" type="Window"]
-offset_right = 321.0
-offset_bottom = 76.0
+size = Vector2i(600, 100)
 exclusive = true
-window_title = "New library"
 script = ExtResource("1")
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 2.0
-offset_top = 2.0
-offset_right = -2.0
-offset_bottom = -2.0
+offset_left = 5.0
+offset_top = 5.0
+offset_right = -9.0
+offset_bottom = 8.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_constants/separation = 5
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer"]
-offset_right = 317.0
-offset_bottom = 48.0
+layout_mode = 2
 columns = 2
 
 [node name="Label1" type="Label" parent="VBoxContainer/GridContainer"]
-offset_top = 5.0
-offset_right = 87.0
-offset_bottom = 19.0
+layout_mode = 2
 text = "Library name:"
 
 [node name="LineEdit" type="LineEdit" parent="VBoxContainer/GridContainer"]
-offset_left = 91.0
-offset_right = 317.0
-offset_bottom = 24.0
 custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
 size_flags_horizontal = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label2" type="Label" parent="VBoxContainer/GridContainer"]
-offset_top = 31.0
-offset_right = 87.0
-offset_bottom = 45.0
-text = "Library file:"
+layout_mode = 2
+text = "Library path:"
 
-[node name="FilePickerButton" parent="VBoxContainer/GridContainer" instance=ExtResource("2")]
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_left = 91.0
-offset_top = 28.0
-offset_right = 317.0
-offset_bottom = 48.0
-text = "Click to enter a path"
+[node name="HBoxContainerPath" type="HBoxContainer" parent="VBoxContainer/GridContainer"]
+layout_mode = 2
+size_flags_vertical = 0
+
+[node name="LineEdit2" type="LineEdit" parent="VBoxContainer/GridContainer/HBoxContainerPath"]
+layout_mode = 2
+size_flags_horizontal = 3
+emoji_menu_enabled = false
+
+[node name="FilePickerButton" parent="VBoxContainer/GridContainer/HBoxContainerPath" instance=ExtResource("2")]
+custom_minimum_size = Vector2(25, 25)
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 4
+text = ""
+icon = SubResource("ImageTexture_8pecb")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
-offset_left = 96.0
-offset_top = 53.0
-offset_right = 220.0
-offset_bottom = 73.0
+layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 
 [node name="OK" type="Button" parent="VBoxContainer/HBoxContainer"]
-offset_right = 60.0
-offset_bottom = 20.0
 custom_minimum_size = Vector2(60, 0)
+layout_mode = 2
 disabled = true
 text = "OK"
 
 [node name="Cancel" type="Button" parent="VBoxContainer/HBoxContainer"]
-offset_left = 64.0
-offset_right = 124.0
-offset_bottom = 20.0
 custom_minimum_size = Vector2(60, 0)
+layout_mode = 2
 text = "Cancel"
 
-[connection signal="popup_hide" from="." to="." method="_on_Cancel_pressed"]
 [connection signal="minimum_size_changed" from="VBoxContainer" to="." method="_on_VBoxContainer_minimum_size_changed"]
+[connection signal="text_changed" from="VBoxContainer/GridContainer/LineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="text_submitted" from="VBoxContainer/GridContainer/LineEdit" to="." method="_on_LineEdit_text_entered"]
-[connection signal="file_selected" from="VBoxContainer/GridContainer/FilePickerButton" to="." method="_on_FilePickerButton_file_selected"]
+[connection signal="text_changed" from="VBoxContainer/GridContainer/HBoxContainerPath/LineEdit2" to="." method="_on_line_edit_2_text_changed"]
+[connection signal="file_selected" from="VBoxContainer/GridContainer/HBoxContainerPath/FilePickerButton" to="." method="_on_FilePickerButton_file_selected"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/OK" to="." method="_on_OK_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/Cancel" to="." method="_on_Cancel_pressed"]

--- a/material_maker/panels/library/create_lib_dialog.tscn
+++ b/material_maker/panels/library/create_lib_dialog.tscn
@@ -6,6 +6,7 @@
 [sub_resource type="ImageTexture" id="ImageTexture_8pecb"]
 
 [node name="CreateLibDialog" type="Window"]
+title = "Create Library"
 position = Vector2i(0, 36)
 size = Vector2i(600, 100)
 exclusive = true

--- a/material_maker/panels/library/library.gd
+++ b/material_maker/panels/library/library.gd
@@ -283,7 +283,7 @@ func _on_Libraries_id_pressed(id : int) -> void:
 			add_child(dialog)
 			var status = await dialog.enter_info()
 			if status.ok:
-				library_manager.create_library(status.path, status.name)
+				library_manager.create_library(status.path + "/" + status.name + ".json", status.name)
 		MENU_LOAD_LIBRARY:
 			if OS.get_name() == "HTML5":
 				pass

--- a/material_maker/panels/library/library.gd
+++ b/material_maker/panels/library/library.gd
@@ -283,7 +283,7 @@ func _on_Libraries_id_pressed(id : int) -> void:
 			add_child(dialog)
 			var status = await dialog.enter_info()
 			if status.ok:
-				library_manager.create_library(status.path + "/" + status.name + ".json", status.name)
+				library_manager.create_library(status.path, status.name)
 		MENU_LOAD_LIBRARY:
 			if OS.get_name() == "HTML5":
 				pass

--- a/material_maker/panels/library/library.tscn
+++ b/material_maker/panels/library/library.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://drbpisn5f3h8y"]
 
-[ext_resource type="Script" path="res://material_maker/panels/library/library_tree.gd" id="1"]
-[ext_resource type="Script" path="res://material_maker/panels/library/library.gd" id="1_748nq"]
+[ext_resource type="Script" uid="uid://byotadn432paf" path="res://material_maker/panels/library/library_tree.gd" id="1"]
+[ext_resource type="Script" uid="uid://cg0s65b0doku6" path="res://material_maker/panels/library/library.gd" id="1_748nq"]
 [ext_resource type="Texture2D" uid="uid://c0j4px4n72di5" path="res://material_maker/icons/icons.tres" id="3"]
 
 [sub_resource type="AtlasTexture" id="1"]
@@ -75,6 +75,7 @@ clip_text = true
 unique_name_in_owner = true
 item_count = 5
 item_0/text = "Rename item"
+item_0/id = 0
 item_1/text = "Update thumbnail"
 item_1/id = 1
 item_2/text = "Remove item"

--- a/material_maker/tools/library_manager/library_manager.gd
+++ b/material_maker/tools/library_manager/library_manager.gd
@@ -130,7 +130,8 @@ func get_items(filter : String, sorted := false) -> Array:
 func save_library_list() -> void:
 	var library_list = []
 	for i in range(2, get_child_count()):
-		library_list.push_back(get_child(i).library_path)
+		var lib_path: String = get_child(i).library_path
+		library_list.push_back(lib_path)
 	mm_globals.config.set_value(config_section, "libraries", library_list)
 
 func has_library(path : String) -> bool:
@@ -145,6 +146,7 @@ func create_library(path : String, library_name : String) -> void:
 	var library = LIBRARY.new()
 	library.create_library(path, library_name)
 	add_child(library)
+	library.save_library()
 	save_library_list()
 
 func load_library(path : String, data : String = "") -> void:

--- a/material_maker/widgets/file_picker_button/file_picker_button.gd
+++ b/material_maker/widgets/file_picker_button/file_picker_button.gd
@@ -16,7 +16,6 @@ func set_mode(m):
 
 func set_path(p : String) -> void:
 	path = p
-	text = path.get_file()
 
 func add_filter(f : String) -> void:
 	filters.append(f)

--- a/material_maker/widgets/file_picker_button/file_picker_button.gd
+++ b/material_maker/widgets/file_picker_button/file_picker_button.gd
@@ -25,7 +25,7 @@ func _on_Control_pressed() -> void:
 	var dialog = preload("res://material_maker/windows/file_dialog/file_dialog.tscn").instantiate()
 	dialog.min_size = Vector2i(500, 500)
 	dialog.access = FileDialog.ACCESS_FILESYSTEM
-	dialog.mode = mode
+	dialog.file_mode = mode
 	dialog.current_dir = path.get_base_dir()
 	for f in filters:
 		dialog.add_filter(f)


### PR DESCRIPTION
This PR attempts to fix all bugs outlined on [Issue 727](https://github.com/RodZill4/material-maker/issues/727).

## Changes
An editable line was added to make it easier to manually add a path or change the filename
When only a directory is chosen for the path, a file name will now be automatically created based on the chosen library name
"Ok" button is now disabled if library name is empty
The file dialog will now correctly ask for a path instead of an existing file
Library creation window layout and size was slightly modified to accomodate changes

X button will now correctly close the window
Added window title "Create Library"


![image](https://github.com/user-attachments/assets/c04f8681-1000-4ed1-92d9-bfb5a49a79a9)
![image](https://github.com/user-attachments/assets/695ff639-5287-4e32-839b-d8ed8995cd31)
