### PR TITLE
Reclassify misidentified(GAP) .gd files in the repository as GDScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gd linguist-language=GDScript


### PR DESCRIPTION
One of the .gd files is being misreported as GAP in the repository instead of GDScript:

<img width="310" alt="image" src="https://github.com/user-attachments/assets/7daba957-8fb4-4d9e-be61-5e33e8278874" />

This adds an override for linguist which will fix this
Reference: https://github.com/github-linguist/linguist/blob/main/docs/overrides.md