### PR TITLE
Force image to RGBA8 to preserve alpha on PNG export - [Fix: #756] 

### DIFF
--- a/addons/material_maker/engine/pipeline/texture.gd
+++ b/addons/material_maker/engine/pipeline/texture.gd
@@ -120,6 +120,7 @@ func save_to_file(file_name : String):
 		var export_image : Image = image
 		match file_name.get_extension():
 			"png":
+				export_image.convert(Image.FORMAT_RGBA8) # force RGBA8 to preserve alpha
 				export_image.save_png(file_name)
 			"jpg":
 				export_image.save_jpg(file_name, 1.0)


### PR DESCRIPTION
This fixes #756.

The reasons behind the 8bit narrowing are explained in the issue. After checking the codebase a bit more, I found this place to be the most reasonable to include this forced conversion. Let me know if you have any thoughts!