### PR TITLE
Normalize bevel range for japanese glyphs node

### DIFF
--- a/addons/material_maker/nodes/japanese_glyphs.mmg
+++ b/addons/material_maker/nodes/japanese_glyphs.mmg
@@ -872,7 +872,7 @@
 		"name": "Japanese Glyphs",
 		"outputs": [
 			{
-				"f": "1.0 - c_$sys($uv-0.5, int($char), $scale, int($gs), $bevel*$bevel_map($uv), $rad)",
+				"f": "1.0 - c_$sys($uv-0.5, int($char), $scale, int($gs), $rad*$bevel*$bevel_map($uv), $rad)",
 				"shortdesc": "Output",
 				"type": "f"
 			}

--- a/addons/material_maker/nodes/japanese_glyphs2.mmg
+++ b/addons/material_maker/nodes/japanese_glyphs2.mmg
@@ -872,7 +872,7 @@
 		"name": "Japanese Glyphs",
 		"outputs": [
 			{
-				"f": "1.0 - c_$sys($uv-0.5, int($char), $scale, int($gs), $bevel*$bevel_map($uv), $rad)",
+				"f": "1.0 - c_$sys($uv-0.5, int($char), $scale, int($gs), $rad*$bevel*$bevel_map($uv), $rad)",
 				"shortdesc": "Output",
 				"type": "f"
 			}

--- a/material_maker/library/base.json
+++ b/material_maker/library/base.json
@@ -125,7 +125,7 @@
 		{
 			"display_name": "Japanese Glyphs",
 			"icon_data": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAAXNSR0IArs4c6QAABSBJREFUaIHtWUtIOlscPpr9iR46PRCrjVEhKUlWUEQgPaBF702vXS1606JN70UFRUGLxKh2IQYREUEQBUFBReXCFj2kDAyLCopq0cNKnbv43Tt4NXVmPBWX67c6zvn9vu/7nTlzzpkRIT/88MMPP/7PCMDINTQ0FBgYeH5+jpHz59De3k6SJEmSP6zLxUUkFotxUTECtgJiY2NxUTECtgKio6NxUTECtgJEIpHvJAqFgmkKz3dVgFAoRAjd3d3RCSYIQiqVyuVyhUKRnp6emppKdRkMBqlUSl+XVgECgaC6uvr19fXt7c1isXx8fFitVpvNZrfbORwOl8vl8XghISEIofv7+/r6ej6fLxAIwsPDo6KihEKhSCSKjY3l8/l0tN7e3ui7Rwhx6AR99+J4dnam1+u3trY2NzdPTk4Y5dK6A0ajMTExkZW3v/H4+Hh1dXVxcWEymYxG4+npqcFguLq68oWTJbhcblBQUGhoqEAgIAiCIAg+nx8cHAy72Ozs7A/7YfwQ2+12i8Xirvf5+dk3P4yBbRkFvL6+4iX0CswFvL+/4yX0CswFfH5+eg6QSqUkSS4uLuJSxFyAzWbzHDA6OooQKi8vx6WIuQAOx8vGUlhYiBAymUy4FLEdJQABAf96QwoJCVEoFBKJRCwW//nzh3rEp6am8OpiAOwDo6OjLS0tOzs7JD0sLy8rlcrf9o4Q+qcA1hgYGPgd30KhcHd319WQwWAYGxsrLS11fNGBLq1Wm5ubOzw8bDKZnLJycnJ+1P3i4qKTg6WlJTiWuqK2thZiZDKZ4/Xq6mqbzUYx9PX1/YT1zMxMR9+rq6vQ2N7edpdyeXkJMV/21tfXU2wdHR3fZhwhhFBbWxsldnR0BEMOPz18U4EAjUbjLkAkElG0ycnJ32IdIdTd3U3JNDQ0UNdvbm5IknR3zhscHISUmJgYD+RisZgix+wbUFNTQwlIJBLHrr29PQ/C9G319/dDZFlZGR7TFAiCoHy4foPQarXuLObn50NXc3MzHSEINpvNGEw74uHhAai/3Hp6enrcFXB9fc1oVngYC/aoq6sD0snJyS8DiouLIcBpGU1KSoLr09PTNLUyMjIghdHnCS/wOoljYmIgwGkzOj8/ZzqckZGRkJKdne01mNZptKSkBBqNjY3uYq6vr6HhqJqVlRUfH48Q0mq1dIQAVqsVGjweprMmzVGEmI2NDacrTGdzXFwcZKWkpLCx687Z/Py85zCnvbavrw9+9vf3M5IrKiqCxLCwMJaOHVFQUAB0Xj9cTkxMUAWEh4ezG36EkEqlwrkKaTQamnRKpZIq9fPzE9pyuZyp4vPzM84CYPmnHizPAOG1tTVojI+PM5XjcDie12vGALqtrS06wRaLhZo57P4sm5+fh3SCIFikfwGgW1lZoRNMPQbsJkBCQgLkHh8fs0j/GsB4eHjoNXJ9fZ1yr1KpWGuRJBkREcEi/Wvo9XqvI5qenk66gKkQldjb2+uDXxdUVVUBr1qtdu2VSCQHBweU9vHxcUVFBbRbW1tpSuTl5VEMCwsLON0D7HY7JTA3NzcyMjI9Pb2/v+805F1dXRBP/yZERUXpdDoq3sP7mq9wnSGOWFpacgymboIHwsrKSrPZ7EhSW1v7Xe4BHR0dLy8vjpJGo7Gzs5M+Q35+vlqtfnp6cqqf5hL3a7i9vXV362ZmZrhczN9n8cPVt0ajSUtLw0JO619KH9HU1CSTyXQ63ebmJv43XT/88MMPP/z4L+MvYQytXq2xg9YAAAAASUVORK5CYII=",
-			"name": "japanese_glyphs",
+			"name": "japanese_glyphs2",
 			"parameters": {
 				"bevel": 0.01,
 				"char": 1,
@@ -135,7 +135,7 @@
 				"sys": 0
 			},
 			"tree_item": "Simple/Japanese Glyphs",
-			"type": "japanese_glyphs"
+			"type": "japanese_glyphs2"
 		},
 		{
 			"display_name": "Gradient",


### PR DESCRIPTION
Normalize bevel range for Japanese Glyphs node so it's actually a factor (i.e. 0.0-1.0) based on the radius

Before:

![before](https://github.com/user-attachments/assets/9d51ba4d-779c-487c-895b-c7ba1fa427af)

After:

![after](https://github.com/user-attachments/assets/5b53baa9-34d9-40a2-88d3-a8a36a5f1ef5)