### PR TITLE
Add feedback for saving files

### DIFF
--- a/addons/material_maker/engine/nodes/gen_material.gd
+++ b/addons/material_maker/engine/nodes/gen_material.gd
@@ -574,7 +574,7 @@ func process_uids(template : String) -> String:
 		template = template.replace(result.strings[0], uid)
 	return template
 
-func create_file_from_template(template : String, file_name : String, export_context : Dictionary) -> bool:
+func create_file_from_template(template : String, file_name : String, export_context : Dictionary) -> Error:
 	template = get_template_text(template)
 	var processed_template : String = process_uids(process_buffers(process_conditionals(process_template(template, export_context))))
 	var custom_script = ""
@@ -586,11 +586,11 @@ func create_file_from_template(template : String, file_name : String, export_con
 	else:
 		DirAccess.remove_absolute(file_name)
 		var out_file = FileAccess.open(file_name, FileAccess.WRITE)
-		if out_file == null:
-			print("Cannot write file '"+file_name+"' ("+str(out_file.get_error())+")")
-			return false
+		if FileAccess.get_open_error() != OK:
+			print("Cannot write file '"+file_name+"' ("+str(FileAccess.get_open_error())+")")
+			return FileAccess.get_open_error()
 		out_file.store_string(processed_template)
-	return true
+	return OK
 
 func get_connections_and_parameters_context() -> Dictionary:
 	var context : Dictionary = {}
@@ -671,8 +671,10 @@ func export_material(prefix : String, profile : String, size : int = 0) -> void:
 				total_files += 1
 			"buffers", "buffer_templates":
 				total_files += preview_texture_dependencies.size()
-	var saved_files = 0
+	var processed_files = 0
+	var error_files = 0
 	for f in exported_files:
+		var e: Error = OK
 		match f.type:
 			"texture":
 				# Wait until the render queue is empty
@@ -696,22 +698,28 @@ func export_material(prefix : String, profile : String, size : int = 0) -> void:
 					output_index = EXPORT_OUTPUT_DEF_INDEX
 				else:
 					# Error! Just ignore it
-					saved_files += 1
-					progress_dialog.set_progress(float(saved_files)/float(total_files))
+					e = FAILED
+					processed_files += 1
+					error_files += 1
+					progress_dialog.set_progress(float(processed_files)/float(total_files))
 					continue
 				var result : MMTexture = await render_output_to_texture(output_index, Vector2i(size, size))
-				await result.save_to_file(file_name)
-				saved_files += 1
-				progress_dialog.set_progress(float(saved_files)/float(total_files))
+				e = await result.save_to_file(file_name)
+				if e != OK:
+					error_files += 1
+				processed_files += 1
+				progress_dialog.set_progress(float(processed_files)/float(total_files))
 			"template":
 				var file_export_context = export_context.duplicate()
 				if f.has("file_params"):
 					for p in f.file_params.keys():
 						file_export_context["$(file_param:"+p+")"] = f.file_params[p]
 				var file_name = subst_string(f.file_name, export_context)
-				create_file_from_template(f.template, file_name, file_export_context)
-				saved_files += 1
-				progress_dialog.set_progress(float(saved_files)/float(total_files))
+				e = create_file_from_template(f.template, file_name, file_export_context)
+				if e != OK:
+					error_files += 1
+				processed_files += 1
+				progress_dialog.set_progress(float(processed_files)/float(total_files))
 			"buffers":
 				var index : int = 1
 				if mm_deps.get_render_queue_size() > 0:
@@ -719,10 +727,12 @@ func export_material(prefix : String, profile : String, size : int = 0) -> void:
 				for t in preview_texture_dependencies.keys():
 					var file_name = subst_string(f.file_name, export_context)
 					file_name = file_name.replace("$(buffer_index)", str(index))
-					preview_texture_dependencies[t].get_image().save_png(file_name)
+					e = preview_texture_dependencies[t].get_image().save_png(file_name)
+					if e != OK:
+						error_files += 1
 					index += 1
-					saved_files += 1
-					progress_dialog.set_progress(float(saved_files)/float(total_files))
+					processed_files += 1
+					progress_dialog.set_progress(float(processed_files)/float(total_files))
 			"buffer_templates":
 				var index : int = 1
 				for t in preview_texture_dependencies.keys():
@@ -733,12 +743,23 @@ func export_material(prefix : String, profile : String, size : int = 0) -> void:
 							file_export_context["$(file_param:"+p+")"] = f.file_params[p]
 					var file_name = subst_string(f.file_name, export_context)
 					file_name = file_name.replace("$(buffer_index)", str(index))
-					create_file_from_template(f.template, file_name, file_export_context)
+					e = create_file_from_template(f.template, file_name, file_export_context)
+					if e != OK:
+						error_files += 1
 					index += 1
-					saved_files += 1
-					progress_dialog.set_progress(float(saved_files)/float(total_files))
+					processed_files += 1
+					progress_dialog.set_progress(float(processed_files)/float(total_files))
 	if progress_dialog != null:
 		progress_dialog.queue_free()
+	if error_files == 0:
+		mm_globals.set_tip_text("Files succesfully exported as \"%s\"" % prefix, 5, 1)
+		return
+	if error_files >= total_files:
+		mm_globals.main_window.accept_dialog("Could not export files to \"%s\"" % prefix.get_base_dir(), false, true)
+		return
+	if error_files < total_files:
+		mm_globals.set_tip_text("%s errors encountered when exporting files" % error_files, 5, 1)
+		return
 
 func _serialize_data(data: Dictionary) -> Dictionary:
 	data = super._serialize_data(data)

--- a/addons/material_maker/engine/nodes/gen_material.gd
+++ b/addons/material_maker/engine/nodes/gen_material.gd
@@ -758,7 +758,7 @@ func export_material(prefix : String, profile : String, size : int = 0) -> void:
 		mm_globals.main_window.accept_dialog("Could not export files to \"%s\"" % prefix.get_base_dir(), false, true)
 		return
 	if error_files < total_files:
-		mm_globals.set_tip_text("%s errors encountered when exporting files" % error_files, 5, 1)
+		mm_globals.set_tip_text("%d errors encountered when exporting files" % error_files, 5, 1)
 		return
 
 func _serialize_data(data: Dictionary) -> Dictionary:

--- a/addons/material_maker/engine/pipeline/texture.gd
+++ b/addons/material_maker/engine/pipeline/texture.gd
@@ -113,7 +113,7 @@ func get_width() -> int:
 func get_height() -> int:
 	return texture_size.y
 
-func save_to_file(file_name : String):
+func save_to_file(file_name : String) -> Error:
 	var texture : ImageTexture = await get_texture()
 	var image : Image = texture.get_image()
 	if image != null:
@@ -121,14 +121,15 @@ func save_to_file(file_name : String):
 		match file_name.get_extension():
 			"png":
 				export_image.convert(Image.FORMAT_RGBA8) # force RGBA8 to preserve alpha
-				export_image.save_png(file_name)
+				return export_image.save_png(file_name)
 			"jpg":
-				export_image.save_jpg(file_name, 1.0)
+				return export_image.save_jpg(file_name, 1.0)
 			"webp":
-				export_image.save_webp(file_name)
+				return export_image.save_webp(file_name)
 			"exr":
 				match image.get_format():
 					Image.FORMAT_RF,Image.FORMAT_RH:
-						export_image.save_exr(file_name, true)
+						return export_image.save_exr(file_name, true)
 					_:
-						export_image.save_exr(file_name, false)
+						return export_image.save_exr(file_name, false)
+	return ERR_DOES_NOT_EXIST

--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -145,8 +145,8 @@ func parse_paste_data(data : String):
 static func popup_menu(menu : PopupMenu, parent : Control):
 	menu.popup(Rect2(parent.get_local_mouse_position()+parent.get_screen_position(), Vector2(0, 0)))
 
-func set_tip_text(tip : String, timeout : float = 0.0):
-	main_window.set_tip_text(tip, timeout)
+func set_tip_text(tip : String, timeout : float = 0.0, priority: int = 0):
+	main_window.set_tip_text(tip, timeout, priority)
 
 static func do_propagate_shortcuts(control : Control, event : InputEvent):
 	for child in control.get_children():

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -1202,19 +1202,24 @@ func on_files_dropped(files : PackedStringArray) -> void:
 						mm_loader.save_export_target(data.material, data.name, data)
 						mm_loader.load_external_export_targets()
 
-func set_tip_text(tip : String, timeout : float = 0.0):
+var tip_priority: int = 0
+
+func set_tip_text(tip : String, timeout : float = 0.0, priority: int = 0):
 	tip = tip.replace("#LMB", "[img]res://material_maker/icons/lmb.tres[/img]")
 	tip = tip.replace("#RMB", "[img]res://material_maker/icons/rmb.tres[/img]")
 	tip = tip.replace("#MMB", "[img]res://material_maker/icons/mmb.tres[/img]")
-	$VBoxContainer/StatusBar/HBox/Tip.text = tip
-	var tip_timer : Timer = $VBoxContainer/StatusBar/HBox/Tip/Timer
-	tip_timer.stop()
-	if timeout > 0.0:
-		tip_timer.one_shot = true
-		tip_timer.wait_time = timeout
-		tip_timer.start()
+	if priority >= tip_priority:
+		tip_priority = priority
+		$VBoxContainer/StatusBar/HBox/Tip.text = tip
+		var tip_timer : Timer = $VBoxContainer/StatusBar/HBox/Tip/Timer
+		tip_timer.stop()
+		if timeout > 0.0:
+			tip_timer.one_shot = true
+			tip_timer.wait_time = timeout
+			tip_timer.start()
 
 func _on_Tip_Timer_timeout():
+	tip_priority = 0
 	$VBoxContainer/StatusBar/HBox/Tip.text = ""
 
 # Add dialog

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -212,7 +212,7 @@ func _ready() -> void:
 				file_name = dir.get_next()
 			if ! files.is_empty():
 				var dialog_text : String = "Oops, it seems Material Maker crashed and rescued unsaved work\nLoad %d unsaved projects?" % files.size()
-				var result = await accept_dialog(dialog_text, true, [ { label="Delete them!", action="delete" } ])
+				var result = await accept_dialog(dialog_text, true, false, [ { label="Delete them!", action="delete" } ])
 				match result:
 					"ok":
 						for f in files:
@@ -1232,9 +1232,12 @@ func add_dialog(dialog : Window):
 
 # Accept dialog
 
-func accept_dialog(dialog_text : String, cancel_button : bool = false, extra_buttons : Array[Dictionary] = []):
+func accept_dialog(dialog_text : String, cancel_button : bool = false, autowrap : bool = false, extra_buttons : Array[Dictionary] = []):
 	var dialog = preload("res://material_maker/windows/accept_dialog/accept_dialog.tscn").instantiate()
 	dialog.dialog_text = dialog_text
+	if autowrap:
+		dialog.dialog_autowrap = autowrap
+		dialog.min_size.x = 500
 	if cancel_button:
 		dialog.add_cancel_button("Cancel")
 	for b in extra_buttons:

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -627,8 +627,8 @@ func save_file(filename:String) -> bool:
 		else:
 			e = FileAccess.get_open_error()
 	if e != OK:
-		var message = "Could not save in %s \n\nERROR: %s" % [filename, error_string(e)]
-		mm_globals.main_window.accept_dialog(message, false)
+		var message = "Could not save in \"%s\" \n\nERROR: %s" % [filename, error_string(e)]
+		mm_globals.main_window.accept_dialog(message, false, true)
 		return false
 	set_save_path(filename)
 	set_need_save(false)

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -580,7 +580,7 @@ func load_from_recovery(filename) -> bool:
 
 func save() -> bool:
 	var status = false
-	if save_path != null:
+	if save_path != "":
 		status = save_file(save_path)
 	else:
 		status = await save_as()
@@ -616,14 +616,20 @@ func save_file(filename:String) -> bool:
 	mm_loader.current_project_path = filename.get_base_dir()
 	var data = top_generator.serialize()
 	mm_loader.current_project_path = ""
+	var e: Error
 	if OS.get_name() == "HTML5":
 		JavaScriptBridge.download_buffer(JSON.stringify(data, "\t", true).to_ascii_buffer(), filename)
 	else:
 		var file : FileAccess = FileAccess.open(filename, FileAccess.WRITE)
 		if file != null:
 			file.store_string(JSON.stringify(data, "\t", true))
+			e = file.get_error()
 		else:
-			return false
+			e = FileAccess.get_open_error()
+	if e != OK:
+		var message = "Could not save in %s \n\nERROR: %s" % [filename, error_string(e)]
+		mm_globals.main_window.accept_dialog(message, false)
+		return false
 	set_save_path(filename)
 	set_need_save(false)
 	remove_crash_recovery_file()

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -632,7 +632,7 @@ func save_file(filename:String) -> bool:
 		return false
 	set_save_path(filename)
 	set_need_save(false)
-	mm_globals.set_tip_text("Project saved on \"%s\"" % filename, 5)
+	mm_globals.set_tip_text("Project saved on \"%s\"" % filename, 5, 1)
 	remove_crash_recovery_file()
 	return true
 

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -632,6 +632,7 @@ func save_file(filename:String) -> bool:
 		return false
 	set_save_path(filename)
 	set_need_save(false)
+	mm_globals.set_tip_text("Project saved on \"%s\"" % filename, 5)
 	remove_crash_recovery_file()
 	return true
 

--- a/material_maker/tools/library_manager/library.gd
+++ b/material_maker/tools/library_manager/library.gd
@@ -148,12 +148,16 @@ func get_sections() -> Array:
 			sections.push_back(section_name)
 	return Array(sections)
 
-func save_library() -> void:
+func save_library() -> Error:
+	var e: Error
 	DirAccess.make_dir_recursive_absolute(library_path.get_base_dir())
 	var file : FileAccess = FileAccess.open(library_path, FileAccess.WRITE)
-	if file != null:
+	e = FileAccess.get_open_error()
+	if file != null && e == OK:
 		file.store_string(JSON.stringify({name=library_name, lib=library_items}, "\t", true))
+		e = file.get_error()
 		file.close()
+	return e
 
 func add_item(item_name : String, image : Image, data : Dictionary) -> void:
 	if read_only:

--- a/material_maker/tools/library_manager/library_manager.gd
+++ b/material_maker/tools/library_manager/library_manager.gd
@@ -141,13 +141,19 @@ func has_library(path : String) -> bool:
 	return false
 
 func create_library(path : String, library_name : String) -> void:
+	var e: Error
 	if has_library(path):
 		return
 	var library = LIBRARY.new()
 	library.create_library(path, library_name)
+	e = library.save_library()
+	if e != OK:
+		var message = "Could not create library \"%s\" in \"%s\" \n\nERROR: %s" % [library_name, path, error_string(e)]
+		mm_globals.main_window.accept_dialog(message, false, true)
+		return
 	add_child(library)
-	library.save_library()
 	save_library_list()
+	mm_globals.set_tip_text("Library \"%s\" created at \"%s\"" % [library_name, path], 5, 1)
 
 func load_library(path : String, data : String = "") -> void:
 	if has_library(path):


### PR DESCRIPTION
## Changes
- Attempting to "Save" before a path is set will now correctly be treated the same as "Save as..."
- A few functions were silightly refactored to allow for better error tracking
- When not able to save a project file, create a library, or export a material, a popup window will now be shown with the error given by the godot engine
Examples:
Attempting to save to a directory with no write permission:
![image](https://github.com/user-attachments/assets/3cb989c2-4446-44d0-8dad-d005d4710a1a)
_(Godot will sadly interpret an error as simply "can't open file" without further information on most cases)_
Attempting to save to a full drive:
![Screenshot 2025-03-08 223151](https://github.com/user-attachments/assets/5279b705-db2c-41ac-b07f-7c0ad2010e1b)
Exporting error:
![Screenshot 2025-03-10 151451](https://github.com/user-attachments/assets/db532ae8-f4cc-44bf-8ce3-d5961d13bc58)


- Succesfully saving a file, creating a library or exporting a material will now prompt a message on the status bar
- Additionally, a priority system was added to the status bar, to allow important messages not to get immediately overrriden.
![image](https://github.com/user-attachments/assets/7d9d2e46-3bb2-46fa-94bf-54520e13276f)
![Screenshot 2025-03-10 141814](https://github.com/user-attachments/assets/369cf494-bb97-41c4-af35-a7a0f3368a3e)

