### PR TITLE
Null check for add node popup

### DIFF
--- a/material_maker/windows/add_node_popup/add_node_popup.gd
+++ b/material_maker/windows/add_node_popup/add_node_popup.gd
@@ -224,5 +224,6 @@ func get_list_drag_data(m_position):
 
 func _on_list_item_activated(index: int) -> void:
 	var data = %List.get_item_metadata(index)
-	add_node(data.item)
-	todo_renamed_hide()
+	if not data == null:
+		add_node(data.item)
+		todo_renamed_hide()


### PR DESCRIPTION
Fixes an issue where adding a non-existent item would cause a crash, this makes it so it would do nothing - same as v1.3