### PR TITLE
Add tonemap exposure/white parameters

### DIFF
--- a/material_maker/panels/preview_3d/environment_menu.gd
+++ b/material_maker/panels/preview_3d/environment_menu.gd
@@ -32,7 +32,10 @@ func _open() -> void:
 	
 	if mm_globals.has_config("ui_3d_preview_tonemap_white"):
 		$VBoxContainer/VBox/White.set_value(mm_globals.get_config("ui_3d_preview_tonemap_white"))
-
+	
+	$VBoxContainer/VBox/White.visible = tonemap_mode > 0 && tonemap_mode <= 3
+	$VBoxContainer/VBox/WhiteLabel.visible = tonemap_mode > 0 && tonemap_mode <= 3
+	
 func update_environment_selector() -> void:
 	var environment_manager = get_node("/root/MainWindow/EnvironmentManager")
 	if not environment_manager:

--- a/material_maker/panels/preview_3d/environment_menu.gd
+++ b/material_maker/panels/preview_3d/environment_menu.gd
@@ -26,7 +26,12 @@ func _open() -> void:
 
 	var tonemap_mode: int = mm_globals.get_config("ui_3d_preview_tonemap")
 	ToneMap.select(tonemap_mode)
-
+	
+	if mm_globals.has_config("ui_3d_preview_tonemap_exposure"):
+		$VBoxContainer/VBox/Exposure.set_value(mm_globals.get_config("ui_3d_preview_tonemap_exposure"))
+	
+	if mm_globals.has_config("ui_3d_preview_tonemap_white"):
+		$VBoxContainer/VBox/White.set_value(mm_globals.get_config("ui_3d_preview_tonemap_white"))
 
 func update_environment_selector() -> void:
 	var environment_manager = get_node("/root/MainWindow/EnvironmentManager")
@@ -62,7 +67,8 @@ func _on_environment_list_item_selected(index: int) -> void:
 
 func _on_tone_map_item_selected(index: int) -> void:
 	preview3D.set_tonemap(index)
-
+	$VBoxContainer/VBox/White.visible = index > 0 && index <= 3
+	$VBoxContainer/VBox/WhiteLabel.visible = index > 0 && index <= 3
 
 func _on_clear_background_toggled(toggled_on: bool) -> void:
 	preview3D.clear_background = toggled_on

--- a/material_maker/panels/preview_3d/preview_3d_panel.gd
+++ b/material_maker/panels/preview_3d/preview_3d_panel.gd
@@ -62,3 +62,15 @@ func on_drop_model_file(file_name : String):
 func _on_resized() -> void:
 	$BG.size = size
 	%MenuBar.size.x = size.x
+
+
+func _on_exposure_value_changed(value: Variant) -> void:
+	var environment = $MaterialPreview/Preview3d/WorldEnvironment.environment
+	environment.tonemap_exposure = value
+	mm_globals.set_config("ui_3d_preview_tonemap_exposure", value)
+
+
+func _on_white_value_changed(value: Variant) -> void:
+	var environment = $MaterialPreview/Preview3d/WorldEnvironment.environment
+	environment.tonemap_white = value
+	mm_globals.set_config("ui_3d_preview_tonemap_white", value)

--- a/material_maker/panels/preview_3d/preview_3d_panel.tscn
+++ b/material_maker/panels/preview_3d/preview_3d_panel.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=7 format=3 uid="uid://cj6b1r8b6jel3"]
+[gd_scene load_steps=12 format=3 uid="uid://cj6b1r8b6jel3"]
 
 [ext_resource type="PackedScene" uid="uid://dpaxvlnn2u1f6" path="res://material_maker/panels/preview_3d/preview_3d.tscn" id="1"]
 [ext_resource type="Script" uid="uid://f81isnxjqrub" path="res://material_maker/panels/preview_3d/preview_3d_panel.gd" id="3"]
+[ext_resource type="Texture2D" uid="uid://bqre7xkdgb655" path="res://material_maker/environments/hdris/moonless_golf_1k.hdr" id="3_j6uuq"]
+[ext_resource type="PackedScene" uid="uid://rflulhsuy3ax" path="res://material_maker/widgets/float_edit/float_edit.tscn" id="4_dlxub"]
 
 [sub_resource type="Shader" id="1"]
 code = "shader_type spatial;
@@ -25,7 +27,21 @@ shader = SubResource("1")
 shader_parameter/aabb_position = Vector3(0, 0, 0)
 shader_parameter/aabb_size = Vector3(0, 0, 0)
 
+[sub_resource type="PanoramaSkyMaterial" id="PanoramaSkyMaterial_40ogr"]
+panorama = ExtResource("3_j6uuq")
+
+[sub_resource type="Sky" id="Sky_wye7d"]
+sky_material = SubResource("PanoramaSkyMaterial_40ogr")
+
+[sub_resource type="Environment" id="Environment_qxxdb"]
+background_mode = 1
+background_color = Color(1, 1, 1, 0)
+sky = SubResource("Sky_wye7d")
+ambient_light_source = 3
+reflected_light_source = 2
+
 [sub_resource type="World3D" id="World3D_3xlky"]
+environment = SubResource("Environment_qxxdb")
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_p1u4i"]
 
@@ -88,6 +104,32 @@ button_group = SubResource("ButtonGroup_p1u4i")
 [node name="Speed_Fast" parent="MainMenu/HBox/ModelMenu/ModelMenuPanel/VBoxContainer/Model/RotationSpeeds" index="3"]
 button_group = SubResource("ButtonGroup_p1u4i")
 
+[node name="ExposureLabel" type="Label" parent="MainMenu/HBox/EnvironmentMenu/EnvironmentMenuPanel/VBoxContainer/VBox" index="4"]
+layout_mode = 2
+theme_type_variation = &"MM_PanelMenuSubPanelLabel"
+text = "Exposure"
+
+[node name="Exposure" parent="MainMenu/HBox/EnvironmentMenu/EnvironmentMenuPanel/VBoxContainer/VBox" index="5" instance=ExtResource("4_dlxub")]
+layout_mode = 2
+value = 1.0
+max_value = 4.0
+step = 0.01
+float_only = true
+
+[node name="WhiteLabel" type="Label" parent="MainMenu/HBox/EnvironmentMenu/EnvironmentMenuPanel/VBoxContainer/VBox" index="6"]
+layout_mode = 2
+theme_type_variation = &"MM_PanelMenuSubPanelLabel"
+text = "White"
+
+[node name="White" parent="MainMenu/HBox/EnvironmentMenu/EnvironmentMenuPanel/VBoxContainer/VBox" index="7" instance=ExtResource("4_dlxub")]
+layout_mode = 2
+value = 1.0
+max_value = 4.0
+step = 0.01
+float_only = true
+
 [connection signal="mouse_entered" from="." to="." method="_on_Preview3D_mouse_entered"]
 [connection signal="resized" from="." to="." method="_on_resized"]
 [connection signal="id_pressed" from="PopupMenu" to="." method="_on_PopupMenu_id_pressed"]
+[connection signal="value_changed" from="MainMenu/HBox/EnvironmentMenu/EnvironmentMenuPanel/VBoxContainer/VBox/Exposure" to="." method="_on_exposure_value_changed"]
+[connection signal="value_changed" from="MainMenu/HBox/EnvironmentMenu/EnvironmentMenuPanel/VBoxContainer/VBox/White" to="." method="_on_white_value_changed"]

--- a/material_maker/panels/preview_3d/preview_3d_panel.tscn
+++ b/material_maker/panels/preview_3d/preview_3d_panel.tscn
@@ -112,7 +112,7 @@ text = "Exposure"
 [node name="Exposure" parent="MainMenu/HBox/EnvironmentMenu/EnvironmentMenuPanel/VBoxContainer/VBox" index="5" instance=ExtResource("4_dlxub")]
 layout_mode = 2
 value = 1.0
-max_value = 4.0
+max_value = 16.0
 step = 0.01
 float_only = true
 
@@ -124,7 +124,7 @@ text = "White"
 [node name="White" parent="MainMenu/HBox/EnvironmentMenu/EnvironmentMenuPanel/VBoxContainer/VBox" index="7" instance=ExtResource("4_dlxub")]
 layout_mode = 2
 value = 1.0
-max_value = 4.0
+max_value = 16.0
 step = 0.01
 float_only = true
 


### PR DESCRIPTION
For now Linear/Reinhard just looks the same with their default values (white) in MM so it might be helpful to have both of these options in the environment menu

https://github.com/user-attachments/assets/9eec7b43-d479-4c30-b005-2392432fa019