### PR TITLE
small fix for droppedbeat's meteor rain in splashscreen

### DIFF
--- a/splash_screen/backgrounds/droppedbeat_meteor_rain.gdshader
+++ b/splash_screen/backgrounds/droppedbeat_meteor_rain.gdshader
@@ -48,7 +48,7 @@ vec2 rotate(vec2 uv, float rotate) {
  	vec2 rv;
 	rv.x = cos(rotate)*uv.x + sin(rotate)*uv.y;
 	rv.y = -sin(rotate)*uv.x + cos(rotate)*uv.y;
-	return rv;	
+	return rv;
 }
 float shape_circle(vec2 uv, float sides, float size, float edge) {
 	uv = 2.0*uv-1.0;
@@ -378,6 +378,8 @@ vec4 supersample_o150412(vec2 uv, float size, int count, float width, float _see
 void fragment() {
 	float _seed_variation_ = variation;
 	vec2 uv = fract(UV);
+	uv *= vec2(1.76744186, 1)*0.5;
+	uv += vec2(0.0,0.65);
 vec4 o150416_0_1_rgba = supersample_o150416((uv), 1024.000000000, int(p_o150416_count), p_o150416_width, _seed_variation_);
 vec4 o150412_0_1_rgba = supersample_o150412(((uv)-vec2(p_o150411_translate_x, p_o150411_translate_y)), 256.000000000, int(p_o150412_count), p_o150412_width, _seed_variation_);
 vec4 o150411_0_1_rgba = o150412_0_1_rgba;


### PR DESCRIPTION
I noticed the shader is slightly stretched, this scales it in the correct aspect ratio so it looks better

before/after

<img width="600" alt="a" src="https://github.com/user-attachments/assets/51f53278-8fe7-4b17-929e-6a1a97325670" />

<img width="600" alt="b" src="https://github.com/user-attachments/assets/df1401d8-abed-463b-97d4-d04139eb3d8f" />
