### PR TITLE
fix message when exiting without saving modified 'unnamed' file

### DIFF
--- a/material_maker/widgets/tabs/tabs.gd
+++ b/material_maker/widgets/tabs/tabs.gd
@@ -67,6 +67,8 @@ func check_save_tab(tab) -> bool:
 			save_path = "[unnamed]"
 		else:
 			save_path = save_path.get_file()
+		if save_path == "":
+			save_path = "file"
 		dialog.dialog_text = "Save "+save_path+" before closing?"
 		#dialog.dialog_autowrap = true
 		dialog.get_ok_button().text = "Save and close"


### PR DESCRIPTION
When MM is closing with a modified empty ( [unnamed] ) file, `save_path` is nothing thus it looks like there's an extra space in the alert dialog:

<img width="395" alt="image" src="https://github.com/user-attachments/assets/8f4ad285-316c-44d0-949a-c35edd205f4d" />

This fixes the issue by changing it to "file":
<img width="392" alt="image" src="https://github.com/user-attachments/assets/920e523f-9c82-487d-8515-7b5f34426655" />
