### PR TITLE
Finer float adjustments with alt

### DIFF
--- a/material_maker/widgets/float_edit/float_edit.gd
+++ b/material_maker/widgets/float_edit/float_edit.gd
@@ -184,6 +184,9 @@ func _gui_input(event: InputEvent) -> void:
 							current_step = 0.1
 				elif event.shift_pressed:
 					delta *= 0.2
+				elif event.alt_pressed:
+					current_step *= 0.01
+					delta *= 0.1
 
 
 				var v: float = start_value + delta / (size.x / abs(max_value - min_value))


### PR DESCRIPTION
This restores the behavior from v1.3, which allows you to adjust values more finely when alt is held down:

**v1.3:**
<img src="https://github.com/user-attachments/assets/0a5db5aa-9415-45bc-88a0-ff5859f9a248" width="500" />

**This PR:**
<img src="https://github.com/user-attachments/assets/49745ff8-edf4-47a4-9103-661c542acb68" width="500" />

