### PR TITLE
Replace default node descriptions from Pixels,Smooth Pixels and Splines

### DIFF
--- a/addons/material_maker/nodes/pixels.mmg
+++ b/addons/material_maker/nodes/pixels.mmg
@@ -35,11 +35,10 @@
 		"global": "",
 		"inputs": [],
 		"instance": "",
-		"longdesc": "Draws a uniform greyscale image",
+		"longdesc": "Draws a tiny image",
 		"name": "Pixels",
 		"outputs": [
 			{
-				"longdesc": "A uniform image of the selected value",
 				"rgba": "$pixels(ivec2(floor(vec2(float($pixels_size.x), float($pixels_size.y))*$uv)))",
 				"shortdesc": "Output",
 				"type": "rgba"
@@ -73,7 +72,9 @@
 				},
 				"label": "",
 				"name": "pixels",
-				"type": "pixels"
+				"type": "pixels",
+				"longdesc": "Pixel data of the image",
+				"shortdesc": "Pixels"
 			}
 		]
 	},

--- a/addons/material_maker/nodes/pixels_smooth.mmg
+++ b/addons/material_maker/nodes/pixels_smooth.mmg
@@ -43,11 +43,10 @@
 		"global": "",
 		"inputs": [],
 		"instance": "",
-		"longdesc": "Draws a uniform greyscale image",
+		"longdesc": "Draws a tiny image with pixel smoothing",
 		"name": "Smooth Pixels",
 		"outputs": [
 			{
-				"longdesc": "A uniform image of the selected value",
 				"rgba": "mix(mix($(name_uv)_color0, $(name_uv)_color1, $(name_uv)_fract.x), mix($(name_uv)_color2, $(name_uv)_color3, $(name_uv)_fract.x), $(name_uv)_fract.y)",
 				"shortdesc": "Output",
 				"type": "rgba"
@@ -81,7 +80,9 @@
 				},
 				"label": "",
 				"name": "pixels",
-				"type": "pixels"
+				"type": "pixels",
+				"shortdesc":"Pixels",
+				"longdesc":"Pixel data of the image"
 			}
 		]
 	},

--- a/addons/material_maker/nodes/splines.mmg
+++ b/addons/material_maker/nodes/splines.mmg
@@ -115,11 +115,10 @@
 			"\treturn vec4(0.0);",
 			"}"
 		],
-		"longdesc": "Draws a uniform greyscale image",
+		"longdesc": "Draws splines",
 		"name": "Splines",
 		"outputs": [
 			{
-				"longdesc": "A uniform image of the selected value",
 				"rgba": "mix($(name)_splines($uv), $in_guide($uv), 0.5*$in_guide($uv).a)",
 				"shortdesc": "Output",
 				"type": "rgba"


### PR DESCRIPTION
Noticed a few of these nodes are still using default descriptions (from the greyscale uniform node). This PR replaces them so it better describes what they do:

<img src="https://github.com/user-attachments/assets/5641fd3c-326e-4ee5-a468-aa64b55e6901" width="550" />

