### PR TITLE
Fix minor spelling error in distort node

### DIFF
--- a/addons/material_maker/nodes/distort.mmg
+++ b/addons/material_maker/nodes/distort.mmg
@@ -144,7 +144,7 @@
 					"type": "Lattice"
 				},
 				"label": "",
-				"longdesc": "The lattice that describes the distorsion",
+				"longdesc": "The lattice that describes the distortion",
 				"name": "lattice",
 				"shortdesc": "Lattice",
 				"type": "lattice"


### PR DESCRIPTION
"Distortion" would be the correct English spelling. With a bit of searching it looks like "Distorsion" is a French word