### PR TITLE
Fix dialog title

### DIFF
--- a/material_maker/panels/preview_2d/custom_size_dialog.gd
+++ b/material_maker/panels/preview_2d/custom_size_dialog.gd
@@ -5,7 +5,7 @@ signal close(apply)
 
 
 func ask() -> Dictionary:
-	title = "Custom size"
+	window_title = "Custom size"
 	popup_centered()
 	_on_WindowDialog_minimum_size_changed()
 	var rv : Dictionary

--- a/material_maker/panels/preview_2d/custom_size_dialog.gd
+++ b/material_maker/panels/preview_2d/custom_size_dialog.gd
@@ -5,7 +5,7 @@ signal close(apply)
 
 
 func ask() -> Dictionary:
-	window_title = "Custom size"
+	title = "Custom size"
 	popup_centered()
 	_on_WindowDialog_minimum_size_changed()
 	var rv : Dictionary

--- a/material_maker/tools/environment_manager/environment_manager.gd
+++ b/material_maker/tools/environment_manager/environment_manager.gd
@@ -186,7 +186,7 @@ func read_hdr(index : int, url : String) -> bool:
 			return true
 	if accept_dialog == null:
 		accept_dialog = AcceptDialog.new()
-		accept_dialog.window_title = "HDRI download error"
+		accept_dialog.title = "HDRI download error"
 		accept_dialog.dialog_text = "Failed to download %s" % url
 		mm_globals.main_window.add_child(accept_dialog)
 		accept_dialog.connect("confirmed", Callable(accept_dialog, "queue_free"))


### PR DESCRIPTION
Fix additional instance of `window_title` to `title` as the property was renamed. Based on https://github.com/RodZill4/material-maker/pull/717