### PR TITLE
Fix "title underline too short" warning during doc build

### DIFF
--- a/material_maker/doc/node_filter_adjusthsv.rst
+++ b/material_maker/doc/node_filter_adjusthsv.rst
@@ -1,5 +1,5 @@
 Adjust HSV node
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 The **Adjust HSV** node adjusts the hue, saturation and value of the input image.
 

--- a/material_maker/doc/node_filter_alterhsv.rst
+++ b/material_maker/doc/node_filter_alterhsv.rst
@@ -1,5 +1,5 @@
 Alter HSV node
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 The **Alter HSV** node modifies the hue, saturation and value of the input image, according
 to dedicated input maps. It can be used to easily apply variations to its input.

--- a/material_maker/doc/node_filter_swapchannels.rst
+++ b/material_maker/doc/node_filter_swapchannels.rst
@@ -1,5 +1,5 @@
 Swap Channels node
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 The **Swap Channels** node can be used to replace each channel (R, G, B and A) of
 an with 0, 1 or a channel of its input (inverted or not).

--- a/material_maker/doc/node_simple_easysdf.rst
+++ b/material_maker/doc/node_simple_easysdf.rst
@@ -1,5 +1,5 @@
 Easy SDF node
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 The **Easy SDF** node outputs a custom 2D or 3D SDF shape that can be defined using a simple editor.
 

--- a/material_maker/doc/node_simple_polycurve.rst
+++ b/material_maker/doc/node_simple_polycurve.rst
@@ -1,5 +1,5 @@
 PolyC urve node
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 The **Poly Curve** node outputs a simple RGBA image showing a curve defined by several control points.
 

--- a/material_maker/doc/node_transform_customuv.rst
+++ b/material_maker/doc/node_transform_customuv.rst
@@ -1,5 +1,5 @@
 Custom UV node
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 The **Custom UV** node deforms an input image according to a custom UV map given as input.
 

--- a/material_maker/doc/node_transform_tile2x2.rst
+++ b/material_maker/doc/node_transform_tile2x2.rst
@@ -1,5 +1,5 @@
 Tile 2x2 node
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 The **Tile 2x2** node combines 4 input images into a single output by tiling them.
 

--- a/material_maker/doc/node_workflow_applymap.rst
+++ b/material_maker/doc/node_workflow_applymap.rst
@@ -1,5 +1,5 @@
 Apply Map node
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 The **Apply Map** node applies a map to a simple material by adjusting its orientation and offset,
 and outputs the modified map and the height information.

--- a/material_maker/doc/node_workflow_createmap.rst
+++ b/material_maker/doc/node_workflow_createmap.rst
@@ -1,5 +1,5 @@
 Create Map node
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 The **Create Map** node creates a map holding height, orientation and offset information
 used to combine simple materials.

--- a/material_maker/doc/node_workflow_mixmaps.rst
+++ b/material_maker/doc/node_workflow_mixmaps.rst
@@ -1,5 +1,5 @@
 Mix Maps node
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 The **Mix Maps** node combines up to 4 maps holding height, orientation and offset information.
 


### PR DESCRIPTION
I noticed these warnings when the CI is ran for the documentation (i.e. https://github.com/RodZill4/material-maker/actions/runs/14284350293), this fixes the issue by making the underline as long as the title