### PR TITLE
Reset center when Shfit + MMB is used in 3d view

### DIFF
--- a/material_maker/panels/preview_3d/preview_3d_panel.gd
+++ b/material_maker/panels/preview_3d/preview_3d_panel.gd
@@ -44,9 +44,11 @@ func on_right_click():
 
 func _on_PopupMenu_id_pressed(id):
 	var pivot = get_node("MaterialPreview/Preview3d/ObjectsPivot/Objects")
+	var cam_control = get_node("MaterialPreview/Preview3d/CameraController")
 	match id:
 		0:
 			pivot.transform.origin = Vector3(0, 0, 0)
+			cam_control.transform.origin = Vector3(0, 0, 0)
 		1:
 			pivot.transform.origin = new_pivot_position
 


### PR DESCRIPTION
It appears that the CameraController node is offset but 'reset center' option only resets the ObjectsPivot's

Currently:

https://github.com/user-attachments/assets/02024027-f525-4d6a-8876-0eda3e9bf8b9

This PR:

https://github.com/user-attachments/assets/1391e2ec-23d1-48d8-a1e4-c509511cc00f

