### PR TITLE
Add per-point/node gizmo size control

### DIFF
--- a/addons/material_maker/engine/nodes/gen_shader.gd
+++ b/addons/material_maker/engine/nodes/gen_shader.gd
@@ -808,7 +808,7 @@ func do_edit(node, edit_window_scene : PackedScene, tab : String = "") -> void:
 		edit_window.connect("node_changed", Callable(node, "update_shader_generator"))
 		edit_window.connect("popup_hide", Callable(edit_window, "queue_free"))
 		edit_window.get_window().content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
-		edit_window.get_window().min_size = Vector2(950, 450) * edit_window.get_window().content_scale_factor
+		edit_window.get_window().min_size = Vector2(985, 450) * edit_window.get_window().content_scale_factor
 		edit_window.hide()
 		edit_window.popup_centered()
 		if tab != "":

--- a/material_maker/panels/preview_2d/control_point.tscn
+++ b/material_maker/panels/preview_2d/control_point.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://est6pi7xbptp"]
 
-[ext_resource type="Script" path="res://material_maker/panels/preview_2d/control_point.gd" id="1"]
+[ext_resource type="Script" uid="uid://d5fr47ktyhi" path="res://material_maker/panels/preview_2d/control_point.gd" id="1"]
 
 [node name="Point" type="TextureRect"]
 mouse_filter = 0

--- a/material_maker/panels/preview_2d/preview_2d_panel.tscn
+++ b/material_maker/panels/preview_2d/preview_2d_panel.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=30 format=3 uid="uid://b7x7yqgsurxhv"]
+[gd_scene load_steps=56 format=3 uid="uid://b7x7yqgsurxhv"]
 
-[ext_resource type="Texture2D" uid="uid://c0j4px4n72di5" path="res://material_maker/icons/icons.tres" id="1"]
 [ext_resource type="PackedScene" uid="uid://est6pi7xbptp" path="res://material_maker/panels/preview_2d/control_point.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://bb6iar0tbj2qt" path="res://material_maker/panels/preview_2d/preview_2d.tscn" id="3"]
 [ext_resource type="Script" uid="uid://cjtefdp8oh215" path="res://material_maker/panels/preview_2d/axes.gd" id="3_r76ng"]
@@ -59,12 +58,109 @@ shader_parameter/background_color_1 = Vector4(0.4, 0.4, 0.4, 1)
 shader_parameter/background_color_2 = Vector4(0.6, 0.6, 0.6, 1)
 shader_parameter/checker_size = 32.0
 
-[sub_resource type="AtlasTexture" id="3"]
-atlas = ExtResource("1")
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_wgulb"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_83edi"]
+atlas = SubResource("CompressedTexture2D_wgulb")
 region = Rect2(64, 48, 32, 32)
 
-[sub_resource type="AtlasTexture" id="4"]
-atlas = ExtResource("1")
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_r76ng"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_63a3x"]
+atlas = SubResource("CompressedTexture2D_r76ng")
+region = Rect2(64, 48, 32, 32)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_083ld"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ddtyk"]
+atlas = SubResource("CompressedTexture2D_083ld")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_dps6m"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_c4q6r"]
+atlas = SubResource("CompressedTexture2D_dps6m")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_h3gsw"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_nuc3o"]
+atlas = SubResource("CompressedTexture2D_h3gsw")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_hpbbd"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_b14i0"]
+atlas = SubResource("CompressedTexture2D_hpbbd")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_rm552"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_0r70u"]
+atlas = SubResource("CompressedTexture2D_rm552")
+region = Rect2(64, 48, 32, 32)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_8jmg3"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_2ktdc"]
+atlas = SubResource("CompressedTexture2D_8jmg3")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_7bs5l"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_v7xo2"]
+atlas = SubResource("CompressedTexture2D_7bs5l")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_ywwu1"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_akdui"]
+atlas = SubResource("CompressedTexture2D_ywwu1")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_qr4p0"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_qylr4"]
+atlas = SubResource("CompressedTexture2D_qr4p0")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_83edi"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_r76ng"]
+atlas = SubResource("CompressedTexture2D_83edi")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_m66kb"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_g35k8"]
+atlas = SubResource("CompressedTexture2D_m66kb")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_mjbcq"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_xo6pd"]
+atlas = SubResource("CompressedTexture2D_mjbcq")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_m8aks"]
+load_path = "res://.godot/imported/icons.svg-7e4b30239fa94a02566e96134c06aedb.ctex"
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_4pk1k"]
+atlas = SubResource("CompressedTexture2D_m8aks")
 region = Rect2(16, 64, 16, 16)
 
 [sub_resource type="Shader" id="5"]
@@ -213,7 +309,7 @@ offset_left = 5.0
 offset_top = 29.0
 offset_right = 37.0
 offset_bottom = 61.0
-texture = SubResource("3")
+texture = SubResource("AtlasTexture_83edi")
 
 [node name="P2" parent="." index="7" instance=ExtResource("2")]
 visible = false
@@ -223,7 +319,7 @@ offset_left = 5.0
 offset_top = 29.0
 offset_right = 37.0
 offset_bottom = 61.0
-texture = SubResource("3")
+texture = SubResource("AtlasTexture_63a3x")
 
 [node name="P11" parent="." index="8" instance=ExtResource("2")]
 visible = false
@@ -233,7 +329,7 @@ offset_left = 5.0
 offset_top = 29.0
 offset_right = 37.0
 offset_bottom = 61.0
-texture = SubResource("3")
+texture = SubResource("AtlasTexture_ddtyk")
 parent_control = "P1"
 apply_local_transform = true
 
@@ -246,7 +342,7 @@ offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
 mouse_default_cursor_shape = 10
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_c4q6r")
 parent_control = "P11"
 control_type = 2
 
@@ -258,7 +354,7 @@ offset_left = 5.0
 offset_top = 29.0
 offset_right = 37.0
 offset_bottom = 61.0
-texture = SubResource("3")
+texture = SubResource("AtlasTexture_nuc3o")
 parent_control = "P1"
 apply_local_transform = true
 
@@ -270,7 +366,17 @@ offset_left = 5.0
 offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_b14i0")
+
+[node name="P4" parent="." index="11" instance=ExtResource("2")]
+visible = false
+self_modulate = Color(1, 0, 1, 1)
+layout_mode = 0
+offset_left = 5.0
+offset_top = 50.0
+offset_right = 37.0
+offset_bottom = 82.0
+texture = SubResource("AtlasTexture_0r70u")
 
 [node name="Rect1" parent="." index="12" instance=ExtResource("2")]
 visible = false
@@ -280,7 +386,7 @@ offset_left = 5.0
 offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_2ktdc")
 parent_control = "P1"
 control_type = 1
 apply_local_transform = true
@@ -294,7 +400,7 @@ offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
 mouse_default_cursor_shape = 10
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_v7xo2")
 parent_control = "P1"
 control_type = 2
 
@@ -307,7 +413,7 @@ offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
 mouse_default_cursor_shape = 10
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_akdui")
 parent_control = "P2"
 control_type = 2
 
@@ -320,7 +426,7 @@ offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
 mouse_default_cursor_shape = 10
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_qylr4")
 parent_control = "Radius1"
 control_type = 2
 
@@ -333,7 +439,7 @@ offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
 mouse_default_cursor_shape = 10
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_r76ng")
 parent_control = "P1"
 control_type = 3
 
@@ -346,7 +452,7 @@ offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
 mouse_default_cursor_shape = 10
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_g35k8")
 parent_control = "P1"
 control_type = 4
 
@@ -359,7 +465,7 @@ offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
 mouse_default_cursor_shape = 10
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_xo6pd")
 parent_control = "P1"
 control_type = 2
 
@@ -372,7 +478,7 @@ offset_top = 29.0
 offset_right = 21.0
 offset_bottom = 45.0
 mouse_default_cursor_shape = 10
-texture = SubResource("4")
+texture = SubResource("AtlasTexture_4pk1k")
 parent_control = "P1"
 control_type = 2
 

--- a/material_maker/windows/node_editor/parameter.gd
+++ b/material_maker/windows/node_editor/parameter.gd
@@ -67,3 +67,6 @@ func _on_Type_item_selected(ID) -> void:
 		t.visible = true
 	else:
 		print(ID)
+
+func get_parameter_hbox() -> HBoxContainer:
+	return $Types.get_child($Type.selected)

--- a/material_maker/windows/node_editor/parameter_float.gd
+++ b/material_maker/windows/node_editor/parameter_float.gd
@@ -1,6 +1,18 @@
 extends HBoxContainer
 
-const CONTROLS = [ "None", "P1.x", "P1.y", "P1.a", "P1.r", "P2.x", "P2.y", "P2.a", "P2.r", "P3.x", "P3.y", "Rect1.x", "Rect1.y", "Radius1.r", "Radius1.a", "Radius11.r", "Radius11.a", "Scale1.x", "Scale1.y", "Angle1.a", "Angle2.a" ]
+const CONTROLS = [ "None", "P1.x", "P1.y", "P1.a", "P1.r", "P2.x", "P2.y", "P2.a", "P2.r", "P3.x", "P3.y", "P4.x", "P4.y", "Rect1.x", "Rect1.y", "Radius1.r", "Radius1.a", "Radius11.r", "Radius11.a", "Scale1.x", "Scale1.y", "Angle1.a", "Angle2.a" ]
+
+const CONTROLS_PXY : Array[String] = [ "P1.x", "P2.x", "P3.x", "P4.x", "P1.y", "P2.y", "P3.y", "P4.y" ]
+
+var gizmo_size : ControlPoint.GizmoSize = ControlPoint.GizmoSize.LARGE:
+	set(v):
+		gizmo_size = v
+		if v == ControlPoint.GizmoSize.LARGE:
+			$ControlSize/ControlLarge.visible = false
+			$ControlSize/ControlSmall.visible = true
+		else:
+			$ControlSize/ControlLarge.visible = true
+			$ControlSize/ControlSmall.visible = false
 
 func _ready() -> void:
 	$Control.clear()
@@ -13,7 +25,8 @@ func get_model_data() -> Dictionary:
 		max = $Max.value,
 		step = $Step.value,
 		default = $Default.value,
-		control = $Control.get_item_text($Control.selected)
+		control = $Control.get_item_text($Control.selected),
+		control_size = int($ControlSize/ControlLarge.visible),
 	}
 	return data
 
@@ -34,8 +47,15 @@ func set_model_data(data) -> void:
 		for i in range($Control.get_item_count()):
 			if data.control == $Control.get_item_text(i):
 				$Control.selected = i
+				_on_control_item_selected(i)
 				break
-
+		if data.control in CONTROLS_PXY:
+			if "control_size" not in data:
+				data.control_size = ControlPoint.DEFAULT_GIZMO_SIZES[data.control.split(".")[0]]
+			$ControlSize/ControlSmall.visible = data.control_size == ControlPoint.GizmoSize.SMALL
+			$ControlSize/ControlLarge.visible = data.control_size == ControlPoint.GizmoSize.LARGE
+		else:
+			$ControlSize.hide()
 
 func _on_Min_value_changed(v : float) -> void:
 	$Default.min_value = v
@@ -45,3 +65,34 @@ func _on_Max_value_changed(v : float) -> void:
 
 func _on_Step_value_changed(v : float) -> void:
 	$Default.step = v
+
+func _on_control_small_pressed() -> void:
+	gizmo_size = ControlPoint.GizmoSize.SMALL
+	propagate_gizmo_selection()
+
+func _on_control_large_pressed() -> void:
+	gizmo_size = ControlPoint.GizmoSize.LARGE
+	propagate_gizmo_selection()
+
+func _on_control_item_selected(index: int) -> void:
+	$ControlSize.visible = CONTROLS_PXY.any(func(g: String):
+			return CONTROLS[index] == g)
+
+func propagate_gizmo_selection() -> void:
+	# Sets relevant control(e.g. P1)'s x/y gizmos to the same size
+	var node_editor_parameter_sizer : VBoxContainer = get_node("../../..")
+	var current_index := get_node("../..").get_index()
+	for param in node_editor_parameter_sizer.get_children():
+		if param is Button:
+			continue
+		var param_hbox = param.get_parameter_hbox()
+		if param_hbox.has_method("get_control_name"):
+			var current_control : String = param_hbox.get_control_name()
+			if current_control not in CONTROLS_PXY:
+				continue
+			if (get_control_name().get_slice(".", 0) == current_control.get_slice(".", 0)
+					and param.get_index() != current_index):
+				param_hbox.gizmo_size = gizmo_size
+
+func get_control_name() -> String:
+	return $Control.get_item_text($Control.selected)

--- a/material_maker/windows/node_editor/parameter_float.tscn
+++ b/material_maker/windows/node_editor/parameter_float.tscn
@@ -1,7 +1,16 @@
-[gd_scene load_steps=3 format=3 uid="uid://dn13ybhfpg52k"]
+[gd_scene load_steps=6 format=3 uid="uid://dn13ybhfpg52k"]
 
-[ext_resource type="Script" path="res://material_maker/windows/node_editor/parameter_float.gd" id="1"]
+[ext_resource type="Script" uid="uid://dv7vvyci7v4ma" path="res://material_maker/windows/node_editor/parameter_float.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://rflulhsuy3ax" path="res://material_maker/widgets/float_edit/float_edit.tscn" id="2"]
+[ext_resource type="Texture2D" uid="uid://cvorvnes6fiq7" path="res://material_maker/icons/icons.svg" id="3_y55bf"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_2folb"]
+atlas = ExtResource("3_y55bf")
+region = Rect2(16, 64, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_y55bf"]
+atlas = ExtResource("3_y55bf")
+region = Rect2(64, 48, 32, 32)
 
 [node name="float" type="HBoxContainer"]
 offset_right = 400.0
@@ -14,7 +23,6 @@ text = "Min:"
 
 [node name="Min" parent="." instance=ExtResource("2")]
 layout_mode = 2
-text = "0"
 value = 0.0
 min_value = -65536.0
 max_value = 65536.0
@@ -26,7 +34,6 @@ text = "Max:"
 
 [node name="Max" parent="." instance=ExtResource("2")]
 layout_mode = 2
-text = "1"
 value = 1.0
 min_value = -65536.0
 max_value = 65536.0
@@ -38,7 +45,6 @@ text = "Step:"
 
 [node name="Step" parent="." instance=ExtResource("2")]
 layout_mode = 2
-text = "0.1"
 value = 0.1
 max_value = 10.0
 step = 0.005
@@ -58,6 +64,29 @@ text = "Control:"
 [node name="Control" type="OptionButton" parent="."]
 layout_mode = 2
 
+[node name="ControlSize" type="HBoxContainer" parent="."]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 0
+
+[node name="ControlSmall" type="Button" parent="ControlSize"]
+visible = false
+custom_minimum_size = Vector2(24, 0)
+layout_mode = 2
+tooltip_text = "Small Gizmo"
+icon = SubResource("AtlasTexture_2folb")
+expand_icon = true
+
+[node name="ControlLarge" type="Button" parent="ControlSize"]
+custom_minimum_size = Vector2(24, 0)
+layout_mode = 2
+tooltip_text = "Large Gizmo"
+icon = SubResource("AtlasTexture_y55bf")
+expand_icon = true
+
 [connection signal="value_changed" from="Min" to="." method="_on_Min_value_changed"]
 [connection signal="value_changed" from="Max" to="." method="_on_Max_value_changed"]
 [connection signal="value_changed" from="Step" to="." method="_on_Step_value_changed"]
+[connection signal="item_selected" from="Control" to="." method="_on_control_item_selected"]
+[connection signal="pressed" from="ControlSize/ControlSmall" to="." method="_on_control_small_pressed"]
+[connection signal="pressed" from="ControlSize/ControlLarge" to="." method="_on_control_large_pressed"]


### PR DESCRIPTION
Adds an additional control point (P4.xy) and per-node/control gizmo size customization (only P1-P4 for now). This adds another field in the data model - `control_size` to store the size of the gizmo


https://github.com/user-attachments/assets/06c582b2-0381-4a13-88fa-e361696eea2c