### PR TITLE
Fix sdf3dcolor shader error by setting default input value to 1.0

### DIFF
--- a/addons/material_maker/nodes/sdf3d_color.mmg
+++ b/addons/material_maker/nodes/sdf3d_color.mmg
@@ -13,7 +13,7 @@
 		"global": "",
 		"inputs": [
 			{
-				"default": "0.0",
+				"default": "1.0",
 				"label": "",
 				"longdesc": "The input 3D object",
 				"name": "in",

--- a/addons/material_maker/nodes/sdf3d_color_v.mmg
+++ b/addons/material_maker/nodes/sdf3d_color_v.mmg
@@ -14,7 +14,7 @@
 		"global": "",
 		"inputs": [
 			{
-				"default": "0.0",
+				"default": "1.0",
 				"label": "",
 				"longdesc": "The input 3D object",
 				"name": "in#",


### PR DESCRIPTION
Likely a mac(m1)-specific issue
![glitch](https://github.com/user-attachments/assets/2f98bafe-1fa4-476a-b93c-4a14c4185e19)
