### PR TITLE
fix divide-by-zero in 3d sdf/c preview

### DIFF
--- a/addons/material_maker/nodes/preview_sdf3d.gdshader
+++ b/addons/material_maker/nodes/preview_sdf3d.gdshader
@@ -3,6 +3,8 @@ uniform float variation = 0.0;
 float calcdist(vec3 uv) {
 	float _seed_variation_ = variation;
 	$(code)
+	float v = $(value);
+	v = v == 0.0 ? 1.0 : v;
 	return min($(value), uv.z);
 }
 

--- a/addons/material_maker/nodes/preview_sdf3dc.gdshader
+++ b/addons/material_maker/nodes/preview_sdf3dc.gdshader
@@ -4,6 +4,7 @@ vec2 calcdist(vec3 uv) {
 	float _seed_variation_ = variation;
 	$(code)
 	vec2 v = $(value);
+	v.x = v.x == 0.0 ? 1.0 : v.x;
 	return vec2(min(v.x, uv.z), v.y);
 }
 


### PR DESCRIPTION
Fix an issue where divide-by-zero can happen if input distance is 0, on m1 mac it causes error like this:

<img width="620" alt="image" src="https://github.com/user-attachments/assets/e2d7e5bf-3601-4119-9ec6-2f64ec672c59" />
