### PR TITLE
Fix thin line in tex3d shader preview

### DIFF
--- a/addons/material_maker/nodes/preview_tex3d.gdshader
+++ b/addons/material_maker/nodes/preview_tex3d.gdshader
@@ -36,5 +36,5 @@ vec4 preview_2d(vec2 uv) {
     float o = step(p.z, 0.001);
     float shadow = 1.0-0.75*step(raymarch(l, -ld), length(l-p)-0.01);
     float light = 0.3+0.7*dot(n, ld)*shadow;
-    return vec4(calcColor(vec4(p, 0.0))*light, 1.0);
+    return vec4(calcColor(vec4(p, 0.0))*light-o, 1.0);
 }

--- a/addons/material_maker/nodes/preview_tex3d_gs.gdshader
+++ b/addons/material_maker/nodes/preview_tex3d_gs.gdshader
@@ -36,5 +36,5 @@ vec4 preview_2d(vec2 uv) {
     float o = step(p.z, 0.001);
     float shadow = 1.0-0.75*step(raymarch(l, -ld), length(l-p)-0.01);
     float light = 0.3+0.7*dot(n, ld)*shadow;
-    return vec4(calcColor(vec4(p, 0.0))*light, 1.0);
+    return vec4(calcColor(vec4(p, 0.0))*light-o, 1.0);
 }


### PR DESCRIPTION
It's a bit hard to see but it looks like aliasing on default zoom level (m1 mac)

**Before:**

![a](https://github.com/user-attachments/assets/0e6dc323-c3b1-4c92-a4d4-2eb88000f257)

**After**

![b](https://github.com/user-attachments/assets/926649f9-0c2c-4f1a-a7c6-fe8bbaddf3d5)

probably slightly better view(before), zoomed in just slightly

![c](https://github.com/user-attachments/assets/b021f870-01c0-4f96-9ae2-851484b3c7bd)


