### PR TITLE
Option to remember last used animation export settings

### DIFF
--- a/material_maker/windows/export_animation/export_animation.gd
+++ b/material_maker/windows/export_animation/export_animation.gd
@@ -31,6 +31,19 @@ func _ready():
 	for i in range(BUFFER_NAMES.size()):
 		mm_deps.create_buffer(BUFFER_NAMES[i], self)
 
+	if mm_globals.get_config("remember_anim_export"):
+		if mm_globals.has_config("export_animation_size"):
+			value_size.selected = mm_globals.get_config("export_animation_size")
+		if mm_globals.has_config("export_animation_begin"):
+			value_begin.value = mm_globals.get_config("export_animation_begin")
+		if mm_globals.has_config("export_animation_end"):
+			value_end.value = mm_globals.get_config("export_animation_end")
+		if mm_globals.has_config("export_animation_images"):
+			value_images.value = mm_globals.get_config("export_animation_images")
+		if mm_globals.has_config("export_animation_spritesheet"):
+			value_spritesheet.selected = mm_globals.get_config("export_animation_spritesheet")
+
+
 func set_source(g, o):
 	generator = g
 	output = o
@@ -146,6 +159,13 @@ func _on_Export_pressed():
 		image_anim.material.set_shader_parameter("end", end)
 		image_anim.material.set_shader_parameter("mm_chunk_size", 1.0)
 		image_anim.material.set_shader_parameter("mm_chunk_offset", Vector2(0.0, 0.0))
+
+	if mm_globals.get_config("remember_anim_export"):
+		mm_globals.set_config("export_animation_size", value_size.selected)
+		mm_globals.set_config("export_animation_begin", value_begin.value)
+		mm_globals.set_config("export_animation_end", value_end.value)
+		mm_globals.set_config("export_animation_images", value_images.value)
+		mm_globals.set_config("export_animation_spritesheet", value_spritesheet.selected)
 
 
 func _on_VBox_minimum_size_changed():

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -258,6 +258,21 @@ layout_mode = 2
 text = "Auto size comment node to selection"
 config_variable = "auto_size_comment"
 
+[node name="Export" type="VBoxContainer" parent="VBoxContainer/TabContainer"]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 3
+
+[node name="AnimationLabel" type="Label" parent="VBoxContainer/TabContainer/Export"]
+layout_mode = 2
+text = "Animation"
+
+[node name="RememberAnimExport" parent="VBoxContainer/TabContainer/Export" instance=ExtResource("1")]
+layout_mode = 2
+tooltip_text = "Whether to save export parameters in the export animation dialog (i.e. size, begin, end etc.)"
+text = "Remember last export settings"
+config_variable = "remember_anim_export"
+
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
 layout_mode = 2
 theme_override_constants/separation = 0


### PR DESCRIPTION
Adds an option to remember last used animation export settings (i.e. size, begin, end, images etc.)

![image](https://github.com/user-attachments/assets/751629bb-dfba-487d-b8e3-75d9d69b0709)
