### PR TITLE
macOS: Open about dialog from app menu

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -1085,6 +1085,8 @@ func _notification(what : int) -> void:
 			# Return to the normal FPS limit when the window is focused.
 # warning-ignore:narrowing_conversion
 			OS.low_processor_usage_mode_sleep_usec = (1.0 / clamp(mm_globals.get_config("fps_limit"), FPS_LIMIT_MIN, FPS_LIMIT_MAX)) * 1_000_000
+		NOTIFICATION_WM_ABOUT:
+			about.call_deferred()
 
 func on_close_requested():
 	await get_tree().process_frame


### PR DESCRIPTION
For macOS, make it so that "about app" menu item also opens the about dialog

i.e. the following menu item:

<img width="341" alt="image" src="https://github.com/user-attachments/assets/699f4155-206c-414e-8740-8b03d2c6aae4" />

Reference: https://github.com/godotengine/godot/issues/58116