### PR TITLE
Reset/Expression editor via float edit context menu

### DIFF
--- a/material_maker/nodes/generic/generic.gd
+++ b/material_maker/nodes/generic/generic.gd
@@ -299,6 +299,7 @@ static func create_parameter_control(p : Dictionary, accept_float_expressions : 
 		control.step = 0.005 if !p.has("step") else p.step
 		if p.has("default"):
 			control.value = p.default
+			control.default_value = p.default
 		control.custom_minimum_size.x = 80
 	elif p.type == "size":
 		control = SizeOptionButton.new()

--- a/material_maker/widgets/float_edit/float_edit.gd
+++ b/material_maker/widgets/float_edit/float_edit.gd
@@ -1,6 +1,16 @@
 extends Container
 
 var float_value: float = 0.5
+var default_float_value: float = 0.0
+
+enum ContextMenu {RESET_VALUE, EDIT_EXPRESSION}
+
+@export var default_value: float = 0.0 :
+	get:
+		return default_float_value
+	set(default_value):
+		default_float_value = default_value
+
 @export var value: float = 0.5 :
 	get:
 		return float_value
@@ -213,14 +223,30 @@ func _gui_input(event: InputEvent) -> void:
 
 	if mode == Modes.EDITING or mode == Modes.IDLE:
 		if event is InputEventMouseButton:
-			# Handle Right Click (Expression Editor)
-			if event.button_index == MOUSE_BUTTON_RIGHT and event.pressed and not float_only:
-				var expression_editor: Window = load("res://material_maker/widgets/float_edit/expression_editor.tscn").instantiate()
-				add_child(expression_editor)
-				expression_editor.edit_parameter(
-					"Expression editor - " + name,
-					$Edit.text, self,
-					"set_value_from_expression_editor")
+
+			# Handle Right Click
+			if event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+				var context_menu : PopupMenu = PopupMenu.new()
+				context_menu.position = get_local_mouse_position() + get_screen_position()
+				context_menu.add_item("Reset value")
+
+				if not float_only:
+					context_menu.add_item("Edit expression")
+
+				context_menu.id_pressed.connect(func(id):
+					match id:
+						ContextMenu.RESET_VALUE:
+							set_value(default_float_value, true, true)
+						ContextMenu.EDIT_EXPRESSION:
+							var expression_editor: Window = load("res://material_maker/widgets/float_edit/expression_editor.tscn").instantiate()
+							add_child(expression_editor)
+							expression_editor.edit_parameter(
+									"Expression editor - " + name,
+									$Edit.text, self,
+									"set_value_from_expression_editor")
+				)
+				add_child(context_menu)
+				context_menu.popup()
 				accept_event()
 
 			# Handle CTRL+Scrolling

--- a/material_maker/widgets/float_edit/float_edit.tscn
+++ b/material_maker/widgets/float_edit/float_edit.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://rflulhsuy3ax"]
 
-[ext_resource type="Script" path="res://material_maker/widgets/float_edit/float_edit.gd" id="1"]
+[ext_resource type="Script" uid="uid://c4own5hljyjue" path="res://material_maker/widgets/float_edit/float_edit.gd" id="1"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_t5q7m"]
 content_margin_left = 3.0


### PR DESCRIPTION
Resolves https://github.com/RodZill4/material-maker/issues/263

This also moves the expression editor into the context menu

![float_edit_context](https://github.com/user-attachments/assets/b41444fd-7452-4595-a29a-558223488681)

