### PR TITLE
Add a preference to adjust float parameter sliding sensitivity

### DIFF
--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -58,11 +58,12 @@ const DEFAULT_CONFIG : Dictionary = {
 	ui_use_native_file_dialogs = true,
 	win_tablet_driver = 0,
 	dialog_dim_background = true,
-	node_minimize_button = false,
-	node_close_button = false,
 	ui_single_window_mode = false,
 	add_node_popup_sort = SortMenu.Sorting.QUALITY_DESCENDING,
-	aperture_label_position = 0
+	aperture_label_position = 0,
+	node_minimize_button = true,
+	node_close_button = true,
+	ui_field_sensitivity = 1.0,
 }
 
 

--- a/material_maker/widgets/float_edit/float_edit.gd
+++ b/material_maker/widgets/float_edit/float_edit.gd
@@ -172,6 +172,8 @@ func _gui_input(event: InputEvent) -> void:
 			if actually_dragging:
 				var current_step := step
 
+				delta *= mm_globals.get_config("ui_field_sensitivity")
+
 				if event.is_command_or_control_pressed():
 					if step == 1:
 						current_step *= 5

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -542,6 +542,29 @@ popup/item_1/id = 1
 script = ExtResource("5_vp06c")
 config_variable = "aperture_label_position"
 
+[node name="Spacer3" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer" unique_id=429716171]
+custom_minimum_size = Vector2(0, 10)
+layout_mode = 2
+
+[node name="FloatEditSensitivity" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer" unique_id=1393451760]
+layout_mode = 2
+
+[node name="LabelFloatEditSensitivity" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer/FloatEditSensitivity" unique_id=363806448]
+layout_mode = 2
+text = "Float parameter editor sliding sensitivity"
+
+[node name="Sensitivity" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer/FloatEditSensitivity" unique_id=1159103913 instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
+layout_mode = 2
+size_flags_horizontal = 10
+tooltip_text = "Adjusts sliding sensitivity for float parameter fields."
+config_variable = "ui_field_sensitivity"
+value = 1.0
+min_value = 0.1
+max_value = 2.0
+step = 0.01
+float_only = true
+
 [node name="Export" type="ScrollContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer" unique_id=848471352]
 visible = false
 layout_mode = 2


### PR DESCRIPTION
suggestion via discord
> as we made a lot of nodes (sliders) smaller, would it be possible to decrease sensitivity when moving a slider?

<img width="595" height="89" alt="image" src="https://github.com/user-attachments/assets/8139201e-4ac9-424a-a1f6-555e69c3e8b5" />
