### PR TITLE
Add missing short/long desc. for nodes

### DIFF
--- a/addons/material_maker/engine/nodes/gen_buffer.gd
+++ b/addons/material_maker/engine/nodes/gen_buffer.gd
@@ -50,6 +50,9 @@ func get_buffers(flags : int = BUFFERS_ALL) -> Array:
 		return []
 	return [ self ]
 
+func get_description() -> String:
+	return "\n".join(["Buffer", "Samples input into a texture of a given resolution"])
+
 func get_parameter_defs() -> Array:
 	var parameter_defs : Array = [ { name="size",label="Size", type="size", first=4, last=13, default=4 } ]
 	match version:

--- a/addons/material_maker/engine/nodes/gen_debug.gd
+++ b/addons/material_maker/engine/nodes/gen_debug.gd
@@ -12,6 +12,11 @@ func get_type() -> String:
 func get_type_name() -> String:
 	return "Debug"
 
+func get_description() -> String:
+	return "\n".join(["Debug",
+			"Shows generated shader of an input and code " +
+			"which can be copied and used directly in Shadertoy"])
+
 func get_input_defs() -> Array:
 	return [ { name="in", type="rgba" } ]
 

--- a/addons/material_maker/engine/nodes/gen_export.gd
+++ b/addons/material_maker/engine/nodes/gen_export.gd
@@ -25,6 +25,11 @@ func get_type() -> String:
 func get_type_name() -> String:
 	return "Export"
 
+func get_description() -> String:
+	return "\n".join(["Export",
+			"Defines a texture which will be saved " +
+			"along with other textures on material export"])
+
 func get_parameter_defs() -> Array:
 	return [
 			{ name="size", label="Size", type="size", first=4, last=13, default=10 },

--- a/addons/material_maker/engine/nodes/gen_iterate_buffer.gd
+++ b/addons/material_maker/engine/nodes/gen_iterate_buffer.gd
@@ -47,6 +47,10 @@ func get_type() -> String:
 func get_type_name() -> String:
 	return "Iterate Buffer"
 
+func get_description() -> String:
+	return "\n".join(["Iterate Buffer",
+			"Samples input into a texture and applies a \"loop subgraph\" repeatedly"])
+
 func set_paused(v : bool) -> void:
 	if v == is_paused:
 		return

--- a/addons/material_maker/engine/nodes/gen_text.gd
+++ b/addons/material_maker/engine/nodes/gen_text.gd
@@ -5,7 +5,6 @@ class_name MMGenText
 
 # Texture generator from text
 
-
 var updating : bool = false
 var update_again : bool = false
 
@@ -17,6 +16,9 @@ func get_type() -> String:
 
 func get_type_name() -> String:
 	return "Text"
+
+func get_description() -> String:
+	return "\n".join(["Text", "Text as a greyscale image"])
 
 func get_parameter_defs() -> Array:
 	return [

--- a/addons/material_maker/nodes/curve.mmg
+++ b/addons/material_maker/nodes/curve.mmg
@@ -190,7 +190,7 @@
 			}
 		],
 		"shortdesc": "Curve",
-		"longdesc": "3-point bezier curve with image mapping"
+		"longdesc": "Quadratic bezier curve with image mapping"
 	},
 	"type": "shader"
 }

--- a/addons/material_maker/nodes/curve.mmg
+++ b/addons/material_maker/nodes/curve.mmg
@@ -188,7 +188,9 @@
 				"step": 1,
 				"type": "float"
 			}
-		]
+		],
+		"shortdesc": "Curve",
+		"longdesc": "3-point bezier curve with image mapping"
 	},
 	"type": "shader"
 }

--- a/addons/material_maker/nodes/pattern.mmg
+++ b/addons/material_maker/nodes/pattern.mmg
@@ -205,7 +205,9 @@
 				"step": 1,
 				"type": "float"
 			}
-		]
+		],
+		"shortdesc": "Pattern",
+		"longdesc": "Generates pattern from common waveform shapes"
 	},
 	"type": "shader"
 }

--- a/addons/material_maker/nodes/polycurve.mmg
+++ b/addons/material_maker/nodes/polycurve.mmg
@@ -234,7 +234,9 @@
 				"shortdesc": "Ends",
 				"type": "boolean"
 			}
-		]
+		],
+		"shortdesc": "Poly Curve",
+		"longdesc": "Multi-point curve with image mapping"
 	},
 	"type": "shader"
 }

--- a/addons/material_maker/nodes/profile.mmg
+++ b/addons/material_maker/nodes/profile.mmg
@@ -124,7 +124,9 @@
 				"step": 0.01,
 				"type": "float"
 			}
-		]
+		],
+		"shortdesc": "Profile",
+		"longdesc": "Generates profile as a greyscale image from specified gradient"
 	},
 	"type": "shader"
 }

--- a/addons/material_maker/nodes/sdf3d_cone.mmg
+++ b/addons/material_maker/nodes/sdf3d_cone.mmg
@@ -66,7 +66,9 @@
 				"step": 1,
 				"type": "float"
 			}
-		]
+		],
+		"shortdesc": "Cone",
+		"longdesc": "Generates an infinite cone as a signed distance function"
 	},
 	"type": "shader"
 }


### PR DESCRIPTION
Added missing short/long descriptions for these nodes (based on the current documentation):

Buffer, Iterate Buffer, Debug, Export, Text, Pattern, Profile, Cone, Curve and Poly Curve

![add-node-desc](https://github.com/user-attachments/assets/cdc4a2be-4368-4b02-992d-64eca8ae9fdf)

