### PR TITLE
macOS: Option to enable/disable global menu

### DIFF
--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -64,7 +64,8 @@ const DEFAULT_CONFIG : Dictionary = {
 	node_minimize_button = true,
 	node_close_button = true,
 	ui_field_sensitivity = 1.0,
-	color_picker_floating = false
+	color_picker_floating = false,
+	ui_prefer_global_menu = true,
 }
 
 

--- a/material_maker/globals_menu_manager.gd
+++ b/material_maker/globals_menu_manager.gd
@@ -255,7 +255,7 @@ func create_menu(menu_def : Array, object : Object, menu_name : String, menu : M
 					if s == "Alt":
 						shortcut |= KEY_MASK_ALT
 					elif s == "Control":
-						shortcut |= KEY_MASK_CTRL
+						shortcut |= KEY_MASK_META if OS.get_name() == "macOS" else KEY_MASK_CTRL
 					elif s == "Shift":
 						shortcut |= KEY_MASK_SHIFT
 					else:

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -269,7 +269,7 @@ func update_menus() -> void:
 func do_update_menus() -> void:
 	# Create menus
 	var menu_bar_class
-	if DisplayServer.has_feature(DisplayServer.FEATURE_GLOBAL_MENU):
+	if DisplayServer.has_feature(DisplayServer.FEATURE_GLOBAL_MENU) and mm_globals.get_config("ui_prefer_global_menu"):
 		menu_bar_class = mm_globals.menu_manager.MenuBarDisplayServer
 	else:
 		menu_bar_class = mm_globals.menu_manager.MenuBarGodot

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -308,10 +308,10 @@ func _gui_input(event) -> void:
 				KEY_DELETE,KEY_BACKSPACE,KEY_X:
 					remove_selection()
 				KEY_C:
-					if OS.get_name() == "macOS":
+					if OS.get_name() == "macOS" and mm_globals.get_config("ui_prefer_global_menu"):
 						center_view()
 				KEY_MASK_ALT | KEY_S:
-					if OS.get_name() == "macOS":
+					if OS.get_name() == "macOS" and mm_globals.get_config("ui_prefer_global_menu"):
 						swap_node_inputs()
 				KEY_LEFT:
 					scroll_offset.x -= 0.5*size.x

--- a/material_maker/windows/preferences/preferences.gd
+++ b/material_maker/windows/preferences/preferences.gd
@@ -72,3 +72,4 @@ func _on_DownloadLanguage_closed():
 func _on_ready() -> void:
 	%WinTabletDriver.visible = OS.get_name() == "Windows"
 	%WinTabletDriverSpacer.visible = OS.get_name() == "Windows"
+	%PreferGlobalMenu.visible = OS.get_name() == "macOS"

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -209,6 +209,24 @@ text = "On"
 flat = false
 config_variable = "ui_single_window_mode"
 
+[node name="PreferGlobalMenu" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer" unique_id=777881648]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/PreferGlobalMenu" unique_id=1948109170]
+layout_mode = 2
+mouse_filter = 1
+text = "Prefer global menu (requires restart)"
+
+[node name="GuiPreferGlobalMenu" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/PreferGlobalMenu" unique_id=1488046250 instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+tooltip_text = "Prefer the use of global menu."
+text = "On"
+flat = false
+config_variable = "ui_prefer_global_menu"
+
 [node name="Spacer5" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer" unique_id=1191755573]
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2


### PR DESCRIPTION
Adds a preference option for macOS to allow toggling between built-in/global menu (defaults to global). This option is only visible on a macOS device.

<img width="699" height="398" alt="image" src="https://github.com/user-attachments/assets/020c3b01-c167-4cd4-9cba-29869df0daaf" />

https://github.com/user-attachments/assets/95e0b2f6-cfce-469c-a38c-8293f1ebafd5
