### PR TITLE
Remove Vec3/Math nodes' input labels

### DIFF
--- a/addons/material_maker/nodes/math.mmg
+++ b/addons/material_maker/nodes/math.mmg
@@ -26,7 +26,7 @@
 		"inputs": [
 			{
 				"default": "$default_in1",
-				"label": "2:A",
+				"label": "2:",
 				"longdesc": "The A operand",
 				"name": "in1",
 				"shortdesc": "A",
@@ -34,7 +34,7 @@
 			},
 			{
 				"default": "$default_in2",
-				"label": "B",
+				"label": "",
 				"longdesc": "The B operand",
 				"name": "in2",
 				"shortdesc": "B",

--- a/addons/material_maker/nodes/math_v3.mmg
+++ b/addons/material_maker/nodes/math_v3.mmg
@@ -25,7 +25,7 @@
 		"inputs": [
 			{
 				"default": "vec3($d_in1_x, $d_in1_y, $d_in1_z)",
-				"label": "2:A",
+				"label": "2:",
 				"longdesc": "The A operand",
 				"name": "in1",
 				"shortdesc": "A",
@@ -33,7 +33,7 @@
 			},
 			{
 				"default": "vec3($d_in2_x, $d_in2_y, $d_in2_z)",
-				"label": "B",
+				"label": "",
 				"longdesc": "The B operand",
 				"name": "in2",
 				"shortdesc": "B",


### PR DESCRIPTION
It's already possible to infer that the first two ports are A and B(also visible on ports hover) so these are redundant. This also makes it look cleaner.

<img width="621" alt="image" src="https://github.com/user-attachments/assets/31428911-8b59-4536-ba5c-e8fa7d04c7d3" />
