### PR TITLE
Fix epic logo visibility in about dialog for light/dark themes

### DIFF
--- a/material_maker/windows/about/about.gd
+++ b/material_maker/windows/about/about.gd
@@ -87,3 +87,9 @@ func _ready() -> void:
 
 func open_url(url) -> void:
 	OS.shell_open(url)
+
+func _notification(what: int) -> void:
+	match what:
+		NOTIFICATION_THEME_CHANGED:
+			%EpicLogo.material.set_shader_parameter("invert", 
+					"light" in mm_globals.main_window.theme.resource_path)

--- a/material_maker/windows/about/about.tscn
+++ b/material_maker/windows/about/about.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://btww87u0o4x7t"]
+[gd_scene load_steps=15 format=3 uid="uid://btww87u0o4x7t"]
 
 [ext_resource type="Script" uid="uid://c80e0om4076tc" path="res://material_maker/windows/about/about.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://uwqukrk00ios" path="res://material_maker/windows/about/github.png" id="2"]
@@ -11,6 +11,25 @@
 [ext_resource type="Texture2D" uid="uid://dvniks5a8tybt" path="res://material_maker/windows/about/discord.png" id="10"]
 [ext_resource type="Texture2D" uid="uid://btvwy8odw2nmx" path="res://material_maker/windows/about/patreon.png" id="11"]
 [ext_resource type="Texture2D" uid="uid://t53vu231awns" path="res://material_maker/windows/about/epic_megagrant.svg" id="12"]
+
+[sub_resource type="Shader" id="Shader_0an10"]
+code = "shader_type canvas_item;
+
+uniform sampler2D tex;
+uniform bool invert = false;
+
+void fragment() {
+	vec4 col = texture(tex, UV);
+	COLOR = invert ? col : vec4(1.0-col.rgb, col.a);
+}
+"
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_a5pf6"]
+shader = SubResource("Shader_0an10")
+shader_parameter/tex = ExtResource("12")
+shader_parameter/invert = false
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_0an10"]
 
 [node name="About" type="Window"]
 title = "About Material Maker"
@@ -88,6 +107,7 @@ theme_override_constants/h_separation = 16
 columns = 2
 
 [node name="Donors" type="ScrollContainer" parent="HBoxContainer/VBoxContainer/VBoxContainer"]
+visible = false
 layout_mode = 2
 metadata/_tab_index = 1
 
@@ -104,10 +124,12 @@ layout_mode = 2
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="TextureRect" type="TextureRect" parent="HBoxContainer/VBoxContainer/VBoxContainer/Donors/VBoxContainer/HBoxContainer"]
+[node name="EpicLogo" type="TextureRect" parent="HBoxContainer/VBoxContainer/VBoxContainer/Donors/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+material = SubResource("ShaderMaterial_a5pf6")
 custom_minimum_size = Vector2(96, 96)
 layout_mode = 2
-texture = ExtResource("12")
+texture = SubResource("PlaceholderTexture2D_0an10")
 expand_mode = 1
 
 [node name="Node" type="Control" parent="HBoxContainer/VBoxContainer/VBoxContainer/Donors/VBoxContainer/HBoxContainer"]


### PR DESCRIPTION
Before / After
![epic_before_after](https://github.com/user-attachments/assets/18b3849c-4db3-47be-a3c0-efc88db830a9)
