### PR TITLE
Fix mac ci 'hdiutil: create failed - Resource busy' error

### DIFF
--- a/.github/workflows/dev-desktop-builds.yml
+++ b/.github/workflows/dev-desktop-builds.yml
@@ -205,7 +205,7 @@ jobs:
           #hdiutil create -srcfolder ./build/mac -fs HFS+ -volname material_maker material_maker_${{ env.MM_RELEASE }}.dmg
           wget https://github.com/create-dmg/create-dmg/archive/refs/tags/v1.2.2.zip
           unzip v1.2.2.zip
-          create-dmg-1.2.2/create-dmg --volname "Material Maker" --icon-size 128 --background ./bg.png --window-size 540 330 --icon "Material Maker.app" 158 125 --app-drop-link 384 125 --hide-extension "Material Maker.app" ./build/mac/material_maker_${{ env.MM_RELEASE }}.dmg ./build/mac
+          create-dmg-1.2.2/create-dmg --volname "Material Maker" --icon-size 128 --background ./bg.png --window-size 540 330 --icon "Material Maker.app" 158 125 --app-drop-link 384 125 --hide-extension "Material Maker.app" --no-internet-enable ./build/mac/material_maker_${{ env.MM_RELEASE }}.dmg ./build/mac
       - name: Notarizing ✍️
         if: ${{ github.event.inputs.sign_macos == 'true' }}
         env:


### PR DESCRIPTION
Sometimes mac build fails and this error happens: `hdiutil: create failed - Resource busy`

Have a look at this seems like this happens randomly and the create-dmg already retries the (un)mounting several times, I guess perhaps the retries could be increased or really just trigger another build

https://github.com/search?q=repo%3Acreate-dmg%2Fcreate-dmg+hdiutil%3A+create+failed+-+Resource+busy&type=issues