### PR TITLE
Fix crash using mesh map node with custom model without UVs

### DIFF
--- a/addons/material_maker/map_generator/map_generator.gd
+++ b/addons/material_maker/map_generator/map_generator.gd
@@ -198,7 +198,7 @@ static func generate(mesh : Mesh, map : String, size : int, texture : MMTexture)
 static var busy : bool = false
 
 static func get_map(mesh : Mesh, map : String, size : int = 2048, force_generate : bool = false) -> MMTexture:
-	if mesh == null or size <= 0:
+	if mesh == null or size <= 0 or mesh.surface_get_arrays(0)[Mesh.ARRAY_TEX_UV] == null:
 		if error_texture == null:
 			error_texture = MMTexture.new()
 			var image : Image = Image.create(1, 1, 0, Image.FORMAT_RGBAH)


### PR DESCRIPTION
Currently MM crashes if a mesh map node is in the graph and a custom mesh without uvs is imported. This makes it so that it behaves the same as when there isn't a custom mesh selected.

**Current:**

https://github.com/user-attachments/assets/e3afd2f1-7a92-43ef-91f4-fab3031c4021

**This PR:**

https://github.com/user-attachments/assets/9fb1af54-3aad-4acf-ab0c-42c65c8f4d2d

