### PR TITLE
Remove AO export for Blender export target

### DIFF
--- a/addons/material_maker/nodes/material.mmg
+++ b/addons/material_maker/nodes/material.mmg
@@ -73,12 +73,6 @@
 						"file_name": "$(path_prefix)_emission.png",
 						"output": 2,
 						"type": "texture"
-					},
-					{
-						"conditions": "$(connected:ao_tex)",
-						"file_name": "$(path_prefix)_occlusion.exr",
-						"output": 9,
-						"type": "texture"
 					}
 				]
 			},

--- a/addons/material_maker/nodes/material_tesselated.mmg
+++ b/addons/material_maker/nodes/material_tesselated.mmg
@@ -74,12 +74,6 @@
 						"file_name": "$(path_prefix)_emission.png",
 						"output": 2,
 						"type": "texture"
-					},
-					{
-						"conditions": "$(connected:ao_tex)",
-						"file_name": "$(path_prefix)_occlusion.exr",
-						"output": 9,
-						"type": "texture"
 					}
 				]
 			},


### PR DESCRIPTION
Based on suggestion(s) from @tar0x(via Official Discord):

>Blender export target should not export AO map as neither cycles nor eevee use that map.

>This can be done for artistic vision, but it's not realistic. if one want to have realistic render, it's not advised. Cycles has light traced AO and eevee has SSAO
