### PR TITLE
Round spiral gradient default zoom to nearest decimal

### DIFF
--- a/addons/material_maker/nodes/spiral_gradient.mmg
+++ b/addons/material_maker/nodes/spiral_gradient.mmg
@@ -26,7 +26,7 @@
 			],
 			"type": "Gradient"
 		},
-		"perspective": 0.285821,
+		"perspective": 0.3,
 		"use_perspective": true
 	},
 	"seed_int": 0,

--- a/material_maker/library/base.json
+++ b/material_maker/library/base.json
@@ -227,7 +227,7 @@
 					],
 					"type": "Gradient"
 				},
-				"perspective": 0.285821,
+				"perspective": 0.3,
 				"use_perspective": true
 			},
 			"tree_item": "Simple/Gradient/Spiral",


### PR DESCRIPTION
Spiral gradient's default zoom has a "weirdly-specific" value, this PR rounds it to the nearest decimal, similar to what https://github.com/RodZill4/material-maker/pull/835 does