### PR TITLE
Select next item in add-node popup with one keypress

### DIFF
--- a/material_maker/windows/add_node_popup/add_node_popup.gd
+++ b/material_maker/windows/add_node_popup/add_node_popup.gd
@@ -199,7 +199,7 @@ func _unhandled_input(event) -> void:
 func _on_filter_gui_input(event: InputEvent) -> void:
 	if event.is_action("ui_down"):
 		%List.grab_focus()
-		%List.select(0)
+		%List.select(1)
 
 
 func _on_list_gui_input(event: InputEvent) -> void:


### PR DESCRIPTION
Since the first item is already selected it should navigate to the 2nd item instead of 1st

Current / This PR:

https://github.com/user-attachments/assets/e0c04440-9a4c-46da-aa51-c907361c881d

