### PR TITLE
Remove `modern.tres` custom theme in project settings

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -69,7 +69,6 @@ enabled=PackedStringArray("res://addons/gut/plugin.cfg")
 [gui]
 
 timers/tooltip_delay_sec=0.1
-theme/custom="res://material_maker/theme/modern.tres"
 
 [input]
 


### PR DESCRIPTION
Resource no longer exists/used thus it can be removed. Also fixes associated warnings with it