### PR TITLE
Check if node can be minimized before shortcut action

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -677,7 +677,8 @@ func remove_selection() -> void:
 func minimize_selection() -> void:
 	for c in get_children():
 		if c is GraphElement and c.selected:
-			c.on_minimize_pressed()
+			if c.has_method("on_minimize_pressed"):
+				c.on_minimize_pressed()
 
 # Maybe move this to gen_graph...
 func serialize_selection(nodes = []) -> Dictionary:


### PR DESCRIPTION
Fixes crash in the editor (i.e. crash when trying to minimize a reroute node)