### PR TITLE
Fix orphaned tab nodes in flexible layout

### DIFF
--- a/addons/flexible_layout/flexible_tabs.gd
+++ b/addons/flexible_layout/flexible_tabs.gd
@@ -33,7 +33,11 @@ func erase(ft : Control):
 	var index : int = get_control_index(ft)
 	if ft.get_parent() != null:
 		ft.get_parent().remove_child(ft)
-	$Tabs.remove_child($Tabs.get_child(index))
+
+	var tab_node = $Tabs.get_child(index)
+	$Tabs.remove_child(tab_node)
+	tab_node.queue_free()
+
 	if index == current:
 		if $Tabs.get_child_count() > 0:
 			set_current(0)


### PR DESCRIPTION
When closing and reopening panels in the flexible layout, orphaned tab nodes accumulate in memory because erase() only removes them from the scene tree but doesn’t free them.

Since add() instantiates new tab nodes each time, the old nodes build up and cause a slow memory leak.

This PR adds a queue_free() call in erase() to properly clean up those tab nodes, fixing the leak.