### PR TITLE
Free dynamically added preview nodes on deletion of generic graph nodes

### DIFF
--- a/material_maker/nodes/generic/generic.gd
+++ b/material_maker/nodes/generic/generic.gd
@@ -17,6 +17,14 @@ const GENERIC_ICON : Texture2D = preload("res://material_maker/icons/add_generic
 func _ready() -> void:
 	super._ready()
 	add_to_group("updated_from_locale")
+	
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_PREDELETE:
+		if is_instance_valid(preview_timer):
+			preview_timer.stop()
+			preview_timer.queue_free()
+		if is_instance_valid(preview):
+			preview.queue_free()
 
 func init_buttons():
 	super.init_buttons()


### PR DESCRIPTION
This PR implements the _notification method with NOTIFICATION_PREDELETE in MMGraphNodeGeneric to properly free dynamically added preview and preview_timer nodes when the graph node is deleted.

Previously, these nodes were removed with remove_child() but not freed, causing orphaned preview nodes.