### PR TITLE
Fix deprecated shader parameter warnings on gd4 material import

### DIFF
--- a/addons/material_maker/nodes/material_3d.mmg
+++ b/addons/material_maker/nodes/material_3d.mmg
@@ -98,7 +98,7 @@
 							"[resource]",
 							"shader = ExtResource( 1 )",
 							"$begin_buffers",
-							"shader_param/texture_$(buffer_index) = ExtResource( $(expr:$(buffer_index)+1) )",
+							"shader_parameter/texture_$(buffer_index) = ExtResource( $(expr:$(buffer_index)+1) )",
 							"$end_buffers",
 							""
 						],

--- a/addons/material_maker/nodes/material_dynamic.mmg
+++ b/addons/material_maker/nodes/material_dynamic.mmg
@@ -145,7 +145,7 @@
 							"[resource]",
 							"shader = ExtResource( 1 )",
 							"$begin_buffers",
-							"shader_param/texture_$(buffer_index) = ExtResource( $(expr:$(buffer_index)+1) )",
+							"shader_parameter/texture_$(buffer_index) = ExtResource( $(expr:$(buffer_index)+1) )",
 							"$end_buffers",
 							""
 						],

--- a/addons/material_maker/nodes/material_raymarching.mmg
+++ b/addons/material_maker/nodes/material_raymarching.mmg
@@ -146,7 +146,7 @@
 							"[resource]",
 							"shader = ExtResource( 1 )",
 							"$begin_buffers",
-							"shader_param/texture_$(buffer_index) = ExtResource( $(expr:$(buffer_index)+1) )",
+							"shader_parameter/texture_$(buffer_index) = ExtResource( $(expr:$(buffer_index)+1) )",
 							"$end_buffers",
 							""
 						],

--- a/addons/material_maker/nodes/material_unlit.mmg
+++ b/addons/material_maker/nodes/material_unlit.mmg
@@ -15,7 +15,7 @@
 		"code": "",
 		"custom": "",
 		"exports": {
-			"Godot/CanvasItem": {
+			"Godot 3/CanvasItem": {
 				"export_extension": "tres",
 				"files": [
 					{
@@ -70,7 +70,7 @@
 					}
 				]
 			},
-			"Godot/Spatial": {
+			"Godot 3/Spatial": {
 				"export_extension": "tres",
 				"files": [
 					{
@@ -85,6 +85,117 @@
 							"shader = ExtResource( 1 )",
 							"$begin_buffers",
 							"shader_param/texture_$(buffer_index) = ExtResource( $(expr:$(buffer_index)+1) )",
+							"$end_buffers",
+							""
+						],
+						"type": "template"
+					},
+					{
+						"file_name": "$(path_prefix).gdshader",
+						"template": [
+							"shader_type spatial;",
+							"$begin_generate",
+							"render_mode unshaded, blend_$blend;",
+							"$end_generate",
+							"uniform vec3 uv1_scale = vec3(1.0, 1.0, 1.0);",
+							"uniform vec3 uv1_offset = vec3(0.0, 0.0, 0.0);",
+							"uniform float variation = 0.0;",
+							"varying float elapsed_time;",
+							"void vertex() {",
+							"\telapsed_time = TIME;",
+							"\tUV = UV*uv1_scale.xy+uv1_offset.xy;",
+							"}",
+							"$definitions float_uniform_to_const,rename_buffers",
+							"void fragment() {",
+							"\tfloat _seed_variation_ = variation;",
+							"\tvec2 uv = fract(UV);",
+							"$begin_generate rename_buffers",
+							"\tvec4 color_tex = $color_tex(uv);",
+							"\tcolor_tex = mix(pow((color_tex + vec4(0.055)) * (1.0 / (1.0 + 0.055)),vec4(2.4)),color_tex * (1.0 / 12.92),lessThan(color_tex,vec4(0.04045)));",
+							"\tALBEDO = color_tex.rgb;",
+							"\tALPHA = color_tex.a;",
+							"$end_generate",
+							"}",
+							""
+						],
+						"type": "template"
+					},
+					{
+						"file_name": "$(path_prefix)_texture_$(buffer_index).png",
+						"type": "buffers"
+					}
+				]
+			},
+			"Godot 4/CanvasItem": {
+				"export_extension": "tres",
+				"files": [
+					{
+						"file_name": "$(path_prefix).tres",
+						"template": [
+							"[gd_resource type=\"ShaderMaterial\" load_steps=2 format=2]",
+							"[ext_resource path=\"$(file_prefix).gdshader\" type=\"Shader\" id=1]",
+							"$begin_buffers",
+							"[ext_resource path=\"$(file_prefix)_texture_$(buffer_index).png\" type=\"Texture\" id=$(expr:$(buffer_index)+1)]",
+							"$end_buffers",
+							"[resource]",
+							"shader = ExtResource( 1 )",
+							"$begin_buffers",
+							"shader_parameter/texture_$(buffer_index) = ExtResource( $(expr:$(buffer_index)+1) )",
+							"$end_buffers",
+							""
+						],
+						"type": "template"
+					},
+					{
+						"file_name": "$(path_prefix).gdshader",
+						"template": [
+							"shader_type canvas_item;",
+							"$begin_generate",
+							"render_mode unshaded, blend_$blend;",
+							"$end_generate",
+							"uniform vec3 uv1_scale = vec3(1.0, 1.0, 1.0);",
+							"uniform vec3 uv1_offset = vec3(0.0, 0.0, 0.0);",
+							"uniform float variation = 0.0;",
+							"varying float elapsed_time;",
+							"void vertex() {",
+							"\telapsed_time = TIME;",
+							"\tUV = UV*uv1_scale.xy+uv1_offset.xy;",
+							"}",
+							"$definitions float_uniform_to_const,rename_buffers",
+							"void fragment() {",
+							"\tfloat _seed_variation_ = variation;",
+							"\tvec2 uv = fract(UV);",
+							"$begin_generate rename_buffers",
+							"\tvec4 color_tex = $color_tex(uv);",
+							"\tcolor_tex = mix(pow((color_tex + vec4(0.055)) * (1.0 / (1.0 + 0.055)),vec4(2.4)),color_tex * (1.0 / 12.92),lessThan(color_tex,vec4(0.04045)));",
+							"\tCOLOR = color_tex;",
+							"$end_generate",
+							"}",
+							""
+						],
+						"type": "template"
+					},
+					{
+						"file_name": "$(path_prefix)_texture_$(buffer_index).png",
+						"type": "buffers"
+					}
+				]
+			},
+			"Godot 4/Spatial": {
+				"export_extension": "tres",
+				"files": [
+					{
+						"file_name": "$(path_prefix).tres",
+						"template": [
+							"[gd_resource type=\"ShaderMaterial\" load_steps=2 format=2]",
+							"[ext_resource path=\"$(file_prefix).gdshader\" type=\"Shader\" id=1]",
+							"$begin_buffers",
+							"[ext_resource path=\"$(file_prefix)_texture_$(buffer_index).png\" type=\"Texture\" id=$(expr:$(buffer_index)+1)]",
+							"$end_buffers",
+							"[resource]",
+							"shader = ExtResource( 1 )",
+							"$begin_buffers",
+							"shader_parameter/texture_$(buffer_index) = ExtResource( $(expr:$(buffer_index)+1) )",
 							"$end_buffers",
 							""
 						],


### PR DESCRIPTION
Should resolve https://github.com/RodZill4/material-maker/issues/631 - warnings like these:

![gd4warn](https://github.com/user-attachments/assets/7d425610-52c9-404d-8815-49b1d2a6c1a6)

This PR renames `shader_param` to `shader_parameter` for Godot 4 export targets as it was renamed (3D PBR, Dynamic PBR and Raymarching). For dynamic unlit material, new Godot 4 (Spatial/CanvasItem) targets are added to rename params for the .tres files.