### PR TITLE
Make remote param name LineEdit slightly longer

### DIFF
--- a/material_maker/nodes/remote/remote.gd
+++ b/material_maker/nodes/remote/remote.gd
@@ -16,6 +16,7 @@ func _ready():
 func add_control(text : String, control : Control, is_named_param : bool, short_description : String = "", long_description : String = "", is_first : bool = false, is_last : bool = false) -> void:
 	var line_edit : LineEdit = LineEdit.new()
 	line_edit.set_text(control.name)
+	line_edit.custom_minimum_size.x = 80
 	grid.add_child(line_edit)
 	line_edit.connect("text_changed", Callable(self, "on_param_name_changed").bind(control.name, line_edit))
 	line_edit.connect("text_submitted", Callable(self, "on_param_name_entered").bind(control.name, line_edit))
@@ -268,5 +269,3 @@ func on_exit_widget(widget) -> void:
 		for l in links[widget]:
 			l.queue_free()
 		links.erase(widget)
-
-


### PR DESCRIPTION
Currently their size makes the impression that the parameters are the same on creation but are in fact with numerical suffixes. This PR slightly extends the length for the control (i.e. `custom_minimum_size`  on x) to be able to accommodate the numbers. 

**Before:**

![image](https://github.com/user-attachments/assets/8e622e06-cd85-48d8-94b3-075fc487d407)


**After:**

![image](https://github.com/user-attachments/assets/e4f6a608-6766-481f-ab7d-cc738d7923d3)

