### PR TITLE
Fix cateogry-less library item contrast

### DIFF
--- a/material_maker/tools/library_manager/library_manager.gd
+++ b/material_maker/tools/library_manager/library_manager.gd
@@ -237,7 +237,7 @@ func get_section_color(section_name : String) -> Color:
 	for s in section_colors.keys():
 		if TranslationServer.translate(s) == section_name:
 			return section_colors[s]
-	return Color(0.0, 0.0, 0.0, 0.0)
+	return Color.DIM_GRAY
 
 func is_section_enabled(section_name : String) -> bool:
 	return disabled_sections.find(section_name) == -1


### PR DESCRIPTION
Currently library items that are not part of any of the predefined categories can be a bit hard to read in the add node popup, this improves the contrast by setting a brighter color:

![colorvs](https://github.com/user-attachments/assets/32bdcb03-0afb-4032-83ec-52fe97679324)