### PR TITLE
Duplicate nodes with inputs

### DIFF
--- a/material_maker/doc/user_interface_main_menu.rst
+++ b/material_maker/doc/user_interface_main_menu.rst
@@ -58,6 +58,8 @@ Edit menu
 
 * *Duplicate* creates a copy of the current selection without affecting the clipboard
 
+* *Duplicate with inputs* is similar to *Duplicate*, but with input links kept
+
 * *Select all* selects all nodes in the current graph view
 
 * *Select none* clears the selection in the current graph view

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -71,6 +71,7 @@ const MENU : Array[Dictionary] = [
 	{ menu="Edit/Copy", command="edit_copy", shortcut="Control+C" },
 	{ menu="Edit/Paste", command="edit_paste", shortcut="Control+V" },
 	{ menu="Edit/Duplicate", command="edit_duplicate", shortcut="Control+D" },
+	{ menu="Edit/Duplicate with inputs", command="edit_duplicate_with_inputs", shortcut="Control+Shift+D" },
 	{ menu="Edit/-" },
 	{ menu="Edit/Select All", command="edit_select_all", shortcut="Control+A" },
 	{ menu="Edit/Select None", command="edit_select_none", shortcut="Control+Shift+A" },
@@ -756,6 +757,14 @@ func edit_duplicate() -> void:
 	var graph_edit : MMGraphEdit = get_current_graph_edit()
 	if graph_edit != null:
 		graph_edit.duplicate_selected()
+
+func edit_duplicate_with_inputs() -> void:
+	var graph_edit : MMGraphEdit = get_current_graph_edit()
+	if graph_edit != null:
+		graph_edit.duplicate_selected_with_inputs()
+
+func edit_duplicate_with_inputs_is_disabled() -> bool:
+	return edit_cut_is_disabled()
 
 func edit_select_all() -> void:
 	var graph_edit : MMGraphEdit = get_current_graph_edit()

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -682,7 +682,7 @@ func minimize_selection() -> void:
 			c.on_minimize_pressed()
 
 # Maybe move this to gen_graph...
-func serialize_selection(nodes = []) -> Dictionary:
+func serialize_selection(nodes = [], with_inputs : bool = false) -> Dictionary:
 	var data = { nodes = [], connections = [] }
 	if nodes.is_empty():
 		for c in get_children():
@@ -702,7 +702,7 @@ func serialize_selection(nodes = []) -> Dictionary:
 	for c in get_connection_list():
 		var from = get_node(NodePath(c.from_node))
 		var to = get_node(NodePath(c.to_node))
-		if from != null and from.selected and to != null and to.selected:
+		if from != null and (from.selected or with_inputs) and to != null and to.selected:
 			var connection = c.duplicate(true)
 			connection.from = from.generator.name
 			connection.to = to.generator.name
@@ -753,6 +753,9 @@ func paste() -> void:
 
 func duplicate_selected() -> void:
 	do_paste(serialize_selection())
+
+func duplicate_selected_with_inputs() -> void:
+	do_paste(serialize_selection([], true))
 
 func select_all() -> void:
 	for c in get_children():


### PR DESCRIPTION
Allow duplicating nodes with their input links kept (<kbd>Ctrl</kbd>/<kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd>), similar to Blender:

https://github.com/user-attachments/assets/49c3e351-63dd-4335-94d7-ff96291d551f