### PR TITLE
Fix splines editor errors

### DIFF
--- a/material_maker/widgets/splines_edit/splines_editor.gd
+++ b/material_maker/widgets/splines_edit/splines_editor.gd
@@ -38,8 +38,10 @@ func _ready():
 	await get_tree().process_frame
 	get_window().content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
 	get_window().min_size = get_window().get_contents_minimum_size() * get_window().content_scale_factor
-	get_window().hide()
-	get_window().popup_centered()
+
+	if get_window().get_window_id() != DisplayServer.MAIN_WINDOW_ID:
+		get_window().hide()
+		get_window().popup_centered()
 
 	super._ready()
 	update_controls()


### PR DESCRIPTION
Fixes the following errors from the debugger:

```
splines_editor.gd:43 @ _ready(): Can't change visibility of main window.
splines_editor.gd:44 @ _ready(): Can't popup the main window.
```