### PR TITLE
Fix splashscreen glyph holes by increasing msdf size to 64

### DIFF
--- a/material_maker/fonts/vegur_regular.otf.import
+++ b/material_maker/fonts/vegur_regular.otf.import
@@ -18,7 +18,7 @@ generate_mipmaps=true
 disable_embedded_bitmaps=true
 multichannel_signed_distance_field=true
 msdf_pixel_range=8
-msdf_size=48
+msdf_size=64
 allow_system_fallback=true
 force_autohinter=true
 hinting=1
@@ -33,7 +33,8 @@ preload=[{
 "chars": [],
 "glyphs": [],
 "name": "Nouvelle configuration",
-"size": Vector2i(16, 0)
+"size": Vector2i(16, 0),
+&"variation_embolden": 0.0
 }]
 language_support={}
 script_support={}


### PR DESCRIPTION
Fixes holes in the splash screen glyphs by increasing msdf size for `vegur_regular.otf`

![holes](https://github.com/user-attachments/assets/50248cc1-9138-420f-bf23-e88366430f09)
