### PR TITLE
Improve idle fps tooltip in preferences

### DIFF
--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -182,8 +182,8 @@ text = "Idle FPS limit:"
 
 [node name="IdleFPSLimit" parent="VBoxContainer/TabContainer/General/FPSLimit" instance=ExtResource("3")]
 layout_mode = 2
-tooltip_text = "A higher FPS limit may result in smoother operation but may use more CPU/GPU resources.
-Higher values may increase power usage, leading to reduced battery life on laptops."
+tooltip_text = "FPS limit to use when window isn't focused to save CPU/GPU resources.
+Lower values may help reducing power usage, but could increase response time when window is focused again."
 config_variable = "idle_fps_limit"
 value = 20.0
 min_value = 1.0


### PR DESCRIPTION
Currently the tooltip uses the same text from FPS limit

This updates it to better describe what it do and potential caveat when using a small value:

![tooltip_idle_fps_pref](https://github.com/user-attachments/assets/165cb3c8-cf96-47fe-aaea-04a3c8a1a681)
