### PR TITLE
Fix opaque bg for tooltip/popup menu

### DIFF
--- a/material_maker/theme/default.tres
+++ b/material_maker/theme/default.tres
@@ -619,6 +619,8 @@ corner_radius_top_right = 2
 corner_radius_bottom_right = 2
 corner_radius_bottom_left = 2
 corner_detail = 4
+shadow_color = Color(0, 0, 0, 0.0588235)
+shadow_size = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_k2ns1"]
 bg_color = Color(0.8, 0.8, 0.8, 1)
@@ -843,6 +845,8 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 corner_detail = 4
+shadow_color = Color(0, 0, 0, 0.0588235)
+shadow_size = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_8sgsn"]
 content_margin_left = 3.0
@@ -959,6 +963,8 @@ corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 corner_detail = 4
+shadow_color = Color(0, 0, 0, 0.0588235)
+shadow_size = 4
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_iwtn1"]
 content_margin_left = 4.0

--- a/project.godot
+++ b/project.godot
@@ -55,6 +55,7 @@ window/size/viewport_height=1
 window/size/borderless=true
 window/size/window_width_override=1
 window/size/window_height_override=1
+window/per_pixel_transparency/allowed=true
 window/handheld/orientation.Android="sensor_landscape"
 
 [editor]


### PR DESCRIPTION
This is most noticeable on light themes

**Before/After:**
![test](https://github.com/user-attachments/assets/73ffdf9b-07c7-404b-ad36-c693fd4d50d2)