### PR TITLE
Fix classic/dark theme FileDialog panel colors

### DIFF
--- a/material_maker/theme/classic_base.tres
+++ b/material_maker/theme/classic_base.tres
@@ -95,6 +95,13 @@ region = Rect2(96, 112, 16, 16)
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_meah8"]
 bg_color = Color(0.14902, 0.172549, 0.231373, 1)
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7b2nb"]
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+bg_color = Color(0.118, 0.145333, 0.2, 1)
+
 [sub_resource type="AtlasTexture" id="AtlasTexture_m1w7u"]
 atlas = ExtResource("1_fw8f4")
 region = Rect2(0, 128, 16, 16)
@@ -764,13 +771,6 @@ corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7b2nb"]
-content_margin_left = 5.0
-content_margin_top = 5.0
-content_margin_right = 5.0
-content_margin_bottom = 5.0
-bg_color = Color(0.180392, 0.207843, 0.278431, 1)
-
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_l61pc"]
 content_margin_left = 5.0
 content_margin_top = 5.0
@@ -891,6 +891,7 @@ CodeEdit/colors/single_line_comment_color = Color(0, 0.509804, 0, 1)
 CodeEdit/colors/symbol_color = Color(1, 1, 1, 1)
 CodeEdit/colors/type_color = Color(1, 1, 0.878431, 1)
 CodeEdit/styles/normal = SubResource("StyleBoxFlat_meah8")
+FileDialog/styles/panel = SubResource("StyleBoxFlat_7b2nb")
 GraphEdit/colors/connection_knife = Color(1, 1, 1, 1)
 GraphEdit/colors/grid_major = Color(0.321569, 0.337255, 0.384314, 1)
 GraphEdit/colors/grid_minor = Color(0.321569, 0.337255, 0.384314, 1)

--- a/material_maker/theme/default light.tres
+++ b/material_maker/theme/default light.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" script_class="EnhancedTheme" load_steps=56 format=3 uid="uid://u00kx2lkkx8j"]
+[gd_resource type="Theme" script_class="EnhancedTheme" load_steps=57 format=3 uid="uid://u00kx2lkkx8j"]
 
 [ext_resource type="Theme" uid="uid://b628lwfk6ig2c" path="res://material_maker/theme/default.tres" id="1_ugsao"]
 [ext_resource type="Script" uid="uid://3ga2k3abkk0d" path="res://material_maker/theme/enhanced_theme_system/color_swap.gd" id="4_rhf2q"]
@@ -89,13 +89,6 @@ script = ExtResource("4_rhf2q")
 name = "Hover"
 orig = Color(0.933333, 0.678431, 0.909804, 1)
 target = Color(0.398892, 0.209142, 0.42588, 1)
-
-[sub_resource type="Resource" id="Resource_jh8b5"]
-script = ExtResource("4_rhf2q")
-name = "MM_LibrarySectionButton"
-orig = Color(1, 1, 1, 1)
-target = Color(1, 1, 1, 1)
-metadata/_custom_type_script = "uid://3ga2k3abkk0d"
 
 [sub_resource type="Resource" id="Resource_ub5ur"]
 script = ExtResource("4_rhf2q")
@@ -330,15 +323,30 @@ orig = Color(0.301961, 0.305882, 0.309804, 1)
 target = Color(0.2134, 0.2167, 0.22, 0.470588)
 metadata/_custom_type_script = "uid://3ga2k3abkk0d"
 
+[sub_resource type="Resource" id="Resource_jh8b5"]
+script = ExtResource("4_rhf2q")
+name = "FileDialogPanel"
+orig = Color(0.13333334, 0.14509805, 0.14509805, 1)
+target = Color(0.763672, 0.763672, 0.763672, 1)
+metadata/_custom_type_script = "uid://3ga2k3abkk0d"
+
 [sub_resource type="Resource" id="Resource_2d8ce"]
+script = ExtResource("4_rhf2q")
+name = "MM_LibrarySectionButton"
+orig = Color(1, 1, 1, 1)
+target = Color(1, 1, 1, 1)
+metadata/_custom_type_script = "uid://3ga2k3abkk0d"
+
+[sub_resource type="Resource" id="Resource_qqxbn"]
 script = ExtResource("4_rhf2q")
 name = "GraphEditConnectionKnife"
 orig = Color(0.99215686, 0.9843137, 1, 1)
+target = Color(1, 1, 1, 1)
 metadata/_custom_type_script = "uid://3ga2k3abkk0d"
 
 [resource]
 script = ExtResource("5_fagh3")
 base_theme = ExtResource("1_ugsao")
 font_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_silay"), SubResource("Resource_eavso"), SubResource("Resource_1jhxl"), SubResource("Resource_qiwix"), SubResource("Resource_5yhcl"), SubResource("Resource_vdnfu"), SubResource("Resource_21aar"), SubResource("Resource_us4qf"), SubResource("Resource_3wcad"), SubResource("Resource_mhcke")])
-icon_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_cisvi"), SubResource("Resource_j2h7k"), SubResource("Resource_8dhbo"), SubResource("Resource_5oh4i"), SubResource("Resource_jh8b5")])
-theme_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_ub5ur"), SubResource("Resource_5rv7m"), SubResource("Resource_xqbwo"), SubResource("Resource_a2t6i"), SubResource("Resource_pekt7"), SubResource("Resource_vbpcr"), SubResource("Resource_qngft"), SubResource("Resource_5mixu"), SubResource("Resource_kxmra"), SubResource("Resource_siafh"), SubResource("Resource_s732t"), SubResource("Resource_j1t84"), SubResource("Resource_g7e3b"), SubResource("Resource_oirgf"), SubResource("Resource_1pump"), SubResource("Resource_fxm05"), SubResource("Resource_mfxjg"), SubResource("Resource_upxps"), SubResource("Resource_upxps"), SubResource("Resource_lk0mo"), SubResource("Resource_sgt8g"), SubResource("Resource_p6yfp"), SubResource("Resource_mntha"), SubResource("Resource_5l403"), SubResource("Resource_qx1ic"), SubResource("Resource_skxhu"), SubResource("Resource_gf74u"), SubResource("Resource_6iwcg"), SubResource("Resource_emwrq"), SubResource("Resource_g0345"), SubResource("Resource_mqr67"), SubResource("Resource_enwto"), SubResource("Resource_t0kvp"), SubResource("Resource_tw3yc"), SubResource("Resource_5w06f"), SubResource("Resource_m8hbw"), SubResource("Resource_xnhnj"), SubResource("Resource_2d8ce")])
+icon_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_cisvi"), SubResource("Resource_j2h7k"), SubResource("Resource_8dhbo"), SubResource("Resource_5oh4i")])
+theme_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_ub5ur"), SubResource("Resource_5rv7m"), SubResource("Resource_xqbwo"), SubResource("Resource_a2t6i"), SubResource("Resource_pekt7"), SubResource("Resource_vbpcr"), SubResource("Resource_qngft"), SubResource("Resource_5mixu"), SubResource("Resource_kxmra"), SubResource("Resource_siafh"), SubResource("Resource_s732t"), SubResource("Resource_j1t84"), SubResource("Resource_g7e3b"), SubResource("Resource_oirgf"), SubResource("Resource_1pump"), SubResource("Resource_fxm05"), SubResource("Resource_mfxjg"), SubResource("Resource_upxps"), SubResource("Resource_upxps"), SubResource("Resource_lk0mo"), SubResource("Resource_sgt8g"), SubResource("Resource_p6yfp"), SubResource("Resource_mntha"), SubResource("Resource_5l403"), SubResource("Resource_qx1ic"), SubResource("Resource_skxhu"), SubResource("Resource_gf74u"), SubResource("Resource_6iwcg"), SubResource("Resource_emwrq"), SubResource("Resource_g0345"), SubResource("Resource_mqr67"), SubResource("Resource_enwto"), SubResource("Resource_t0kvp"), SubResource("Resource_tw3yc"), SubResource("Resource_5w06f"), SubResource("Resource_m8hbw"), SubResource("Resource_xnhnj"), SubResource("Resource_jh8b5"), SubResource("Resource_2d8ce"), SubResource("Resource_qqxbn")])

--- a/material_maker/theme/default.tres
+++ b/material_maker/theme/default.tres
@@ -105,6 +105,13 @@ metadata/recolor = false
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_oy0ko"]
 bg_color = Color(0.0980392, 0.0980392, 0.101961, 1)
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ck0hb"]
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+bg_color = Color(0.13333334, 0.14509805, 0.14509805, 1)
+
 [sub_resource type="AtlasTexture" id="AtlasTexture_m1w7u"]
 atlas = ExtResource("1_s43fy")
 region = Rect2(0, 128, 16, 16)
@@ -568,13 +575,6 @@ region = Rect2(96, 96, 16, 16)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ahanl"]
 bg_color = Color(0.266667, 0.278431, 0.301961, 1)
-corner_radius_top_left = 3
-corner_radius_top_right = 3
-corner_radius_bottom_right = 3
-corner_radius_bottom_left = 3
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ck0hb"]
-bg_color = Color(0, 0, 0, 1)
 corner_radius_top_left = 3
 corner_radius_top_right = 3
 corner_radius_bottom_right = 3
@@ -1112,6 +1112,7 @@ CodeEdit/styles/normal = SubResource("StyleBoxFlat_oy0ko")
 FileDialog/colors/file_disabled_color = Color(0.301961, 0.305882, 0.309804, 1)
 FileDialog/colors/file_icon_color = Color(0.698039, 0.698039, 0.698039, 1)
 FileDialog/colors/folder_icon_color = Color(0.698039, 0.698039, 0.698039, 1)
+FileDialog/styles/panel = SubResource("StyleBoxFlat_ck0hb")
 GraphEdit/colors/connection_knife = Color(0.99215686, 0.9843137, 1, 1)
 GraphEdit/colors/grid_major = Color(0.137255, 0.141176, 0.152941, 1)
 GraphEdit/colors/grid_minor = Color(0.137255, 0.141176, 0.152941, 1)


### PR DESCRIPTION
For dark theme a slightly lighter color is chosen to improve contrast against recent/favorite panels

![vs](https://github.com/user-attachments/assets/69fc4afd-4189-4802-b6d3-8c975826da36)
