### PR TITLE
Vertical-tabs preferences

### DIFF
--- a/material_maker/theme/classic_base.tres
+++ b/material_maker/theme/classic_base.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=143 format=3 uid="uid://w487nirev8y5"]
+[gd_resource type="Theme" load_steps=144 format=3 uid="uid://w487nirev8y5"]
 
 [ext_resource type="Texture2D" uid="uid://1s0c37uoj4rf" path="res://material_maker/theme/default_theme_icons.svg" id="1_fw8f4"]
 [ext_resource type="FontFile" uid="uid://lro0qdrhfytt" path="res://material_maker/theme/font_rubik/Rubik-Light.ttf" id="3_h5b0q"]
@@ -612,6 +612,12 @@ corner_detail = 4
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_5e0gw"]
 content_margin_top = 3.0
 
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_vbdqj"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_u368o"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wc6mb"]
@@ -1069,6 +1075,8 @@ MM_PanelMenuSubPanelLabel/base_type = &"Label"
 MM_PanelMenuSubPanelLabel/colors/font_color = Color(0.881937, 0.881937, 0.881937, 1)
 MM_PanelMenuSubPanelLabel/font_sizes/font_size = 15
 MM_PanelMenuSubPanelLabel/styles/normal = SubResource("StyleBoxEmpty_5e0gw")
+MM_PreferenceTab/base_type = &"ScrollContainer"
+MM_PreferenceTab/styles/panel = SubResource("StyleBoxEmpty_vbdqj")
 MM_ProjectsBackground/base_type = &"Panel"
 MM_ProjectsBackground/styles/panel = SubResource("StyleBoxEmpty_u368o")
 MM_Reroute/base_type = &"GraphNode"

--- a/material_maker/theme/default.tres
+++ b/material_maker/theme/default.tres
@@ -818,6 +818,12 @@ corner_detail = 4
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_5e0gw"]
 content_margin_top = 3.0
 
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_rqlqa"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1k0sx"]
 bg_color = Color(0.0941176, 0.0980392, 0.101961, 1)
 corner_radius_top_right = 4
@@ -1353,6 +1359,8 @@ MM_PanelMenuSubPanelLabel/base_type = &"Label"
 MM_PanelMenuSubPanelLabel/colors/font_color = Color(0.556, 0.556, 0.556, 1)
 MM_PanelMenuSubPanelLabel/font_sizes/font_size = 15
 MM_PanelMenuSubPanelLabel/styles/normal = SubResource("StyleBoxEmpty_5e0gw")
+MM_PreferenceTab/base_type = &"ScrollContainer"
+MM_PreferenceTab/styles/panel = SubResource("StyleBoxEmpty_rqlqa")
 MM_ProjectsBackground/base_type = &"Panel"
 MM_ProjectsBackground/styles/panel = SubResource("StyleBoxFlat_1k0sx")
 MM_Reroute/base_type = &"GraphNode"

--- a/material_maker/windows/preferences/bool_option.gd
+++ b/material_maker/windows/preferences/bool_option.gd
@@ -1,5 +1,7 @@
 extends CheckBox
 
+class_name BoolOption
+
 @export var config_variable : String
 
 func _ready() -> void:

--- a/material_maker/windows/preferences/bool_option.tscn
+++ b/material_maker/windows/preferences/bool_option.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://drg0s4lftblx3"]
 
-[ext_resource type="Script" path="res://material_maker/windows/preferences/bool_option.gd" id="1"]
+[ext_resource type="Script" uid="uid://r578e00kfyhy" path="res://material_maker/windows/preferences/bool_option.gd" id="1"]
 
 [node name="BooleanOption" type="CheckBox"]
 offset_right = 308.0

--- a/material_maker/windows/preferences/float_option.gd
+++ b/material_maker/windows/preferences/float_option.gd
@@ -1,5 +1,7 @@
 extends "res://material_maker/widgets/float_edit/float_edit.gd"
 
+class_name FloatOption
+
 @export var config_variable : String
 
 func _ready() -> void:

--- a/material_maker/windows/preferences/preferences.gd
+++ b/material_maker/windows/preferences/preferences.gd
@@ -14,7 +14,7 @@ func edit_preferences(c : ConfigFile) -> void:
 	main_window.add_dialog(self)
 	config_changed.connect(main_window.on_config_changed)
 	update_controls(self)
-	size = $VBoxContainer.get_combined_minimum_size() * content_scale_factor
+	size *= content_scale_factor
 	hide()
 	popup_centered(size)
 
@@ -42,16 +42,6 @@ func _on_OK_pressed():
 func _on_Cancel_pressed():
 	queue_free()
 
-
-func _on_Preferences_about_to_show():
-	await get_tree().process_frame
-	_on_VBoxContainer_minimum_size_changed()
-
-func _on_VBoxContainer_minimum_size_changed():
-	min_size = $VBoxContainer.get_combined_minimum_size() * content_scale_factor
-	size = min_size
-	
-
 func _on_InstallLanguage_pressed():
 	var dialog = load("res://material_maker/windows/file_dialog/file_dialog.tscn").instantiate()
 	dialog.min_size = Vector2(500, 500)
@@ -65,8 +55,8 @@ func _on_InstallLanguage_pressed():
 		update_language_list()
 
 func update_language_list():
-	$VBoxContainer/TabContainer/General/HBoxContainer/Language.init_from_locales()
-	$VBoxContainer/TabContainer/General/HBoxContainer/Language.init_from_config(config)
+	%Language.init_from_locales()
+	%Language.init_from_config(config)
 
 func _on_DownloadLanguage_pressed():
 	var download_popup = load("res://material_maker/windows/preferences/language_download.tscn").instantiate()
@@ -78,7 +68,6 @@ func _on_DownloadLanguage_closed():
 	locale.read_translations()
 	update_language_list()
 
-
 func _on_ready() -> void:
-	$VBoxContainer/TabContainer/General/WinTabletDriverSpacer.visible = OS.get_name() == "Windows"
-	$VBoxContainer/TabContainer/General/WinTabletDriver.visible = OS.get_name() == "Windows"
+	%WinTabletDriver.visible = OS.get_name() == "Windows"
+	%WinTabletDriverSpacer.visible = OS.get_name() == "Windows"

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=6 format=3 uid="uid://c1j6a4jdggjm6"]
+[gd_scene load_steps=8 format=3 uid="uid://c1j6a4jdggjm6"]
 
 [ext_resource type="PackedScene" uid="uid://drg0s4lftblx3" path="res://material_maker/windows/preferences/bool_option.tscn" id="1"]
 [ext_resource type="Script" uid="uid://cwom8loyqsvf2" path="res://material_maker/windows/preferences/preferences.gd" id="2"]
+[ext_resource type="FontFile" uid="uid://bn648prik7soq" path="res://material_maker/theme/font_rubik/Rubik-416.ttf" id="2_vp06c"]
 [ext_resource type="PackedScene" uid="uid://3lo2jh781ten" path="res://material_maker/windows/preferences/float_option.tscn" id="3"]
+[ext_resource type="Script" uid="uid://b6irr1ykhui6l" path="res://material_maker/windows/preferences/preferences_tree.gd" id="3_mlqij"]
 [ext_resource type="Script" uid="uid://gmystrme5ayw" path="res://material_maker/windows/preferences/lang_option.gd" id="4"]
 [ext_resource type="Script" path="res://material_maker/windows/preferences/enum_option.gd" id="5_vp06c"]
 
@@ -10,107 +12,180 @@
 oversampling_override = 1.0
 title = "Preferences"
 position = Vector2i(0, 36)
-size = Vector2i(610, 505)
+size = Vector2i(700, 450)
 exclusive = true
 script = ExtResource("2")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="HSplitContainer" type="HSplitContainer" parent="."]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 2.0
-offset_top = 2.0
-offset_right = -2.0
-offset_bottom = -2.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 6
+size_flags_vertical = 3
+split_offset = 100
+dragger_visibility = 2
+
+[node name="PreferenceCategory" type="MarginContainer" parent="HSplitContainer"]
+custom_minimum_size = Vector2(86.8, 0)
+layout_mode = 2
+theme_override_constants/margin_left = 4
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
+
+[node name="Tree" type="Tree" parent="HSplitContainer/PreferenceCategory" groups=["updated_from_locale"]]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/item_margin = 2
+theme_override_fonts/font = ExtResource("2_vp06c")
+theme_override_font_sizes/font_size = 18
+auto_tooltip = false
+script = ExtResource("3_mlqij")
+
+[node name="PreferencesPanel" type="MarginContainer" parent="HSplitContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 4
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
+
+[node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer/PreferencesPanel"]
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
+[node name="TabContainer" type="TabContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(289, 172)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 current_tab = 0
+tabs_visible = false
 use_hidden_tabs_for_min_size = true
 
-[node name="General" type="VBoxContainer" parent="VBoxContainer/TabContainer"]
+[node name="General" type="ScrollContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer"]
 layout_mode = 2
-size_flags_vertical = 3
+theme_type_variation = &"MM_PreferenceTab"
 metadata/_tab_index = 0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
+[node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Language" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/TabContainer/General/HBoxContainer"]
+[node name="Label2" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Language"]
 layout_mode = 2
-text = "Language:"
+text = "Language"
 
-[node name="Language" type="OptionButton" parent="VBoxContainer/TabContainer/General/HBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Language"]
+layout_mode = 2
+size_flags_horizontal = 10
+
+[node name="Language" type="OptionButton" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Language/HBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 script = ExtResource("4")
 config_variable = "locale"
 
-[node name="InstallLanguage" type="Button" parent="VBoxContainer/TabContainer/General/HBoxContainer"]
+[node name="InstallLanguage" type="Button" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Language/HBoxContainer"]
 layout_mode = 2
 text = "Install"
 
-[node name="DownloadLanguage" type="Button" parent="VBoxContainer/TabContainer/General/HBoxContainer"]
+[node name="DownloadLanguage" type="Button" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Language/HBoxContainer"]
 layout_mode = 2
 text = "Download"
 
-[node name="Space1" type="Control" parent="VBoxContainer/TabContainer/General"]
+[node name="Spacer1" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 
-[node name="ConfirmQuit" parent="VBoxContainer/TabContainer/General" instance=ExtResource("1")]
+[node name="ConfirmQuit" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/ConfirmQuit"]
+layout_mode = 2
+text = "Confirm when quitting the application"
+
+[node name="ConfirmQuit" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/ConfirmQuit" instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+text = "On"
+flat = false
 config_variable = "confirm_quit"
 
-[node name="ConfirmCloseProject" parent="VBoxContainer/TabContainer/General" instance=ExtResource("1")]
+[node name="ConfirmCloseProject" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/ConfirmCloseProject"]
 layout_mode = 2
 text = "Confirm when closing a project"
+
+[node name="ConfirmCloseProject" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/ConfirmCloseProject" instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+text = "On"
+flat = false
 config_variable = "confirm_close_project"
 
-[node name="Space3" type="Control" parent="VBoxContainer/TabContainer/General"]
+[node name="Spacer2" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 
-[node name="GuiScale" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
+[node name="GuiScale" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/TabContainer/General/GuiScale"]
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/GuiScale"]
 layout_mode = 2
-text = "UI scale (0 = auto):"
+text = "UI scale (0 = auto)"
 
-[node name="GuiScale" parent="VBoxContainer/TabContainer/General/GuiScale" instance=ExtResource("3")]
+[node name="GuiScale" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/GuiScale" instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
 layout_mode = 2
+size_flags_horizontal = 10
 config_variable = "ui_scale"
 value = 0.0
 max_value = 2.0
 step = 0.01
 float_only = true
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
+[node name="GuiUseNativeFileDialogs" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
 
-[node name="GuiUseNativeFileDialogs" parent="VBoxContainer/TabContainer/General/HBoxContainer2" instance=ExtResource("1")]
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/GuiUseNativeFileDialogs"]
 layout_mode = 2
-tooltip_text = "Prefer the use of native file dialogs"
+mouse_filter = 1
 text = "Use native file dialogs"
+
+[node name="GuiUseNativeFileDialogs" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/GuiUseNativeFileDialogs" instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+tooltip_text = "Prefer the use of native file dialogs"
+text = "On"
+flat = false
 config_variable = "ui_use_native_file_dialogs"
 
-[node name="Gui3DPreviewResolution" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
+[node name="Gui3DPreviewResolution" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/TabContainer/General/Gui3DPreviewResolution"]
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Gui3DPreviewResolution"]
 layout_mode = 2
-tooltip_text = "Higher values result in better antialiasing, but are more demanding to render."
 mouse_filter = 1
-text = "3D preview resolution:"
+text = "3D preview resolution"
 
-[node name="Gui3DPreviewResolution" parent="VBoxContainer/TabContainer/General/Gui3DPreviewResolution" instance=ExtResource("3")]
+[node name="Gui3DPreviewResolution" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Gui3DPreviewResolution" instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
 layout_mode = 2
+size_flags_horizontal = 10
 tooltip_text = "Higher values result in better antialiasing, but are more demanding to render."
 config_variable = "ui_3d_preview_resolution"
 value = 2.0
@@ -119,19 +194,18 @@ max_value = 2.5
 step = 0.1
 float_only = true
 
-[node name="Gui3DPreviewTesselationDetail" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
+[node name="Gui3DPreviewTesselationDetail" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/TabContainer/General/Gui3DPreviewTesselationDetail"]
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Gui3DPreviewTesselationDetail"]
 layout_mode = 2
-tooltip_text = "Higher values result in better tesselation quality, but are more demanding to render and require more memory.
-Don't increase this setting above 256 on slower machines!
-This only affects the 3D preview when using tesselation, not parallax occlusion mapping."
 mouse_filter = 1
-text = "3D preview tesselation detail:"
+text = "3D preview tesselation detail"
 
-[node name="Gui3DPreviewTesselationDetail" parent="VBoxContainer/TabContainer/General/Gui3DPreviewTesselationDetail" instance=ExtResource("3")]
+[node name="Gui3DPreviewTesselationDetail" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Gui3DPreviewTesselationDetail" instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
 layout_mode = 2
+size_flags_horizontal = 10
 tooltip_text = "Higher values result in better tesselation quality, but are more demanding to render and require more memory.
 Don't increase this setting above 256 on slower machines!
 This only affects the 3D preview when using tesselation, not parallax occlusion mapping."
@@ -142,27 +216,41 @@ max_value = 1024.0
 step = 1.0
 float_only = true
 
-[node name="Gui3DPreviewSunShadow" parent="VBoxContainer/TabContainer/General" instance=ExtResource("1")]
+[node name="Gui3DPreviewSunShadow" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Gui3DPreviewSunShadow"]
+layout_mode = 2
+text = "3D preview sun shadow (requires restart)"
+
+[node name="Gui3DPreviewSunShadow" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Gui3DPreviewSunShadow" instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
 tooltip_text = "If enabled, the DirectionalLight3D will cast shadows in the 3D preview. This has a moderate performance cost.
 The effect of this shadow is only visible when using a tesselated mesh or a custom object.
 Changes to this setting are only applied on application restart."
-text = "3D preview sun shadow (requires restart)"
+text = "On"
+flat = false
 config_variable = "ui_3d_preview_sun_shadow"
 
-[node name="WinTabletDriverSpacer" type="Control" parent="VBoxContainer/TabContainer/General"]
+[node name="WinTabletDriverSpacer" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 
-[node name="WinTabletDriver" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
+[node name="WinTabletDriver" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/TabContainer/General/WinTabletDriver"]
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/WinTabletDriver"]
 layout_mode = 2
-text = "Tablet Driver:"
+text = "Tablet Driver"
 
-[node name="EnumOption" type="OptionButton" parent="VBoxContainer/TabContainer/General/WinTabletDriver"]
+[node name="EnumOption" type="OptionButton" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/WinTabletDriver"]
+custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
+size_flags_horizontal = 10
 tooltip_text = "Pen tablet driver to use
 
 Winink: Windows Ink API (Windows 8.1+)
@@ -179,27 +267,36 @@ popup/item_2/id = 2
 script = ExtResource("5_vp06c")
 config_variable = "win_tablet_driver"
 
-[node name="Space2" type="Control" parent="VBoxContainer/TabContainer/General"]
+[node name="Spacer3" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 
-[node name="EnableVSync" parent="VBoxContainer/TabContainer/General" instance=ExtResource("1")]
+[node name="EnableVSync" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
-text = "Enable VSync"
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/EnableVSync"]
+layout_mode = 2
+text = "VSync"
+
+[node name="EnableVSync" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/EnableVSync" instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+text = "On"
+flat = false
 config_variable = "vsync"
 
-[node name="FPSLimit" type="HBoxContainer" parent="VBoxContainer/TabContainer/General"]
+[node name="FPSLimit" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label1" type="Label" parent="VBoxContainer/TabContainer/General/FPSLimit"]
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/FPSLimit"]
 layout_mode = 2
-tooltip_text = "A higher FPS limit may result in smoother operation but may use more CPU/GPU resources.
-Higher values may increase power usage, leading to reduced battery life on laptops."
-mouse_filter = 1
-text = "FPS limit:"
+text = "FPS Limit"
 
-[node name="FPSLimit" parent="VBoxContainer/TabContainer/General/FPSLimit" instance=ExtResource("3")]
+[node name="FPSLimit" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/FPSLimit" instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
 layout_mode = 2
+size_flags_horizontal = 10
 tooltip_text = "A higher FPS limit may result in smoother operation but may use more CPU/GPU resources.
 Higher values may increase power usage, leading to reduced battery life on laptops."
 config_variable = "fps_limit"
@@ -209,20 +306,21 @@ max_value = 200.0
 step = 1.0
 float_only = true
 
-[node name="Space" type="Control" parent="VBoxContainer/TabContainer/General/FPSLimit"]
-custom_minimum_size = Vector2(15, 0)
+[node name="IdleFPSLimit" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/General/FPSLimit"]
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/IdleFPSLimit"]
 layout_mode = 2
 size_flags_horizontal = 0
 tooltip_text = "FPS limit to use when window isn't focused to save CPU/GPU resources.
 Lower values may help reducing power usage, but could increase response time when window is focused again."
 mouse_filter = 1
-text = "Idle FPS limit:"
+text = "Idle FPS limit"
 
-[node name="IdleFPSLimit" parent="VBoxContainer/TabContainer/General/FPSLimit" instance=ExtResource("3")]
+[node name="IdleFPSLimit" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/IdleFPSLimit" instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
 layout_mode = 2
+size_flags_horizontal = 10
 tooltip_text = "FPS limit to use when window isn't focused to save CPU/GPU resources.
 Lower values may help reducing power usage, but could increase response time when window is focused again."
 config_variable = "idle_fps_limit"
@@ -232,18 +330,31 @@ max_value = 20.0
 step = 1.0
 float_only = true
 
-[node name="Bake" type="GridContainer" parent="VBoxContainer/TabContainer"]
+[node name="Spacer4" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
+custom_minimum_size = Vector2(0, 10)
+layout_mode = 2
+
+[node name="Bake" type="ScrollContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer"]
 visible = false
 layout_mode = 2
-columns = 2
+theme_type_variation = &"MM_PreferenceTab"
 metadata/_tab_index = 1
 
-[node name="LabelRayCount" type="Label" parent="VBoxContainer/TabContainer/Bake"]
+[node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake"]
 layout_mode = 2
-text = "Ray count:"
+size_flags_horizontal = 3
 
-[node name="RayCount" parent="VBoxContainer/TabContainer/Bake" instance=ExtResource("3")]
+[node name="RayCount" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer"]
 layout_mode = 2
+
+[node name="LabelRayCount" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer/RayCount"]
+layout_mode = 2
+text = "Ray Count"
+
+[node name="RayCount" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer/RayCount" instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
+layout_mode = 2
+size_flags_horizontal = 10
 config_variable = "bake_ray_count"
 value = 64.0
 min_value = 8.0
@@ -251,12 +362,17 @@ max_value = 256.0
 step = 1.0
 float_only = true
 
-[node name="LabelRayLength" type="Label" parent="VBoxContainer/TabContainer/Bake"]
+[node name="RayLength" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer"]
 layout_mode = 2
-text = "Ray length:"
 
-[node name="RayLength" parent="VBoxContainer/TabContainer/Bake" instance=ExtResource("3")]
+[node name="LabelRayLength" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer/RayLength"]
 layout_mode = 2
+text = "Ray Length"
+
+[node name="RayLength" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer/RayLength" instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
+layout_mode = 2
+size_flags_horizontal = 10
 config_variable = "bake_ao_ray_dist"
 value = 128.0
 min_value = 32.0
@@ -264,24 +380,34 @@ max_value = 1024.0
 step = 1.0
 float_only = true
 
-[node name="LabelRayBias" type="Label" parent="VBoxContainer/TabContainer/Bake"]
+[node name="RayBias" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer"]
 layout_mode = 2
-text = "Ray bias:"
 
-[node name="RayBias" parent="VBoxContainer/TabContainer/Bake" instance=ExtResource("3")]
+[node name="LabelRayBias" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer/RayBias"]
 layout_mode = 2
+text = "Ray Bias"
+
+[node name="RayBias" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer/RayBias" instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
+layout_mode = 2
+size_flags_horizontal = 10
 config_variable = "bake_ao_ray_bias"
 value = 0.005
 max_value = 1024.0
 step = 0.001
 float_only = true
 
-[node name="LabelDenoiseRadius" type="Label" parent="VBoxContainer/TabContainer/Bake"]
+[node name="DenoiseRadius" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer"]
 layout_mode = 2
-text = "Denoise radius:"
 
-[node name="DenoiseRadius" parent="VBoxContainer/TabContainer/Bake" instance=ExtResource("3")]
+[node name="LabelDenoiseRadius" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer/DenoiseRadius"]
 layout_mode = 2
+text = "Denoise Radius"
+
+[node name="DenoiseRadius" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Bake/VBoxContainer/DenoiseRadius" instance=ExtResource("3")]
+custom_minimum_size = Vector2(200, 24)
+layout_mode = 2
+size_flags_horizontal = 10
 config_variable = "bake_denoise_radius"
 value = 3.0
 min_value = 1.0
@@ -289,60 +415,89 @@ max_value = 10.0
 step = 1.0
 float_only = true
 
-[node name="Graph" type="VBoxContainer" parent="VBoxContainer/TabContainer"]
+[node name="Graph" type="ScrollContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer"]
 visible = false
 layout_mode = 2
+theme_type_variation = &"MM_PreferenceTab"
 metadata/_tab_index = 2
 
-[node name="AutoSizeComment" parent="VBoxContainer/TabContainer/Graph" instance=ExtResource("1")]
+[node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="AutoSizeComment" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer/AutoSizeComment"]
 layout_mode = 2
 text = "Auto size comment node to selection"
+
+[node name="AutoSizeComment" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer/AutoSizeComment" instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+text = "On"
+flat = false
 config_variable = "auto_size_comment"
 
-[node name="Export" type="VBoxContainer" parent="VBoxContainer/TabContainer"]
+[node name="Export" type="ScrollContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer"]
 visible = false
 layout_mode = 2
+theme_type_variation = &"MM_PreferenceTab"
 metadata/_tab_index = 3
 
-[node name="AnimationLabel" type="Label" parent="VBoxContainer/TabContainer/Export"]
+[node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Export"]
 layout_mode = 2
-text = "Animation"
+size_flags_horizontal = 3
 
-[node name="RememberAnimExport" parent="VBoxContainer/TabContainer/Export" instance=ExtResource("1")]
+[node name="RememberAnimExport" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Export/VBoxContainer"]
 layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Export/VBoxContainer/RememberAnimExport"]
+layout_mode = 2
+text = "Remember last animation export settings"
+
+[node name="RememberAnimExport" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Export/VBoxContainer/RememberAnimExport" instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
 tooltip_text = "Whether to save export parameters in the export animation dialog (i.e. size, begin, end etc.)"
-text = "Remember last export settings"
+text = "On"
+flat = false
 config_variable = "remember_anim_export"
 
-[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer"]
 layout_mode = 2
-theme_override_constants/separation = 0
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/MarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 8
 
-[node name="Apply" type="Button" parent="VBoxContainer/HBoxContainer"]
-custom_minimum_size = Vector2(60, 0)
+[node name="Apply" type="Button" parent="HSplitContainer/PreferencesPanel/VBoxContainer/MarginContainer/HBoxContainer"]
+custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 text = "Apply"
 
-[node name="OK" type="Button" parent="VBoxContainer/HBoxContainer"]
-custom_minimum_size = Vector2(60, 0)
+[node name="OK" type="Button" parent="HSplitContainer/PreferencesPanel/VBoxContainer/MarginContainer/HBoxContainer"]
+custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 text = "OK"
 
-[node name="Cancel" type="Button" parent="VBoxContainer/HBoxContainer"]
-custom_minimum_size = Vector2(60, 0)
+[node name="Cancel" type="Button" parent="HSplitContainer/PreferencesPanel/VBoxContainer/MarginContainer/HBoxContainer"]
+custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 text = "Cancel"
 
-[connection signal="about_to_popup" from="." to="." method="_on_Preferences_about_to_show"]
 [connection signal="close_requested" from="." to="." method="_on_Cancel_pressed"]
 [connection signal="ready" from="." to="." method="_on_ready"]
-[connection signal="minimum_size_changed" from="VBoxContainer" to="." method="_on_VBoxContainer_minimum_size_changed"]
-[connection signal="pressed" from="VBoxContainer/TabContainer/General/HBoxContainer/InstallLanguage" to="." method="_on_InstallLanguage_pressed"]
-[connection signal="pressed" from="VBoxContainer/TabContainer/General/HBoxContainer/DownloadLanguage" to="." method="_on_DownloadLanguage_pressed"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/Apply" to="." method="_on_Apply_pressed"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/OK" to="." method="_on_OK_pressed"]
-[connection signal="pressed" from="VBoxContainer/HBoxContainer/Cancel" to="." method="_on_Cancel_pressed"]
+[connection signal="item_selected" from="HSplitContainer/PreferenceCategory/Tree" to="HSplitContainer/PreferenceCategory/Tree" method="_on_item_selected"]
+[connection signal="ready" from="HSplitContainer/PreferenceCategory/Tree" to="HSplitContainer/PreferenceCategory/Tree" method="_on_ready"]
+[connection signal="minimum_size_changed" from="HSplitContainer/PreferencesPanel/VBoxContainer" to="." method="_on_VBoxContainer_minimum_size_changed"]
+[connection signal="pressed" from="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Language/HBoxContainer/InstallLanguage" to="." method="_on_InstallLanguage_pressed"]
+[connection signal="pressed" from="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/Language/HBoxContainer/DownloadLanguage" to="." method="_on_DownloadLanguage_pressed"]
+[connection signal="pressed" from="HSplitContainer/PreferencesPanel/VBoxContainer/MarginContainer/HBoxContainer/Apply" to="." method="_on_Apply_pressed"]
+[connection signal="pressed" from="HSplitContainer/PreferencesPanel/VBoxContainer/MarginContainer/HBoxContainer/OK" to="." method="_on_OK_pressed"]
+[connection signal="pressed" from="HSplitContainer/PreferencesPanel/VBoxContainer/MarginContainer/HBoxContainer/Cancel" to="." method="_on_Cancel_pressed"]

--- a/material_maker/windows/preferences/preferences_tree.gd
+++ b/material_maker/windows/preferences/preferences_tree.gd
@@ -1,0 +1,29 @@
+extends Tree
+
+
+func _on_ready() -> void:
+	update_tree()
+
+func update_tree() -> void:
+	var selected_section_id: int = 0
+	var current_section: TreeItem = get_selected()
+	if current_section:
+		selected_section_id = current_section.get_metadata(0)
+	clear()
+	hide_root = true
+	create_item()
+	var sections = []
+
+	for child in %TabContainer.get_children():
+		var item: TreeItem = create_item()
+		item.set_text(0, " %s " % tr(child.name))
+		item.set_metadata(0, child.get_index())
+		sections.append(item)
+
+	set_selected(sections[selected_section_id], 0)
+
+func update_from_locale() -> void:
+	update_tree()
+
+func _on_item_selected() -> void:
+	%TabContainer.current_tab = get_selected().get_index()

--- a/material_maker/windows/preferences/preferences_tree.gd.uid
+++ b/material_maker/windows/preferences/preferences_tree.gd.uid
@@ -1,0 +1,1 @@
+uid://b6irr1ykhui6l


### PR DESCRIPTION
Alternative design for the preference dialog, similar to Godot(or Blender)'s project settings/preferences

![vtabsprefs](https://github.com/user-attachments/assets/5b51b815-9be7-4158-a109-8cf689e962fe)

The preference looks alright as it is right now so I can't justify adding this at this moment, but I believe this could potentially be a cleaner solution when we get more preferences (categories) - a few tabs look fine with horizontal tabs, but a dozen can get a bit messy:

![nowpr](https://github.com/user-attachments/assets/696b1e0b-cc54-4531-8664-f0a261aec313)