### PR TITLE
Fix switch node input tooltips

### DIFF
--- a/addons/material_maker/engine/nodes/gen_switch.gd
+++ b/addons/material_maker/engine/nodes/gen_switch.gd
@@ -33,7 +33,7 @@ func get_input_defs() -> Array:
 	var rv : Array = []
 	for c in range(parameters.choices):
 		for o in range(parameters.outputs):
-			var n = PackedByteArray([65+o]).get_string_from_ascii()+str(c)
+			var n = PackedByteArray([65+o]).get_string_from_ascii()+str(c+1)
 			rv.push_back({ name=n, label=n, type="any" })
 	return rv
 


### PR DESCRIPTION
Fix switch node input tooltips not matching labels (current/pr):

![vs](https://github.com/user-attachments/assets/031ced04-5213-4ef5-baec-a133eefcafdd)
