### PR TITLE
Fix lmb/rmb/mmb icons

### DIFF
--- a/material_maker/icons/lmb.tres
+++ b/material_maker/icons/lmb.tres
@@ -1,6 +1,6 @@
 [gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://b0xjx0eyuyghe"]
 
-[ext_resource type="Texture2D" uid="uid://1s0c37uoj4rf" path="res://material_maker/theme/default_theme_icons.svg" id="1_xwqx4"]
+[ext_resource type="Texture2D" uid="uid://cvorvnes6fiq7" path="res://material_maker/icons/icons.svg" id="1_xwqx4"]
 
 [resource]
 atlas = ExtResource("1_xwqx4")

--- a/material_maker/icons/mmb.tres
+++ b/material_maker/icons/mmb.tres
@@ -1,8 +1,7 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://c64bul68ma1uq"]
 
-[ext_resource type="Texture2D" path="res://material_maker/icons/icons.tres" id="1"]
+[ext_resource type="Texture2D" uid="uid://cvorvnes6fiq7" path="res://material_maker/icons/icons.svg" id="1_kee16"]
 
 [resource]
-flags = 4
-atlas = ExtResource( 1 )
-region = Rect2( 144, 128, 16, 16 )
+atlas = ExtResource("1_kee16")
+region = Rect2(144, 128, 16, 16)

--- a/material_maker/icons/rmb.tres
+++ b/material_maker/icons/rmb.tres
@@ -1,8 +1,7 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://bjyiijiib1m6o"]
 
-[ext_resource type="Texture2D" path="res://material_maker/icons/icons.tres" id="1"]
+[ext_resource type="Texture2D" uid="uid://cvorvnes6fiq7" path="res://material_maker/icons/icons.svg" id="1_rqy0j"]
 
 [resource]
-flags = 4
-atlas = ExtResource( 1 )
-region = Rect2( 128, 128, 16, 16 )
+atlas = ExtResource("1_rqy0j")
+region = Rect2(128, 128, 16, 16)


### PR DESCRIPTION
Noticed these icons are not referencing the icon resource correctly

before / after

![before-after](https://github.com/user-attachments/assets/792df824-d321-44d9-96cb-5ca773442f00)
