### PR TITLE
Fix sdf builder param panel not resizing

### DIFF
--- a/material_maker/windows/sdf_builder/sdf_builder.tscn
+++ b/material_maker/windows/sdf_builder/sdf_builder.tscn
@@ -75,6 +75,7 @@ control_target = NodePath("../../..")
 [node name="ScrollContainer" type="ScrollContainer" parent="TopContainer/Main"]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
+horizontal_scroll_mode = 0
 
 [node name="Parameters" type="VBoxContainer" parent="TopContainer/Main/ScrollContainer"]
 layout_mode = 2


### PR DESCRIPTION
ScrollContainer's `horizontal_scroll_mode` was set to `Auto`, changing this to `Disabled` resolves the issue (restores v1.3 behavior)

Current

https://github.com/user-attachments/assets/4e0bc284-c93e-4e94-9bdc-7d34078375c8


PR

https://github.com/user-attachments/assets/161f55fc-674a-4d34-931c-03ed3d5752f5

