### PR TITLE
Fix and update tip text mouse icons

### DIFF
--- a/material_maker/icons/lmb.tres
+++ b/material_maker/icons/lmb.tres
@@ -4,4 +4,4 @@
 
 [resource]
 atlas = ExtResource("1_xwqx4")
-region = Rect2(112, 128, 16, 16)
+region = Rect2(32, 32, 16, 16)

--- a/material_maker/icons/mmb.tres
+++ b/material_maker/icons/mmb.tres
@@ -1,8 +1,7 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://n6tc7ocgxm0d"]
 
-[ext_resource type="Texture2D" path="res://material_maker/icons/icons.tres" id="1"]
+[ext_resource type="Texture2D" uid="uid://1s0c37uoj4rf" path="res://material_maker/theme/default_theme_icons.svg" id="1_kee16"]
 
 [resource]
-flags = 4
-atlas = ExtResource( 1 )
-region = Rect2( 144, 128, 16, 16 )
+atlas = ExtResource("1_kee16")
+region = Rect2(48, 32, 16, 16)

--- a/material_maker/icons/rmb.tres
+++ b/material_maker/icons/rmb.tres
@@ -1,8 +1,7 @@
-[gd_resource type="AtlasTexture" load_steps=2 format=3]
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://b0xjx0eyuyghe"]
 
-[ext_resource type="Texture2D" path="res://material_maker/icons/icons.tres" id="1"]
+[ext_resource type="Texture2D" uid="uid://1s0c37uoj4rf" path="res://material_maker/theme/default_theme_icons.svg" id="1_xwqx4"]
 
 [resource]
-flags = 4
-atlas = ExtResource( 1 )
-region = Rect2( 128, 128, 16, 16 )
+atlas = ExtResource("1_xwqx4")
+region = Rect2(16, 32, 16, 16)

--- a/material_maker/theme/default_theme_icons.svg
+++ b/material_maker/theme/default_theme_icons.svg
@@ -28,15 +28,15 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="4"
-     inkscape:cx="59.625"
-     inkscape:cy="112.125"
+     inkscape:zoom="128"
+     inkscape:cx="55.242187"
+     inkscape:cy="37.707031"
      inkscape:window-width="1152"
      inkscape:window-height="981"
      inkscape:window-x="0"
      inkscape:window-y="38"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer82">
+     inkscape:current-layer="g27">
     <inkscape:grid
        id="grid2"
        units="px"
@@ -477,7 +477,7 @@
        id="swatch4"
        inkscape:swatch="solid"
        inkscape:label="Main"
-       gradientTransform="matrix(9.5183323e-5,0,0,9.5183323e-5,83.600476,68.329685)">
+       gradientTransform="matrix(-9.5183323e-5,0,0,9.5183323e-5,2990.8886,68.329685)">
       <stop
          style="stop-color:#ffffff;stop-opacity:1;"
          offset="0"
@@ -2442,6 +2442,18 @@
        y1="100.63053"
        x2="417.83676"
        y2="100.63053" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#swatch25"
+       id="linearGradient88"
+       gradientTransform="matrix(-9.5183323e-5,0,0,9.5183323e-5,2967.2219,68.329685)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#swatch25"
+       id="linearGradient96"
+       gradientTransform="matrix(-9.5183323e-5,0,0,9.5183323e-5,2990.8886,68.329685)"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <g
      inkscape:groupmode="layer"
@@ -4058,7 +4070,7 @@
      inkscape:groupmode="layer"
      id="layer55"
      inkscape:label="third_row"
-     sodipodi:insensitive="true">
+     style="display:inline">
     <g
        inkscape:groupmode="layer"
        id="layer17"
@@ -4125,10 +4137,10 @@
        style="display:inline"
        transform="matrix(0.67636941,0,0,0.67636941,-1007.6956,-654.48258)">
       <path
-         id="rect19-3"
-         style="display:inline;fill:url(#swatch25);stroke:none;stroke-width:0;stroke-dasharray:none;paint-order:fill markers stroke"
+         id="path88"
+         style="display:inline;fill:url(#linearGradient96);stroke:none;stroke-width:0;stroke-dasharray:none;paint-order:fill markers stroke"
          inkscape:label="Middle"
-         d="m 1572.7104,1020.7905 c 0.6658,0 1.2017,0.5359 1.2017,1.2017 v 2.4067 c 0,0.6657 -0.5359,1.2016 -1.2017,1.2016 -0.6657,0 -1.2016,-0.5359 -1.2016,-1.2016 v -2.4067 c 0,-0.6658 0.5359,-1.2017 1.2016,-1.2017 z" />
+         d="m 1572.7215,1020.7907 c 0.6656,0 1.2016,0.5359 1.2016,1.2017 v 2.4067 c 0,0.6657 -0.536,1.2016 -1.2016,1.2016 -0.6657,0 -1.2016,-0.5359 -1.2016,-1.2016 v -2.4067 c 0,-0.6658 0.5359,-1.2017 1.2016,-1.2017 z" />
       <path
          style="display:inline;fill:url(#linearGradient145);stroke:none;stroke-width:0;stroke-dasharray:none;paint-order:stroke markers fill"
          d="m 1565.3741,1025.1364 v 5.3315 c -0.035,4.052 3.2206,7.3653 7.2726,7.4007 4.0873,0 7.4005,-3.3134 7.4005,-7.4007 v -5.3315 h -5.017 v 0.074 c 0,0.8464 -0.6815,1.528 -1.5278,1.528 h -1.5832 c -0.8465,0 -1.528,-0.6816 -1.528,-1.528 v -0.074 z"
@@ -4186,26 +4198,26 @@
       <path
          id="rect19-2"
          style="display:inline;fill:url(#swatch4);stroke:none;stroke-width:0;stroke-dasharray:none;paint-order:fill markers stroke"
-         inkscape:label="middle"
+         inkscape:label="Middle"
          d="m 1525.4036,1020.6604 c 0.6708,0 1.2108,0.54 1.2108,1.2108 v 2.425 c 0,0.6709 -0.54,1.2109 -1.2108,1.2109 -0.6708,0 -1.2108,-0.54 -1.2108,-1.2109 v -2.425 c 0,-0.6708 0.54,-1.2108 1.2108,-1.2108 z" />
       <path
          style="display:inline;fill:url(#linearGradient147);stroke:none;stroke-width:0;stroke-dasharray:none;paint-order:stroke markers fill"
          d="m 1518.0114,1025.0397 v 5.372 c -0.035,4.0826 3.2451,7.4212 7.3278,7.4569 4.1182,0 7.4568,-3.3386 7.4568,-7.4569 v -5.372 h -5.0553 v 0.074 c 0,0.8527 -0.6867,1.5395 -1.5394,1.5395 h -1.5953 c -0.8527,0 -1.5394,-0.6868 -1.5394,-1.5395 v -0.074 z"
          id="path20-4"
          sodipodi:nodetypes="cccsccsssscc"
-         inkscape:label="bottom" />
+         inkscape:label="Bottom" />
       <path
-         style="display:inline;fill:url(#swatch25);stroke:none;stroke-width:0;stroke-dasharray:none;paint-order:stroke markers fill"
-         d="m 1526.225,1015.6914 -0.014,4.0673 c 0.8463,0.012 1.5257,0.6906 1.5257,1.539 v 2.6077 h 5.0011 v -1.6349 c 0,-3.6338 -2.4566,-6.5791 -6.0902,-6.5791 z"
-         id="path21-1"
-         sodipodi:nodetypes="ccscccsc"
-         inkscape:label="right" />
+         style="display:inline;fill:url(#linearGradient88);stroke:none;stroke-width:0;stroke-dasharray:none;paint-order:stroke markers fill"
+         d="m 1526.7209,1015.6914 c 3.6336,0 6.0901,2.9455 6.0901,6.5791 v 1.6349 h -5.0552 v -2.6077 c 0,-0.83 -0.6505,-1.5024 -1.4715,-1.5377 l 0.014,-4.0686 z"
+         id="path19"
+         sodipodi:nodetypes="scccsccs"
+         inkscape:label="Right" />
       <path
          style="display:inline;fill:url(#swatch4);stroke:none;stroke-width:0;stroke-dasharray:none;paint-order:stroke markers fill"
          d="m 1524.1015,1015.6914 c -3.6336,0 -6.0901,2.9455 -6.0901,6.5791 v 1.6349 h 5.0552 v -2.6077 c 0,-0.83 0.6505,-1.5024 1.4715,-1.5377 l -0.014,-4.0686 z"
          id="path22-4"
          sodipodi:nodetypes="scccsccs"
-         inkscape:label="left" />
+         inkscape:label="Left" />
     </g>
     <g
        inkscape:groupmode="layer"


### PR DESCRIPTION
Updates mouse icons (i.e. used in tip texts) from the new icon sheet + minor fixes for the mouse icons (replacing the layers in the svg as they do not show up in editor)

![icon](https://github.com/user-attachments/assets/d9157e84-8fb9-421f-9716-f24568d8183e)
