### PR TITLE
Smaller nodes when possible

### DIFF
--- a/material_maker/nodes/generic/generic.gd
+++ b/material_maker/nodes/generic/generic.gd
@@ -313,6 +313,7 @@ static func create_parameter_control(p : Dictionary, accept_float_expressions : 
 			control.add_item(value.name)
 			control.selected = 0 if !p.has("default") else p.default
 		control.custom_minimum_size.x = 80
+		control.fit_to_longest_item = false
 	elif p.type == "boolean":
 		control = CheckBox.new()
 		control.theme_type_variation = "MM_NodeCheckbox"
@@ -708,3 +709,7 @@ func _input(_event:InputEvent) -> void:
 
 func update_from_locale() -> void:
 	update_title()
+
+
+func _on_minimum_size_changed() -> void:
+	size = get_combined_minimum_size()

--- a/material_maker/nodes/generic/generic.tscn
+++ b/material_maker/nodes/generic/generic.tscn
@@ -7,3 +7,5 @@ offset_right = 95.0
 offset_bottom = 29.0
 title = "Generic"
 script = ExtResource("1")
+
+[connection signal="minimum_size_changed" from="." to="." method="_on_minimum_size_changed"]


### PR DESCRIPTION
Also sets `fit_to_longest_item` for OptionEdit to `false`

This allows nodes with the control to use a smaller size when possible, especially Math:

**Current**

https://github.com/user-attachments/assets/5f114801-9e6c-4e8b-b0fc-ca0f56d6075c

**PR**

https://github.com/user-attachments/assets/b732b6f6-8318-44a2-9c18-c1dfefbaf336