### PR TITLE
Fix splines editor `signal is already connected` error spam when drawing lines

### DIFF
--- a/material_maker/widgets/splines_edit/splines_editor.gd
+++ b/material_maker/widgets/splines_edit/splines_editor.gd
@@ -86,8 +86,10 @@ func update_controls() -> void:
 			control_point.initialize(p, self)
 			control_point.setpos(transform_point(p))
 			control_point.set_meta("point", splines.get_point_index(si, pi))
-			control_point.moved.connect(self._on_ControlPoint_moved)
-			control_point.selected.connect(self._on_ControlPoint_selected)
+			if not control_point.is_connected("moved", self._on_ControlPoint_moved):
+				control_point.moved.connect(self._on_ControlPoint_moved)
+			if not control_point.is_connected("selected", self._on_ControlPoint_selected):
+				control_point.selected.connect(self._on_ControlPoint_selected)
 			i += 1
 	while i < control_points.get_child_count():
 		control_points.get_child(i).queue_free()


### PR DESCRIPTION
Fix the error spam when drawing lines in the Splines Editor:

```
splines_editor.gd:89 @ update_controls(): Signal 'moved' is already connected to given callable
splines_editor.gd:90 @ update_controls(): Signal 'selected' is already connected to given callable
```