### PR TITLE
Fix missing comment_line doc definition in `nodes_miscellaneous.rst`

### DIFF
--- a/material_maker/doc/nodes_miscellaneous.rst
+++ b/material_maker/doc/nodes_miscellaneous.rst
@@ -11,6 +11,7 @@ Miscellaneous nodes
 	node_miscellaneous_switch
 	node_miscellaneous_remote
 	node_miscellaneous_comment
+	node_miscellaneous_comment_line
 	node_miscellaneous_export
 	node_miscellaneous_debug
 	node_miscellaneous_variations


### PR DESCRIPTION
Should fix the following warning during doc build:

<img width="681" alt="image" src="https://github.com/user-attachments/assets/ef81f0a7-682a-423a-aed2-34a06fd09589" />
