### PR TITLE
Round add node popup panel

### DIFF
--- a/material_maker/theme/default.tres
+++ b/material_maker/theme/default.tres
@@ -310,6 +310,10 @@ border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
 border_color = Color(0.359069, 0.359069, 0.359069, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_agwde"]
 bg_color = Color(0.0980392, 0.0980392, 0.101961, 1)


### PR DESCRIPTION
Slightly rounds the popup to make it consistent with other panels.

- Requires #953 

![light_dark_with_pr_953](https://github.com/user-attachments/assets/83c4f881-04f6-409a-9252-d5ae10265aba)

