### PR TITLE
Remove library tree tooltips

### DIFF
--- a/material_maker/panels/library/library.tscn
+++ b/material_maker/panels/library/library.tscn
@@ -62,6 +62,7 @@ columns = 2
 allow_rmb_select = true
 hide_root = true
 select_mode = 1
+auto_tooltip = false
 script = ExtResource("1")
 
 [node name="GetFromWebsite" type="Button" parent="Library"]


### PR DESCRIPTION
At the moment these simply shows the item labels so they serve no purpose