### PR TITLE
Fix connections shown in front of nodes

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -462,6 +462,7 @@ func update_graph(generators, connections) -> Array:
 			add_node(node)
 			node.generator = g
 		node.do_set_position(g.position)
+		node.move_to_front()
 		rv.push_back(node)
 	for c in connections:
 		super.connect_node("node_"+c.from, c.from_port, "node_"+c.to, c.to_port)


### PR DESCRIPTION
Should fix connections being shown in front of nodes when loading files/duplicating/pasting nodes etc. - by moving nodes using `move_to_front()` when graph updates

Current:

https://github.com/user-attachments/assets/2af3e0b3-0e65-4272-b4d2-9fcac06409e1

PR:

https://github.com/user-attachments/assets/5eab8033-8961-46f7-a467-e558837267e0