### PR TITLE
Fix unlit material doc on inputs

### DIFF
--- a/material_maker/doc/node_material_unlit.rst
+++ b/material_maker/doc/node_material_unlit.rst
@@ -9,7 +9,7 @@ The **Unlit Material** node describes a simple unlit material.
 Inputs
 ++++++
 
-The **Unlit Material** node has inputs for the distance function and all PBR channels.
+The **Unlit Material** node has a single RGBA input.
 
 Parameters
 ++++++++++


### PR DESCRIPTION
Noticed it uses the same description as the Raymarching material, this updates it to show that it has only one input