### PR TITLE
Fix reroute context menu

### DIFF
--- a/material_maker/nodes/reroute/reroute.gd
+++ b/material_maker/nodes/reroute/reroute.gd
@@ -61,7 +61,7 @@ func update_preview(preview : Control = null):
 func _input(event:InputEvent) -> void:
 	if not Rect2(Vector2(), size).has_point(get_local_mouse_position()):
 		return
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_RIGHT:
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_RIGHT and is_visible_in_tree():
 		accept_event()
 		var menu : PopupMenu = PopupMenu.new()
 		menu.add_item("No preview")


### PR DESCRIPTION
Fixes reroute node right-clickable even though it's in another tab 

Current:

https://github.com/user-attachments/assets/541e2052-0998-40c6-beb9-a7d44385be27

PR:

https://github.com/user-attachments/assets/616b8636-f5ad-42f0-aeaf-ff91d7a31a2b


