### PR TITLE
Save Preview3D mesh uv scales

### DIFF
--- a/material_maker/panels/preview_3d/mesh_config_popup.gd
+++ b/material_maker/panels/preview_3d/mesh_config_popup.gd
@@ -2,6 +2,8 @@ extends PopupPanel
 
 var mesh : MeshInstance3D
 
+const config_key : String = "3D_preview_objects/%s_uv_scale"
+
 func _ready() -> void:
 	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
 	min_size = get_contents_minimum_size() * content_scale_factor
@@ -9,8 +11,15 @@ func _ready() -> void:
 
 func configure_mesh(m : MeshInstance3D) -> void:
 	mesh = m
-	%UV_Scale_X.value = mesh.uv_scale.x
-	%UV_Scale_Y.value = mesh.uv_scale.y
+	
+	var key : String = config_key % mesh.name.to_snake_case()
+	if mm_globals.has_config(key):
+		var uv_scale : Vector2 = mm_globals.get_config(key)
+		%UV_Scale_X.value = uv_scale.x
+		%UV_Scale_Y.value = uv_scale.y
+	else:
+		%UV_Scale_X.value = mesh.uv_scale.x
+		%UV_Scale_Y.value = mesh.uv_scale.y
 
 	%ScaleLinked.button_pressed = %UV_Scale_X.value == %UV_Scale_Y.value
 
@@ -53,6 +62,7 @@ func _on_UV_value_changed(_value):
 		%UV_Scale_Y.value = _value
 
 	mesh.uv_scale = Vector2(%UV_Scale_X.value, %UV_Scale_Y.value)
+	mm_globals.set_config(config_key % mesh.name.to_snake_case(), mesh.uv_scale)
 
 
 func _on_Tesselated_toggled(button_pressed):


### PR DESCRIPTION
Config for the meshes are saved as a Vector2 under the`3D_preview_objects` key, for example:
- `3D_preview_objects/cylinder_uv_scale=Vector2(2, 2)`
-  `3D_preview_objects/custom_uv_scale=Vector2(1.23, 4.56)`