### PR TITLE
Fix preview3d does not immediately apply 3d scale

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -298,7 +298,9 @@ func on_config_changed() -> void:
 
 	# Clamp to reasonable values to avoid crashes on startup.
 	preview_rendering_scale_factor = clamp(mm_globals.get_config("ui_3d_preview_resolution"), 1.0, 2.0)
-# warning-ignore:narrowing_conversion
+	update_preview_3d([ preview_3d, projects_panel.preview_3d_background ])
+
+	@warning_ignore("narrowing_conversion")
 	preview_tesselation_detail = clamp(mm_globals.get_config("ui_3d_preview_tesselation_detail"), 16, 1024)
 
 func get_panel(panel_name : String) -> Control:


### PR DESCRIPTION
Restores v1.3 behaviour where preview 3d resolution is applied immediately when config updates

**Current:**

https://github.com/user-attachments/assets/91b612f8-8293-4892-91f6-7252b839e29e

**PR:**

https://github.com/user-attachments/assets/bbae73d9-a43e-4370-8e1d-0e5ad827c07c
