### PR TITLE
Fix crash hovering param linked to minimized nodes

### DIFF
--- a/material_maker/nodes/remote/remote.gd
+++ b/material_maker/nodes/remote/remote.gd
@@ -253,7 +253,7 @@ func on_enter_widget(widget) -> void:
 	var new_links = []
 	for l in w.linked_widgets:
 		var graph_node = get_parent().get_node("node_"+l.node)
-		if graph_node != null:
+		if graph_node != null and graph_node.controls.has(l.widget):
 			var control = graph_node.controls[l.widget]
 			if control != null:
 				var link = MMNodeLink.new(get_parent())


### PR DESCRIPTION
Resolves https://github.com/RodZill4/material-maker/issues/690

It does not crash in release builds now(only in editor), but I think a check is still worth it