### PR TITLE
Fix noise node banding artifacts

### DIFF
--- a/addons/material_maker/nodes/noise2.mmg
+++ b/addons/material_maker/nodes/noise2.mmg
@@ -1,0 +1,61 @@
+{
+	"name": "noise",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"parameters": {
+		"density": 0.5,
+		"size": 4
+	},
+	"seed_int": 0,
+	"shader_model": {
+		"code": "vec2 $(name_uv)_uv = floor($uv*$size);",
+		"global": "",
+		"inputs": [
+			{
+				"default": "$density",
+				"label": "2:",
+				"name": "density_in",
+				"type": "f"
+			}
+		],
+		"instance": "",
+		"longdesc": "Generates a grid made of black and white squares",
+		"name": "Noise",
+		"outputs": [
+			{
+				"f": "step(rand($(name_uv)_uv+vec2($seed)), $density_in($(name_uv)_uv))",
+				"longdesc": "Shows the noise pattern",
+				"shortdesc": "Output",
+				"type": "f"
+			}
+		],
+		"parameters": [
+			{
+				"default": 8,
+				"first": 2,
+				"label": "Grid Size",
+				"last": 12,
+				"longdesc": "The grid size",
+				"name": "size",
+				"shortdesc": "Size",
+				"type": "size"
+			},
+			{
+				"control": "None",
+				"default": 0.5,
+				"label": "Density",
+				"longdesc": "The density of white squares",
+				"max": 1,
+				"min": 0,
+				"name": "density",
+				"shortdesc": "Density",
+				"step": 0.01,
+				"type": "float"
+			}
+		],
+		"shortdesc": "Noise pattern"
+	},
+	"type": "shader"
+}

--- a/material_maker/library/base.json
+++ b/material_maker/library/base.json
@@ -1994,13 +1994,13 @@
 			"display_name": "Noise",
 			"icon": "noise",
 			"icon_data": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAVBJREFUeJztmkEOwzAIBO2q//+ye8dSVgi7o5adYxI5qxU4QDzHGGs8sNbj7TRzzsf14/0s2fVepbf9ATaAFkDzjhdUDqk9QT2f3VNO7xGR9hFgA2gBNHOEOiCbo6dz8nbOx/XbR4ANoAXQbHVA9rtf7RVO53hE6WsfATaAFkAjewFFNodVb6DWq9YJ8fn2EWADaAE0cyWTvprzp3O8Woe0jwAbQAugOT4PyM4Ms5yuU9pHgA2gBdBsvUDk13Pc8wCBDaAF0Gx1gKK6B9DnAfxfIGADaAE02zygmsO3czxSXb99BNgAWgCN7AVu53x1plfV1z4CbAAtgCZ9TjDLt/t7hXuBgA2gBdDIM0KR6nf39lnh7PvbR4ANoAXQpM8HbAtcPi9Qxf8FBDaAFkBTPiscOf386fmC5wEBG0ALoCnXAduCX54fqPd7JiiwAbQAmg8Mv79dtyZxBwAAAABJRU5ErkJggg==",
-			"name": "noise",
+			"name": "noise2",
 			"parameters": {
 				"density": 0.5,
 				"size": 4.0
 			},
 			"tree_item": "Noise",
-			"type": "noise"
+			"type": "noise2"
 		},
 		{
 			"display_name": "Value",


### PR DESCRIPTION
Should resolve https://github.com/RodZill4/material-maker/issues/250

Tested on Apple M1 (macOS 15.5) & Nvidia Geforce MX150 (Windows 11 24H2), applying this fix removes the banding

Images are created by plugging noise node into a scale node with scale x/y set to 15.0, exported to 512x512 png

| Grid Size  | 2048x2048 | 4096x4096 |
| ------------- | ------------- | ------------- |
| Current  | <img width="256" src="https://github.com/user-attachments/assets/0bc4a0de-b012-462f-a8b8-98cb4a984879">  | <img width="256" src="https://github.com/user-attachments/assets/e2a2d511-7053-4d3e-9c01-d021007f6c96"> |
| PR  | <img width="256" src="https://github.com/user-attachments/assets/17381c2e-ca6c-4500-8cc1-2cf390cab59a">  | <img width="256" src="https://github.com/user-attachments/assets/408e996d-0df5-4a58-8178-b6dec964a9a0"> |