### PR TITLE
Add link support for name controls in about dialog

### DIFF
--- a/material_maker/windows/about/about.gd
+++ b/material_maker/windows/about/about.gd
@@ -5,33 +5,33 @@ extends Window
 @onready var patrons_list = $HBoxContainer/VBoxContainer/VBoxContainer/Donors/VBoxContainer/Patrons
 
 const CONTRIBUTORS = [
-	{ icon="res://material_maker/icons/godot_logo.svg", contribution="99% of Material Maker's code is the awesome Godot Engine GODOT_VERSION" },
-	{ name="Rodolphe Suescun", contribution="Lead developer" },
-	{ name="williamchange", contribution="Many UI updates, several nodes (including Seven/Sixteen Segment Display, Roman numerals, Japanese Glyphs and Triangle Voronoi) and node updates" },
-	{ name="Jowan-Spooner", contribution="UI redesign" },
-	{ name="NotArme", contribution="Many improvements and bug fixes" },
-	{ name="Thibaud Goiffon", contribution="Website design" },
-	{ name="Kasper Arnklit Frandsen", contribution="Several nodes (including Auto Tones, Mask to SDF, Normal Blend and many Bricks nodes) and node updates, and very nice video tutorials" },
-	{ name="Hugo Locurcio", contribution="Lots of contributions, mostly related to rendering and user interface" },
-	{ name="Theaninova", contribution="Spiral Gradient node, many SDF nodes" },
-	{ name="Roujel Williams", contribution="Curvature, Ambient Occlusion and Thickness maps generation" },
-	{ name="wojtekpil", contribution="Multiwarp, HBAO and Denoiser nodes as well as fixes in baker tools" },
-	{ name="GoldenThumbs", contribution="Wavefront (OBJ) model loader" },
-	{ name="Bonbonmiel", contribution="Many user interface improvements (in Nodes popup, 3D preview...)" },
-	{ name="myaaaaaaaaa", contribution="Many improvements and bug fixes including better and faster connection loop detection, nicer file format for shader nodes, as well as colorspace nodes" },
-	{ name="Donald Mull Jr.", contribution="Export for Unity HDRP" },
-	{ name="Metin ÇETİN", contribution="Add node popup menu" },
-	{ name="Jack Perkins", contribution="User interface improvements" },
-	{ name="Paulo Falcao", contribution="Preview for v4v4 input/outputs, Temporal Anti Aliasing and lots of ideas/feedback for SDF nodes" },
-	{ name="Jesse Dubay", contribution="3D preview and user interface improvements, Colormap node" },
-	{ name="escargot-sans-gluten", contribution="3D preview and user interface improvements" },
-	{ name="Tarox", contribution="Material Maker icon and lots of very useful feedback" },
-	{ name="Easynam", contribution="Propagate Changes function in subgraph nodes" },
-	{ name="Zhibade", contribution="Auto size new comment nodes to current selection" },
-	{ name="paddy-exe", contribution="New modes in the Blend node" },
-	{ name="Variable", contribution="UI fixes" },
-	{ name="jeremybeier", contribution="Unity export fixes" },
-	{ name="Maybe you?", contribution="If I forgot anyone here, or if you wish to contribute to this project, please don't hesitate to join our Discord channel and/or contact me directly" },
+	{ icon="res://material_maker/icons/godot_logo.svg", contribution="99% of Material Maker's code is the awesome Godot Engine GODOT_VERSION", url="https://godotengine.org/" },
+	{ name="Rodolphe Suescun", contribution="Lead developer", url="https://github.com/RodZill4/material-maker/commits/master/?author=RodZill4" },
+	{ name="williamchange", contribution="Many UI updates, several nodes (including Seven/Sixteen Segment Display, Roman numerals, Japanese Glyphs and Triangle Voronoi) and node updates", url="https://github.com/RodZill4/material-maker/commits/master/?author=williamchange" },
+	{ name="Jowan-Spooner", contribution="UI redesign", url="https://github.com/RodZill4/material-maker/commits/master/?author=Jowan-Spooner" },
+	{ name="NotArme", contribution="Many improvements and bug fixes", url="https://github.com/RodZill4/material-maker/commits/master/?author=NotArme" },
+	{ name="Thibaud Goiffon", contribution="Website design", url="https://github.com/gtibo" },
+	{ name="Kasper Arnklit Frandsen", contribution="Several nodes (including Auto Tones, Mask to SDF, Normal Blend and many Bricks nodes) and node updates, and very nice video tutorials", url="https://github.com/RodZill4/material-maker/commits/master/?author=Arnklit" },
+	{ name="Hugo Locurcio", contribution="Lots of contributions, mostly related to rendering and user interface", url="https://github.com/RodZill4/material-maker/commits/master/?author=Calinou" },
+	{ name="Theaninova", contribution="Spiral Gradient node, many SDF nodes", url="https://github.com/RodZill4/material-maker/commits/master/?author=Theaninova" },
+	{ name="Roujel Williams", contribution="Curvature, Ambient Occlusion and Thickness maps generation", url="https://github.com/RodZill4/material-maker/commits/master/?author=SIsilicon" },
+	{ name="wojtekpil", contribution="Multiwarp, HBAO and Denoiser nodes as well as fixes in baker tools", url="https://github.com/RodZill4/material-maker/commits/master/?author=wojtekpil" },
+	{ name="GoldenThumbs", contribution="Wavefront (OBJ) model loader", url="https://github.com/RodZill4/material-maker/commits/master/?author=GoldenThumbs" },
+	{ name="Bonbonmiel", contribution="Many user interface improvements (in Nodes popup, 3D preview...)", url="https://github.com/mieldepoche" },
+	{ name="myaaaaaaaaa", contribution="Many improvements and bug fixes including better and faster connection loop detection, nicer file format for shader nodes, as well as colorspace nodes", url="https://github.com/RodZill4/material-maker/commits/master/?author=myaaaaaaaaa" },
+	{ name="Donald Mull Jr.", contribution="Export for Unity HDRP", url="https://github.com/RodZill4/material-maker/commits/master/?author=luggage66" },
+	{ name="Metin ÇETİN", contribution="Add node popup menu", url="https://github.com/RodZill4/material-maker/commits/master/?author=metincetin" },
+	{ name="Jack Perkins", contribution="User interface improvements", url="https://github.com/RodZill4/material-maker/commits/master/?author=jackaperkins" },
+	{ name="Paulo Falcao", contribution="Preview for v4v4 input/outputs, Temporal Anti Aliasing and lots of ideas/feedback for SDF nodes", url="https://github.com/RodZill4/material-maker/commits/master/?author=paulofalcao" },
+	{ name="Jesse Dubay", contribution="3D preview and user interface improvements, Colormap node", url="https://github.com/RodZill4/material-maker/commits/master/?author=vreon" },
+	{ name="escargot-sans-gluten", contribution="3D preview and user interface improvements", url="https://github.com/RodZill4/material-maker/commits/master/?author=escargot-sans-gluten" },
+	{ name="Tarox", contribution="Material Maker icon and lots of very useful feedback", url="https://x.com/pavel_oliva" },
+	{ name="Easynam", contribution="Propagate Changes function in subgraph nodes", url="https://github.com/RodZill4/material-maker/commits/master/?author=easynam" },
+	{ name="Zhibade", contribution="Auto size new comment nodes to current selection", url="https://github.com/RodZill4/material-maker/commits/master/?author=Zhibade" },
+	{ name="paddy-exe", contribution="New modes in the Blend node", url="https://github.com/RodZill4/material-maker/commits/master/?author=paddy-exe" },
+	{ name="Variable", contribution="UI fixes", url="https://github.com/RodZill4/material-maker/commits/master/?author=Variable-ind" },
+	{ name="jeremybeier", contribution="Unity export fixes", url="https://github.com/RodZill4/material-maker/commits/master/?author=jeremybeier" },
+	{ name="Maybe you?", contribution="If I forgot anyone here, or if you wish to contribute to this project, please don't hesitate to join our Discord channel and/or contact me directly", url="https://discord.gg/PF5V3mFwFM" },
 ]
 
 const PATRONS = [
@@ -73,6 +73,10 @@ func _ready() -> void:
 			icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT
 			icon.texture = load(c.icon)
 			name_control = icon
+		if c.has("url"):
+			name_control.mouse_filter = Control.MOUSE_FILTER_STOP
+			name_control.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+			name_control.gui_input.connect(_name_control_gui_input.bind(c.url))
 		name_control.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
 		authors_grid.add_child(name_control)
 
@@ -96,6 +100,11 @@ func _ready() -> void:
 			print(p, " already in patrons list")
 			continue
 		patrons_list.add_item(p)
+
+func _name_control_gui_input(event : InputEvent, url : String) -> void:
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		open_url(url)
+
 
 func open_url(url) -> void:
 	OS.shell_open(url)


### PR DESCRIPTION
This also adds a link for Godot's logo, which restores the behavior from v1.3

Links for authors can also be added using url="some link", i.e.

```json5
{ name"author", contribution="added features", url="https://example.com/" }
```