### PR TITLE
Fix duplicate with links shortcut

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -886,7 +886,11 @@ func _on_GraphEdit_node_selected(node : GraphElement) -> void:
 				if n.generator == current_preview[0].generator:
 					return
 		if node.get_output_port_count():
-			if Input.is_key_pressed(KEY_SHIFT):
+			if (Input.is_physical_key_pressed(KEY_SHIFT)
+			# Avoid conflicting with Ctrl/Command+Shift+D (Duplicate with inputs)
+					and not (Input.is_physical_key_pressed(KEY_D) or
+					Input.is_physical_key_pressed(KEY_META) or
+					Input.is_physical_key_pressed(KEY_CTRL))):
 				set_current_preview(1, node)
 			else:
 				set_current_preview(0, node)

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -886,11 +886,11 @@ func _on_GraphEdit_node_selected(node : GraphElement) -> void:
 				if n.generator == current_preview[0].generator:
 					return
 		if node.get_output_port_count():
-			if (Input.is_physical_key_pressed(KEY_SHIFT)
+			if (Input.is_key_pressed(KEY_SHIFT)
 			# Avoid conflicting with Ctrl/Command+Shift+D (Duplicate with inputs)
-					and not (Input.is_physical_key_pressed(KEY_D) or
-					Input.is_physical_key_pressed(KEY_META) or
-					Input.is_physical_key_pressed(KEY_CTRL))):
+					and not (Input.is_key_pressed(KEY_D) or
+					Input.is_key_pressed(KEY_META) or
+					Input.is_key_pressed(KEY_CTRL))):
 				set_current_preview(1, node)
 			else:
 				set_current_preview(0, node)


### PR DESCRIPTION
Fix shortcut <kbd>Ctrl/Command</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> conflicting with preview(2) activation (shift pressed on node selection)