### PR TITLE
Fix simplex noise seed offset

### DIFF
--- a/addons/material_maker/nodes/fbm3.mmg
+++ b/addons/material_maker/nodes/fbm3.mmg
@@ -116,7 +116,7 @@
 			"",
 			"vec2 fbm_2d_rgrad2(vec2 p, float rot, float seed) {",
 			"\tfloat u = fbm_2d_permute(fbm_2d_permute(p.x) + p.y) * 0.0243902439 + rot; // Rotate by shift",
-			"\tu = fract(u) * 6.28318530718; // 2*pi",
+			"\tu = fract(u+seed) * 6.28318530718; // 2*pi",
 			"\treturn vec2(cos(u), sin(u));",
 			"}",
 			"",


### PR DESCRIPTION
It appears that `seed` isn't used in the `fbm_2d_rgrad2` function
this replaces `fract(u)` with `fract(u+seed)` to introduce some randomness when rolling the seed

https://github.com/user-attachments/assets/c0e01a9b-cf88-4fa0-86a7-fde7adfcbade

