### PR TITLE
Simplify `Clamp result` on nodes to `Clamp`

### DIFF
--- a/addons/material_maker/nodes/math.mmg
+++ b/addons/material_maker/nodes/math.mmg
@@ -233,7 +233,7 @@
 			},
 			{
 				"default": false,
-				"label": "Clamp result",
+				"label": "Clamp",
 				"longdesc": "The result is clamped to [0, 1] if this option is checked",
 				"name": "clamp",
 				"shortdesc": "Clamp",

--- a/addons/material_maker/nodes/math_v3.mmg
+++ b/addons/material_maker/nodes/math_v3.mmg
@@ -256,7 +256,7 @@
 			},
 			{
 				"default": false,
-				"label": "Clamp result",
+				"label": "Clamp",
 				"longdesc": "The result is clamped to [0, 1] if this option is checked",
 				"name": "clamp",
 				"shortdesc": "Clamp",

--- a/addons/material_maker/nodes/smooth_minmax.mmg
+++ b/addons/material_maker/nodes/smooth_minmax.mmg
@@ -115,7 +115,7 @@
 			},
 			{
 				"default": false,
-				"label": "Clamp result",
+				"label": "Clamp",
 				"longdesc": "The result is clamped to [0, 1] if this option is checked",
 				"name": "clamp",
 				"shortdesc": "Clamp",


### PR DESCRIPTION
Simplify 'Clamp result' label on Vec3 Math/Math/Smooth MinMax nodes to 'Clamp'.

Tooltip should already provide sufficient context(i.e. clamp is applied to the result, not input(s))