### PR TITLE
Fix environment preview reflection and thumbnail generation

### DIFF
--- a/material_maker/tools/environment_manager/environment_manager.gd
+++ b/material_maker/tools/environment_manager/environment_manager.gd
@@ -125,6 +125,8 @@ func apply_environment(index: int, e: Environment, s: DirectionalLight3D, bg_col
 	elif env.show_color:
 		e.background_mode = Environment.BG_COLOR
 		e.background_color = MMType.deserialize_value(env.color)
+		e.ambient_light_source = Environment.AMBIENT_SOURCE_SKY
+		e.reflected_light_source = Environment.REFLECTION_SOURCE_SKY
 	else:
 		e.background_mode = Environment.BG_SKY
 		e.background_energy_multiplier = env.sky_energy

--- a/material_maker/tools/environment_manager/environment_manager.tscn
+++ b/material_maker/tools/environment_manager/environment_manager.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=6 format=3 uid="uid://dmyq6xxfx88m0"]
+[gd_scene load_steps=7 format=3 uid="uid://dmyq6xxfx88m0"]
 
 [ext_resource type="Script" uid="uid://vkw5u7nwwyeh" path="res://material_maker/tools/environment_manager/environment_manager.gd" id="1"]
 
@@ -13,6 +13,10 @@ sky = SubResource("1")
 [sub_resource type="SphereMesh" id="3"]
 radius = 2.0
 height = 4.0
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_lfvfh"]
+metallic = 1.0
+roughness = 0.2
 
 [node name="EnvironmentManager" type="Node"]
 script = ExtResource("1")
@@ -39,6 +43,7 @@ transform = Transform3D(1, 0, 0, 0, -1.62921e-07, 1, 0, -1, -1.62921e-07, 0, 0, 
 
 [node name="Sphere" type="MeshInstance3D" parent="PreviewGenerator"]
 mesh = SubResource("3")
+surface_material_override/0 = SubResource("StandardMaterial3D_lfvfh")
 
 [node name="HTTPRequest" type="HTTPRequest" parent="."]
 


### PR DESCRIPTION
- Fixes https://github.com/RodZill4/material-maker/issues/1062

### Environment preview

<img width="2378" height="797" alt="current-v-pr" src="https://github.com/user-attachments/assets/961e0908-2d32-40ca-80b5-b86f83b56b48" />

### Environment thumbnail generation
This restores the behavior from v1.3 by adding a surface material override for the Sphere with the same settings(roughness/metallic)

<img width="497" height="207" alt="vs" src="https://github.com/user-attachments/assets/cd411985-fc2a-43d8-a473-6344bb1494de" />
