### PR TITLE
Fix 3d panel export menu briefly visible on start

### DIFF
--- a/material_maker/panels/preview_3d/preview_3d.tscn
+++ b/material_maker/panels/preview_3d/preview_3d.tscn
@@ -311,6 +311,7 @@ step = 0.01
 float_only = true
 
 [node name="ExportMenu" type="Button" parent="MainMenu/HBox"]
+visible = false
 custom_minimum_size = Vector2(40, 25)
 layout_mode = 2
 tooltip_text = "Export"


### PR DESCRIPTION
https://github.com/user-attachments/assets/871be5c9-2c12-4c82-a8bd-94073f79061e

