### PR TITLE
Fix text copy/paste/cut shortcuts not working on mac

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -742,7 +742,7 @@ func edit_redo_is_disabled() ->  bool:
 
 func edit_cut_is_disabled() -> bool:
 	var graph_edit : MMGraphEdit = get_current_graph_edit()
-	return graph_edit == null or !graph_edit.can_copy()
+	return graph_edit == null or !graph_edit.can_copy() or not graph_edit.has_focus()
 
 func edit_copy() -> void:
 	var graph_edit : MMGraphEdit = get_current_graph_edit()
@@ -758,7 +758,12 @@ func edit_paste() -> void:
 		graph_edit.paste()
 
 func edit_paste_is_disabled() -> bool:
-	return false # todo validate_json(DisplayServer.clipboard_get()) != ""
+	var graph_edit : MMGraphEdit = get_current_graph_edit()
+	return graph_edit == null or not graph_edit.has_focus() # todo validate_json(DisplayServer.clipboard_get()) != ""
+
+func edit_select_all_is_disabled() -> bool:
+	var graph_edit : MMGraphEdit = get_current_graph_edit()
+	return graph_edit == null or not graph_edit.has_focus()
 
 func edit_duplicate() -> void:
 	var graph_edit : MMGraphEdit = get_current_graph_edit()

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -1517,3 +1517,13 @@ func _get_connection_line(from: Vector2, to: Vector2) -> PackedVector2Array:
 			return points
 		_:
 			return points
+
+
+func _on_focus_exited() -> void:
+	if OS.get_name() == "macOS":
+		mm_globals.main_window.update_menus()
+
+
+func _on_focus_entered() -> void:
+	if OS.get_name() == "macOS":
+		mm_globals.main_window.update_menus()

--- a/material_maker/panels/graph_edit/graph_edit.tscn
+++ b/material_maker/panels/graph_edit/graph_edit.tscn
@@ -92,6 +92,8 @@ script = ExtResource("3")
 [connection signal="copy_nodes_request" from="." to="." method="copy"]
 [connection signal="disconnection_request" from="." to="." method="on_disconnect_node"]
 [connection signal="duplicate_nodes_request" from="." to="." method="duplicate_selected"]
+[connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
+[connection signal="focus_exited" from="." to="." method="_on_focus_exited"]
 [connection signal="node_deselected" from="." to="." method="_on_GraphEdit_node_unselected"]
 [connection signal="node_selected" from="." to="." method="_on_GraphEdit_node_selected"]
 [connection signal="paste_nodes_request" from="." to="." method="paste"]


### PR DESCRIPTION
Workaround by enabling/disabling the relevant global menu items on GraphEdit focus change:

https://github.com/user-attachments/assets/7049569c-166b-42d6-b97d-4fb887a962bf