### PR TITLE
Made grayscale strings consistent

### DIFF
--- a/addons/material_maker/nodes/fast_blur.mmg
+++ b/addons/material_maker/nodes/fast_blur.mmg
@@ -235,7 +235,7 @@
 					{
 						"default": "vec4(0.0)",
 						"label": "",
-						"longdesc": "The input greyscale image",
+						"longdesc": "The input grayscale image",
 						"name": "input",
 						"shortdesc": "Input",
 						"type": "rgba"
@@ -246,7 +246,7 @@
 				"name": "EnsureRGBA",
 				"outputs": [
 					{
-						"longdesc": "The remapped greyscale image",
+						"longdesc": "The remapped grayscale image",
 						"rgba": "$input($uv)",
 						"shortdesc": "Output",
 						"type": "rgba"

--- a/addons/material_maker/nodes/hbao.mmg
+++ b/addons/material_maker/nodes/hbao.mmg
@@ -235,7 +235,7 @@
 			"ports": [
 				{
 					"group_size": 0,
-					"longdesc": "Greyscale heightmap",
+					"longdesc": "Grayscale heightmap",
 					"name": "input",
 					"shortdesc": "Input",
 					"type": "f"

--- a/addons/material_maker/nodes/io_types.mmt
+++ b/addons/material_maker/nodes/io_types.mmt
@@ -1,7 +1,7 @@
 [
     {
         "name":"f",
-        "label":"Greyscale",
+        "label":"Grayscale",
         "type":"float",
         "paramdefs":"vec2 uv",
         "params":"uv",
@@ -73,7 +73,7 @@
     },
 	{
         "name":"tex3d_gs",
-        "label":"Greyscale TEX3D",
+        "label":"Grayscale TEX3D",
         "type":"float",
         "paramdefs":"vec4 p",
         "params":"p",

--- a/addons/material_maker/nodes/shard_fbm.mmg
+++ b/addons/material_maker/nodes/shard_fbm.mmg
@@ -93,7 +93,7 @@
 		"outputs": [
 			{
 				"f": "fbm_shard(vec3($uv,$offset_in($uv)),vec3($sx,$sy,1.0),int($folds),int($iter),$per,pow(2,$sharp_in($uv)*$sharp*8.0),$seed)",
-				"longdesc": "Greyscale image of the generated noise",
+				"longdesc": "Grayscale image of the generated noise",
 				"shortdesc": "Output",
 				"type": "f"
 			}

--- a/addons/material_maker/sdf_builder/sdf2d/alter/color.gd
+++ b/addons/material_maker/sdf_builder/sdf2d/alter/color.gd
@@ -2,7 +2,7 @@ extends "res://addons/material_maker/sdf_builder/sdf2d/boolean/union.gd"
 
 
 @export var channel_name : String
-@export var type : int # (int, "greyscale", "rgb", "rgba")
+@export var type : int # (int, "grayscale", "rgb", "rgba")
 
 
 func _ready():

--- a/addons/material_maker/sdf_builder/sdf3d/color.gd
+++ b/addons/material_maker/sdf_builder/sdf3d/color.gd
@@ -2,7 +2,7 @@ extends "res://addons/material_maker/sdf_builder/sdf3d/boolean/union.gd"
 
 
 @export var channel_name : String
-@export var type : int # (int, "greyscale", "rgb", "rgba")
+@export var type : int # (int, "grayscale", "rgb", "rgba")
 
 
 func _ready():

--- a/material_maker/doc/shader_nodes.rst
+++ b/material_maker/doc/shader_nodes.rst
@@ -59,7 +59,7 @@ Inputs
 ~~~~~~
 
 Inputs can be added and removed, have a name and a label (but no label trick) just
-like parameters. they also have a type that can be **Greyscale**, **Color** or
+like parameters. they also have a type that can be **Grayscale**, **Color** or
 **RGBA**.
 Please note that Material Maker will convert automatically if you connect an input
 to an output of a different but compatible type.
@@ -68,7 +68,7 @@ The yellow document button can be used to define a name and add a tooltip to the
 
 On the right of the input type, you must define a default value that will be used
 if the input is not connected. The default value is a GLSL expression that must
-evaluate to a **float** for **Greyscale**, a **vec3** for **Color** or a **vec4**
+evaluate to a **float** for **Grayscale**, a **vec3** for **Color** or a **vec4**
 for **RGBA**. Inputs default values can use the **$uv** implicit variable. You may
 want to define interesting default inputs for your nodes, so it is possible
 to see their effect without connecting the inputs (the screenshot above is the
@@ -88,7 +88,7 @@ Outputs
 
 Outputs are defined in the **Outputs** tab and are very similar to inputs, but instead
 of a default value, the generated value of the output should be specified as a
-GLSL expression (**float** for **Greyscale**, a **vec3** for **Color** or a
+GLSL expression (**float** for **Grayscale**, a **vec3** for **Color** or a
 **vec4** for **RGBA**). This expression can use everything in the node (parameters,
 inputs, main code, instance functions and global functions) except other outputs.
 And generally, complex nodes mean complex output expressions. You may thus want to

--- a/material_maker/library/base_brushes.json
+++ b/material_maker/library/base_brushes.json
@@ -7709,7 +7709,7 @@
 						"global": "vec3 brush_flatten(vec2 uv, vec2 angle, vec3 v) {\n\tvec3 target_normal = normalize(view_back*cos(angle.x)*cos(angle.y)+view_right*sin(angle.x)+view_up*sin(angle.y));\n\tvec3 mesh_normal = normalize(texture(mesh_normal_tex, uv).rgb*2.0-vec3(1.0));\n\tvec3 mesh_tangent = normalize(texture(mesh_tangent_tex, uv).rgb*2.0-vec3(1.0));\n\tvec3 mesh_bitangent = cross(mesh_normal, mesh_tangent);\n\treturn vec3(0.5)+0.5*normalize(v*vec3(dot(target_normal, mesh_tangent), dot(target_normal, mesh_bitangent), dot(target_normal, mesh_normal)));\n}\n",
 						"inputs": [],
 						"instance": "",
-						"longdesc": "Draws a uniform greyscale image",
+						"longdesc": "Draws a uniform grayscale image",
 						"name": "Flatten",
 						"outputs": [
 							{
@@ -7856,7 +7856,7 @@
 						"global": "vec3 brush_flatten(vec2 uv, vec2 angle, vec3 v) {\n\tvec3 target_normal = normalize(view_back*cos(angle.x)*cos(angle.y)+view_right*sin(angle.x)+view_up*sin(angle.y));\n\tvec3 mesh_normal = normalize(texture(mesh_normal_tex, uv).rgb*2.0-vec3(1.0));\n\tvec3 mesh_tangent = normalize(texture(mesh_tangent_tex, uv).rgb*2.0-vec3(1.0));\n\tvec3 mesh_bitangent = cross(mesh_normal, mesh_tangent);\n\treturn vec3(0.5)+0.5*normalize(v*vec3(dot(target_normal, mesh_tangent), dot(target_normal, mesh_bitangent), dot(target_normal, mesh_normal)));\n}\n",
 						"inputs": [],
 						"instance": "",
-						"longdesc": "Draws a uniform greyscale image",
+						"longdesc": "Draws a uniform grayscale image",
 						"name": "Flatten",
 						"outputs": [
 							{


### PR DESCRIPTION
- Turns several `Greyscale` to `Grayscale` to make it consistent as per https://github.com/RodZill4/material-maker/issues/460
