### PR TITLE
Fixed reroute preview showing previous linked node on undo

### DIFF
--- a/material_maker/nodes/reroute/reroute.gd
+++ b/material_maker/nodes/reroute/reroute.gd
@@ -91,6 +91,8 @@ func on_parameter_changed(n : String, v):
 		disable_undoredo_for_offset = true
 		position_offset -= (size-old_size)/2
 		disable_undoredo_for_offset = false
+	else:
+		update_preview()
 
 func set_preview(v : int):
 	var preview : Control = null


### PR DESCRIPTION
Fixed an issue where the reroute preview still shows output from the previous link even after the link is severed by undo

Current:

https://github.com/user-attachments/assets/cad339ad-32cd-4cd2-ba35-c1510e8bcc92

PR:

https://github.com/user-attachments/assets/3ea47798-d123-4ace-9f75-39b17ea1edf8