### PR TITLE
Fix double file dialog for linux (i.e. flatpak)

### DIFF
--- a/material_maker/windows/file_dialog/file_dialog.tscn
+++ b/material_maker/windows/file_dialog/file_dialog.tscn
@@ -6,7 +6,7 @@
 title = "Open a File"
 initial_position = 2
 size = Vector2i(500, 400)
-visible = true
+visible = false
 ok_button_text = "Open"
 file_mode = 0
 access = 2


### PR DESCRIPTION
This should not have any effect on other platforms, but on Linux (i.e. flatpak) this fixes the native filedialog being shown twice.

Opening this PR as per Calinou's suggestion via 
- https://github.com/flathub/io.github.RodZill4.Material-Maker/pull/17