### PR TITLE
Fix "Fill To Random Color" repeating colors on adjacent tiles

### DIFF
--- a/addons/material_maker/nodes/fill_to_random_color3.mmg
+++ b/addons/material_maker/nodes/fill_to_random_color3.mmg
@@ -1,0 +1,59 @@
+{
+	"name": "fill_to_random_color3",
+	"node_position": {
+		"x": 0,
+		"y": 0
+	},
+	"parameters": {
+		"edgecolor": {
+			"a": 1,
+			"b": 1,
+			"g": 1,
+			"r": 1,
+			"type": "Color"
+		}
+	},
+	"seed_int": 0,
+	"shader_model": {
+		"code": "vec4 $(name_uv)_bb = $in($uv);",
+		"global": "",
+		"inputs": [
+			{
+				"default": "vec4(0.0)",
+				"label": "",
+				"longdesc": "The input fill data, to be connected to the output of a Fill node",
+				"name": "in",
+				"shortdesc": "Input",
+				"type": "fill"
+			}
+		],
+		"instance": "",
+		"longdesc": "A fill companion node that fills each area with a random color",
+		"name": "Fill to Random Color        ",
+		"outputs": [
+			{
+				"longdesc": "The generated output image",
+				"rgb": "mix($edgecolor.rgb, rand3_4d(vec4($(name_uv)_bb.xy, $(name_uv)_bb.z + float($seed), $(name_uv)_bb.w)), step(0.0000001, dot($(name_uv)_bb.zw, vec2(1.0))))",
+				"shortdesc": "Output",
+				"type": "rgb"
+			}
+		],
+		"parameters": [
+			{
+				"default": {
+					"a": 1,
+					"b": 1,
+					"g": 1,
+					"r": 1
+				},
+				"label": "Edge Color",
+				"longdesc": "The color used for outlines",
+				"name": "edgecolor",
+				"shortdesc": "Outline color",
+				"type": "color"
+			}
+		],
+		"shortdesc": "Fill to random color"
+	},
+	"type": "shader"
+}

--- a/addons/material_maker/shader_functions.tres
+++ b/addons/material_maker/shader_functions.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="TextResource" load_steps=2 format=3 uid="uid://by8m5knpg5yqf"]
 
-[ext_resource type="Script" path="res://addons/material_maker/engine/text_resource.gd" id="1_o2e2t"]
+[ext_resource type="Script" uid="uid://bc3eljtuurjsd" path="res://addons/material_maker/engine/text_resource.gd" id="1_o2e2t"]
 
 [resource]
 script = ExtResource("1_o2e2t")
@@ -22,6 +22,15 @@ vec3 rand3(vec2 x) {
 							  dot(x, vec2(3.4562, 17.398)),
                               dot(x, vec2(13.254, 5.867))), vec3(3.14, 3.14, 3.14))) * 43758.5);
 }
+
+vec3 rand3_4d(vec4 x) {
+    return fract(cos(mod(vec3(
+        dot(x, vec4(13.9898, 8.141, 3.4562, 17.398)),
+        dot(x + 0.1234, vec4(3.4562, 17.398, 13.254, 5.867)),
+        dot(x + 0.5678, vec4(11.1357, 23.234, 95.346, 9.123))
+    ), vec3(3.14))) * 43758.5);
+}
+
 vec3 rgb2hsv(vec3 c) {
 	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
 	vec4 p = c.g < c.b ? vec4(c.bg, K.wz) : vec4(c.gb, K.xy);

--- a/material_maker/library/base.json
+++ b/material_maker/library/base.json
@@ -3069,7 +3069,7 @@
 				}
 			},
 			"tree_item": "Filter/Fill/To Random Color",
-			"type": "fill_to_random_color2"
+			"type": "fill_to_random_color3"
 		},
 		{
 			"display_name": "To UV",


### PR DESCRIPTION
- Added `fill_to_random_color3.mmg`
- Updated `base.json` to use the new node
- Added `rand3_4d(vec4)` to `shader_functions.tres`
- Replaced nested 2D random calls with a single 4D-based function

Fixes issue #632. 

**Before:**  
<img src="https://github.com/user-attachments/assets/4760aa19-81b2-4619-a8b0-b345361e5c25" width="400">

**After:**  
<img src="https://github.com/user-attachments/assets/7fd8e4d0-8d89-4290-8a0b-4a43d52921c1" width="400">
