### PR TITLE
Only include master branch builds for dev builds link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ brew install --cask material-maker
 
 Can't wait for next release? Automated builds from master branch are available (use at your own risk):
 
-<a href="https://github.com/RodZill4/material-maker/actions">
+<a href="https://github.com/RodZill4/material-maker/actions?query=branch%3Amaster">
     <img src="https://github.com/RodZill4/material-maker/workflows/dev-desktop-builds/badge.svg" alt="Build Passing" />
 </a>
 


### PR DESCRIPTION
Update `README.md`'s dev-desktop-builds link to only include builds on the master branch. Currently the link also lists builds triggered from PRs which can be confusing for users