### PR TITLE
Fixed reroute positions when added from in/output

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -1330,7 +1330,7 @@ func add_reroute_to_input(node : MMGraphNodeMinimal, port_index : int) -> void:
 	if ! removed:
 		var global_scale = Vector2(1, 1) # node.get_global_transform().get_scale()
 		var port_position = node.position_offset+node.get_input_port_position(port_index)/global_scale
-		var reroute_position = port_position+Vector2(-74, -16)
+		var reroute_position = port_position+Vector2(-74, -12)
 		var reroute_node = {name="reroute",type="reroute",node_position={x=reroute_position.x,y=reroute_position.y}}
 		for c2 in get_connection_list():
 			if c2.to_node == node.name and c2.to_port == port_index:
@@ -1363,7 +1363,7 @@ func add_reroute_to_output(node : MMGraphNodeMinimal, port_index : int) -> void:
 	if !reroutes:
 		var global_scale = Vector2(1, 1) # node.get_global_transform().get_scale()
 		var port_position = node.position_offset+node.get_output_port_position(port_index)/global_scale
-		var reroute_position = port_position+Vector2(50, -16)
+		var reroute_position = port_position+Vector2(50, -12)
 		var reroute_node = {name="reroute",type="reroute",node_position={x=reroute_position.x,y=reroute_position.y}}
 		var reroute_connections = [ { from=node.generator.name, from_port=port_index, to="reroute", to_port=0 }]
 		for d in destinations:


### PR DESCRIPTION
- Introduced in https://github.com/RodZill4/material-maker/pull/1119 where I forgot to account for the change in node size

Current:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/0fe63371-ca94-460c-a64c-a07d663b0a16" />


PR:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ecdc02c5-30e6-4215-b703-9319bab08fdb" />
