### PR TITLE
Hide native favorites/recents for FileDialog

### DIFF
--- a/material_maker/windows/file_dialog/file_dialog.tscn
+++ b/material_maker/windows/file_dialog/file_dialog.tscn
@@ -10,6 +10,8 @@ visible = true
 ok_button_text = "Open"
 file_mode = 0
 access = 2
+favorites_enabled = false
+recent_list_enabled = false
 script = ExtResource("1")
 
 [connection signal="canceled" from="." to="." method="_on_FileDialog_popup_hide"]


### PR DESCRIPTION
Hides the native Favorites and Recents for the FileDialog, as there doesn't seem to be any functions to save/load them yet - we might have to keep the dialog hack around a bit longer