### PR TITLE
Fix Morphology node Y dilation to use resolution

### DIFF
--- a/addons/material_maker/nodes/morphology2.mmg
+++ b/addons/material_maker/nodes/morphology2.mmg
@@ -417,6 +417,14 @@
 						{
 							"node": "buffer_3",
 							"widget": "size"
+						},
+						{
+							"node": "shape_4",
+							"widget": "s"
+						},
+						{
+							"node": "buffer_2",
+							"widget": "size"
 						}
 					],
 					"longdesc": "Resolution of the generated image",


### PR DESCRIPTION
### What this PR does
In the Morphology node, only dilation X is currently controlled by the resolution parameter, while dilation Y is set to 1024px.  
This PR connects dilation Y to the resolution parameter as well, so both X and Y scale correctly with resolution.

### Before
<img width="1478" height="797" alt="morph" src="https://github.com/user-attachments/assets/333c4a36-77c1-4ea1-b3b8-a172556796ea" />

### After
<img width="1399" height="894" alt="morph_after" src="https://github.com/user-attachments/assets/55009e7c-ae3d-4a5d-9f34-d0c1318cfa73" />
