### PR TITLE
Fixed file dialog save button text

### DIFF
--- a/material_maker/windows/file_dialog/file_dialog.gd
+++ b/material_maker/windows/file_dialog/file_dialog.gd
@@ -14,6 +14,8 @@ func _context_menu_about_to_popup(context_menu : PopupMenu):
 			get_mouse_position() * _content_scale_factor)
 
 func _ready() -> void:
+	if file_mode == FileMode.FILE_MODE_SAVE_FILE:
+		ok_button_text = tr("Save")
 	_content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
 	content_scale_factor = _content_scale_factor
 	


### PR DESCRIPTION
Fixed cases where `Save` button should have the `Save` text but shown as `Open`:

**Current / PR**

![current-v-pr](https://github.com/user-attachments/assets/bb703a9c-5a56-433a-8622-2141a3e90a04)
