### PR TITLE
Change graph zoom range to 5%-400% for better overview

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -1,6 +1,8 @@
 extends GraphEdit
 class_name MMGraphEdit
 
+const ZOOM_MIN := 0.05
+const ZOOM_MAX := 4.0
 
 class Preview:
 	var generator
@@ -54,6 +56,8 @@ signal preview_changed
 
 func _ready() -> void:
 	OS.low_processor_usage_mode = true
+	zoom_min = ZOOM_MIN
+	zoom_max = ZOOM_MAX
 	center_view()
 	for t in range(41):
 		add_valid_connection_type(t, 42)

--- a/material_maker/panels/graph_edit/graph_zoom_menu.gd
+++ b/material_maker/panels/graph_edit/graph_zoom_menu.gd
@@ -34,7 +34,7 @@ func _on_zoom_reset_pressed() -> void:
 
 
 func update_zoom() -> void:
-	zoom_level = clamp(zoom_level, 0.25, 2)
+	zoom_level = clamp(zoom_level, MMGraphEdit.ZOOM_MIN, MMGraphEdit.ZOOM_MAX)
 	%ZoomLabel.text = str(zoom_level*100).pad_decimals(0)+"%"
 	var graph_edit : GraphEdit = mm_globals.main_window.get_current_graph_edit()
 	if graph_edit:


### PR DESCRIPTION
Currently, the zoom range in MMGraphEdit is limited to 25%-200%, which makes it difficult to get an overview of large graphs.

**This PR adjusts the zoom limits as follows:**
Zoom Min: 5% (0.05) - allows a better overview of large graphs.
Zoom Max: 400% (4.0) - enables closer inspection of previews in the graph.

**PR (new zoom range 5%-400%):**  
<img src="https://github.com/user-attachments/assets/606a745d-5b10-4478-ba41-a14d4f7bc822" width="300">

**Current (old zoom range 25%-200%):**  
<img src="https://github.com/user-attachments/assets/48efd2b1-8994-4631-a211-62a65ddaa8c5" width="300">