### PR TITLE
Fix VRAM leak in Preview2DPanel

### DIFF
--- a/material_maker/panels/preview_2d/preview_2d_panel.gd
+++ b/material_maker/panels/preview_2d/preview_2d_panel.gd
@@ -110,6 +110,14 @@ func get_shader_custom_functions():
 
 
 func set_generator(g : MMGenBase, o : int = 0, force : bool = false) -> void:
+	if generator and is_instance_valid(generator):
+		if not is_instance_valid(g) or g != generator:
+			var old_id = generator.get_instance_id()
+			var old_tex_name = "o%d_tex" % old_id
+			if material and material.get_shader_parameter(old_tex_name):
+				# Clean up reference to old buffer texture to free VRAM
+				material.set_shader_parameter(old_tex_name, null)
+
 	super.set_generator(g, o, force)
 	update_shader_options()
 


### PR DESCRIPTION
**Issue**
When previewing a buffer node in the 2D preview panel, the texture wasn’t getting released from VRAM after deleting the node.
The old material shader kept a reference to the texture in one of its parameters, so it never got freed.

**Fix**
Added a check in Preview2DPanel.set_generator() to clean up the old texture reference before switching shaders.
If the old generator buffer texture is still set on the material, it now sets that shader parameter to null, letting the VRAM free up.


**Related**
There’s also a case where deleting a buffer node after deactivating its preview slot leaves behind an orphaned Preview2D node, which prevents VRAM cleanup since that orphaned node keeps a reference to the old buffer texture.
#917

**Before:**
![vram_buffer_before_pr](https://github.com/user-attachments/assets/b71d4eca-c9d2-4148-bf75-fc3e93e4e685)

**After:**
![vram_buffer_after_pr](https://github.com/user-attachments/assets/fc38dc21-7c84-4b58-a029-8091728c7130)

