### PR TITLE
Improved FloatEdit uneditable font color

### DIFF
--- a/material_maker/widgets/float_edit/float_edit.gd
+++ b/material_maker/widgets/float_edit/float_edit.gd
@@ -289,7 +289,10 @@ func update() -> void:
 	$Slider.add_theme_stylebox_override("fill", get_theme_stylebox("fill_hover" if is_hovered else "fill_normal"))
 	$Slider.add_theme_stylebox_override("background", get_theme_stylebox("hover" if is_hovered else "normal"))
 
-	$Edit.add_theme_color_override("font_uneditable_color", get_theme_color("font_color"))
+	if editable:
+		$Edit.add_theme_color_override("font_uneditable_color", get_theme_color("font_color"))
+	else:
+		$Edit.remove_theme_color_override("font_uneditable_color")
 	$Edit.queue_redraw()
 
 


### PR DESCRIPTION
Improves uneditable FloatEdit font colors so they properly gray out (i.e. read-only environments), currently they have the same appearance whether they are editable or not

|  | Normal  | Uneditable |
| ------------- | ------------- | ------------- |
| Dark | <img width="175" alt="dark_normal" src="https://github.com/user-attachments/assets/7c11a4dc-6071-49a3-9c85-59474446179d" />  | <img width="175" alt="dark_uneditable" src="https://github.com/user-attachments/assets/dce43cb4-ba09-4c42-bac2-31ad0c44379e" /> |
| Light | <img width="175" alt="light_normal" src="https://github.com/user-attachments/assets/580e678b-9dc7-4f95-bdfb-fe47ae717309" />  | <img width="175" alt="light_uneditable" src="https://github.com/user-attachments/assets/23bf0612-63bc-4c14-bd99-2c23ad930890" /> |
| Classic | <img width="175" alt="classic_normal" src="https://github.com/user-attachments/assets/9c1ef9d8-c7bc-4520-9804-2aeed16147ed" />  | <img width="175" alt="classic_uneditable" src="https://github.com/user-attachments/assets/2ae503ab-4d6e-4027-b696-ad691b799bae" /> |
