### PR TITLE
Made environment editor labels casing consistent

### DIFF
--- a/material_maker/windows/environment_editor/environment_editor.tscn
+++ b/material_maker/windows/environment_editor/environment_editor.tscn
@@ -91,7 +91,7 @@ float_only = true
 
 [node name="AmbientLightLabel" type="Label" parent="Main/HSplitContainer/UI"]
 layout_mode = 2
-text = "Ambient color:"
+text = "Ambient Color:"
 
 [node name="ambient_light_color" type="ColorPickerButton" parent="Main/HSplitContainer/UI"]
 layout_mode = 2
@@ -111,7 +111,7 @@ float_only = true
 
 [node name="AmbientLightSkyContributionLabel" type="Label" parent="Main/HSplitContainer/UI"]
 layout_mode = 2
-text = "Sky contribution:"
+text = "Sky Contribution:"
 
 [node name="ambient_light_sky_contribution" parent="Main/HSplitContainer/UI" instance=ExtResource("3")]
 layout_mode = 2
@@ -122,7 +122,7 @@ float_only = true
 
 [node name="SunLabel" type="Label" parent="Main/HSplitContainer/UI"]
 layout_mode = 2
-text = "Sun color:"
+text = "Sun Color:"
 
 [node name="sun_color" type="ColorPickerButton" parent="Main/HSplitContainer/UI"]
 layout_mode = 2


### PR DESCRIPTION
Most labels uses title casing, this makes it consistent for all labels:

**Current**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/f4e0afc2-9b08-4c36-8f32-9caa38b07bdd" />

**PR**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/88e29ac2-5787-4fab-b2dd-ca06fa9c2e20" />
