### PR TITLE
Fixed ORM texture not loaded into slot for godot4

### DIFF
--- a/addons/material_maker/nodes/material.mmg
+++ b/addons/material_maker/nodes/material.mmg
@@ -264,7 +264,7 @@
 							"$if $(connected:albedo_tex)",
 							"albedo_texture = ExtResource( 1 )",
 							"$fi",
-							"$if $(connected:metallic_tex)",
+							"$if $(connected:ao_tex) or $(connected:roughness_tex) or $(connected:metallic_tex)",
 							"orm_texture = ExtResource( 2 )",
 							"$fi",
 							"$if $(connected:normal_tex)",

--- a/addons/material_maker/nodes/material_tesselated.mmg
+++ b/addons/material_maker/nodes/material_tesselated.mmg
@@ -259,7 +259,7 @@
 							"$if $(connected:albedo_tex)",
 							"albedo_texture = ExtResource( 1 )",
 							"$fi",
-							"$if $(connected:metallic_tex)",
+							"$if $(connected:ao_tex) or $(connected:roughness_tex) or $(connected:metallic_tex)",
 							"orm_texture = ExtResource( 2 )",
 							"$fi",
 							"$if $(connected:normal_tex)",


### PR DESCRIPTION
Fixes ORM texture not loaded to slot in .tres if metallic texture is not connected