### PR TITLE
Made godot export target names consistent

### DIFF
--- a/addons/material_maker/nodes/material_tesselated.mmg
+++ b/addons/material_maker/nodes/material_tesselated.mmg
@@ -79,7 +79,7 @@
 					}
 				]
 			},
-			"Godot/G3 Spatial": {
+			"Godot/Godot 3 Spatial": {
 				"export_extension": "tres",
 				"files": [
 					{
@@ -193,7 +193,7 @@
 					}
 				]
 			},
-			"Godot/G4 ORM": {
+			"Godot/Godot 4 ORM": {
 				"export_extension": "tres",
 				"files": [
 					{
@@ -292,7 +292,7 @@
 					}
 				]
 			},
-			"Godot/G4 Standard": {
+			"Godot/Godot 4 Standard": {
 				"export_extension": "tres",
 				"files": [
 					{


### PR DESCRIPTION
Makes it consistent across both static pbr/displacement targets

`G3` > `Godot 3`
`G4` > `Godot 4`