### PR TITLE
Fixed library creation dialog icon button

### DIFF
--- a/material_maker/widgets/file_picker_button/file_picker_button.gd
+++ b/material_maker/widgets/file_picker_button/file_picker_button.gd
@@ -15,8 +15,9 @@ func set_mode(m):
 	mode = m
 
 func set_path(p : String) -> void:
-	path = p
-	text = path.get_file()
+	if not icon:
+		path = p
+		text = path.get_file()
 
 func add_filter(f : String) -> void:
 	filters.append(f)


### PR DESCRIPTION
Fixes file picker button showing text after selecting a path by checking if an icon is set