### PR TITLE
Fixed dynamic unlit export for unity

### DIFF
--- a/addons/material_maker/nodes/material_unlit.mmg
+++ b/addons/material_maker/nodes/material_unlit.mmg
@@ -241,12 +241,12 @@
 			},
 			"Unity": {
 				"custom": [
-					"func process_option_unity_unlit_tags(input_template : String, _is_definitions : bool) -> String:",
+					"func process_option_unity_unlit_tags(input_template : String, _is_declaration : bool) -> String:",
 					"\tvar blend : String = input_template.strip_edges()",
 					"\tvar out_tag : String = \"Opaque\" if blend == \"mix\" else \"Transparent\"",
 					"\treturn \"\\t\\tTags { \\\"RenderType\\\"=\\\"%s\\\" \\\"Queue\\\"=\\\"%s\\\" }\\n\" % [ out_tag, out_tag ]",
 					"",
-					"func process_option_unity_unlit_blend(input_template : String, _is_definitions : bool) -> String:",
+					"func process_option_unity_unlit_blend(input_template : String, _is_declaration : bool) -> String:",
 					"\tvar blend : String = input_template.strip_edges()",
 					"\tvar blend_mode : String",
 					"\tmatch blend:",


### PR DESCRIPTION
This PR:
- Exports blend mode selection for unity by choosing the appropriate blend command in the generated shader:
https://docs.unity3d.com/Manual/SL-Blend.html
- Fixes buffered texture/images not loading by adding textures slots(material properties)


https://github.com/user-attachments/assets/5b63a292-2f1d-4aa5-8ce8-a24175ce8838

