### PR TITLE
Set image node filedialog path to image directory

### DIFF
--- a/material_maker/widgets/image_picker_button/image_picker_button.gd
+++ b/material_maker/widgets/image_picker_button/image_picker_button.gd
@@ -49,6 +49,10 @@ func get_filetime(file_path: String) -> int:
 
 func open_image_dialog() -> void:
 	var dialog = preload("res://material_maker/windows/file_dialog/file_dialog.tscn").instantiate()
+	if image_path:
+		dialog.current_dir = image_path.get_base_dir()
+		if FileAccess.file_exists(image_path):
+			dialog.current_file = image_path.get_file()
 	dialog.min_size = Vector2(500, 500)
 	dialog.access = FileDialog.ACCESS_FILESYSTEM
 	dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE


### PR DESCRIPTION
Based on suggestion via Discord

> clicking on an image node with some image already imported should open open file dialog with the directory where the image is stored instead of directory where MM is stored

This PR sets the FileDialog's current directory to where the image is if the path is set