### PR TITLE
Fixed FloatEdit sliding when data drag hovered over

### DIFF
--- a/material_maker/widgets/float_edit/float_edit.gd
+++ b/material_maker/widgets/float_edit/float_edit.gd
@@ -282,6 +282,10 @@ func _notification(what):
 			if get_theme_stylebox("clip") != get_theme_stylebox("panel"):
 				add_theme_stylebox_override("panel", get_theme_stylebox("clip"))
 			update()
+		NOTIFICATION_DRAG_BEGIN:
+			mouse_filter = Control.MOUSE_FILTER_IGNORE
+		NOTIFICATION_DRAG_END:
+			mouse_filter = Control.MOUSE_FILTER_STOP
 
 
 func update() -> void:


### PR DESCRIPTION
Fixes FloatEdit changing value when mouse is over them while drag/dropping data (tonality, gradient etc.) from other nodes

Current vs PR:

https://github.com/user-attachments/assets/fa42064b-c3c2-4e82-b8e9-4e5db8e2e592


