### PR TITLE
Workaround for macOS native filedialog adding .res for .tres files

### DIFF
--- a/material_maker/windows/file_dialog/file_dialog.gd
+++ b/material_maker/windows/file_dialog/file_dialog.gd
@@ -80,6 +80,11 @@ func select_files() -> Array:
 	popup_centered()
 	var result = await self.return_paths
 	queue_free()
+
+	# Workaround for macOS native file dialog adding .res for .tres files
+	if OS.get_name() == "macOS" and use_native_dialog:
+		result = result.map(func(p): return p.replace(".res.tres", ".tres"))
+
 	return result
 
 func add_favorite():


### PR DESCRIPTION
- https://github.com/RodZill4/material-maker/pull/956