### PR TITLE
Added 3d rotation for vec3 math node

### DIFF
--- a/addons/material_maker/nodes/math_v3.mmg
+++ b/addons/material_maker/nodes/math_v3.mmg
@@ -22,6 +22,9 @@
 			""
 		],
 		"global": "",
+		"includes": [
+			"sdf3d_rotate"
+		],
 		"inputs": [
 			{
 				"default": "vec3($d_in1_x, $d_in1_y, $d_in1_z)",
@@ -187,6 +190,10 @@
 					{
 						"name": "log(A, B)",
 						"value": "log($in1($uv))/log($in2($uv))"
+					},
+					{
+						"name": "rotate(A, B)",
+						"value": "rotate3d($in1($uv),$in2($uv))"
 					}
 				]
 			},


### PR DESCRIPTION
This includes the rotate3d function from `sdf3d_rotate` node

![rotate](https://github.com/user-attachments/assets/b4dfc6e1-73ce-4222-878c-7a45d44f31a3)
