### PR TITLE
Fixed connection knife color/legibility in themes

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -271,7 +271,7 @@ func get_padded_node_rect(graph_node:GraphNode) -> Rect2:
 
 func _draw() -> void:
 	if drag_cut_line.size() > 1:
-		draw_polyline(drag_cut_line, Color.WHITE, 0.5)
+		draw_polyline(drag_cut_line, get_theme_color("connection_knife", "GraphEdit"), 1.0)
 
 
 # Misc. useful functions

--- a/material_maker/theme/classic_base.tres
+++ b/material_maker/theme/classic_base.tres
@@ -837,6 +837,7 @@ CodeEdit/colors/single_line_comment_color = Color(0, 0.509804, 0, 1)
 CodeEdit/colors/symbol_color = Color(1, 1, 1, 1)
 CodeEdit/colors/type_color = Color(1, 1, 0.878431, 1)
 CodeEdit/styles/normal = SubResource("StyleBoxFlat_meah8")
+GraphEdit/colors/connection_knife = Color(1, 1, 1, 1)
 GraphEdit/colors/grid_major = Color(0.321569, 0.337255, 0.384314, 1)
 GraphEdit/colors/grid_minor = Color(0.321569, 0.337255, 0.384314, 1)
 GraphEdit/constants/port_hotzone_inner_extent = 8

--- a/material_maker/theme/default dark.tres
+++ b/material_maker/theme/default dark.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" script_class="EnhancedTheme" load_steps=37 format=3 uid="uid://dhuhq2immquoh"]
+[gd_resource type="Theme" script_class="EnhancedTheme" load_steps=38 format=3 uid="uid://dhuhq2immquoh"]
 
 [ext_resource type="Theme" uid="uid://b628lwfk6ig2c" path="res://material_maker/theme/default.tres" id="3_xjelh"]
 [ext_resource type="Script" uid="uid://3ga2k3abkk0d" path="res://material_maker/theme/enhanced_theme_system/color_swap.gd" id="4_0efyb"]
@@ -187,8 +187,6 @@ target = Color(0.356863, 0.356863, 0.356863, 1)
 [sub_resource type="Resource" id="Resource_430ei"]
 script = ExtResource("4_0efyb")
 name = "RichTextLabel"
-orig = Color(0, 0, 0, 1)
-target = Color(0, 0, 0, 1)
 metadata/_custom_type_script = "uid://3ga2k3abkk0d"
 
 [sub_resource type="Resource" id="Resource_svk4l"]
@@ -205,9 +203,16 @@ orig = Color(0.0980392, 0.0980392, 0.101961, 1)
 target = Color(0.0980392, 0.0980392, 0.101961, 1)
 metadata/_custom_type_script = "uid://3ga2k3abkk0d"
 
+[sub_resource type="Resource" id="Resource_0m7hk"]
+script = ExtResource("4_0efyb")
+name = "GraphEditConnectionKnife"
+orig = Color(0.99215686, 0.9843137, 1, 1)
+target = Color(1, 1, 1, 1)
+metadata/_custom_type_script = "uid://3ga2k3abkk0d"
+
 [resource]
 script = ExtResource("5_yjidp")
 base_theme = ExtResource("3_xjelh")
 font_color_swaps = Array[ExtResource("4_0efyb")]([SubResource("Resource_silay"), SubResource("Resource_eavso"), SubResource("Resource_1jhxl"), SubResource("Resource_qiwix"), SubResource("Resource_5yhcl"), SubResource("Resource_vdnfu"), SubResource("Resource_21aar"), SubResource("Resource_us4qf")])
 icon_color_swaps = Array[ExtResource("4_0efyb")]([SubResource("Resource_cisvi"), SubResource("Resource_j2h7k"), SubResource("Resource_8dhbo"), SubResource("Resource_5oh4i")])
-theme_color_swaps = Array[ExtResource("4_0efyb")]([SubResource("Resource_ub5ur"), SubResource("Resource_5rv7m"), SubResource("Resource_xqbwo"), SubResource("Resource_a2t6i"), SubResource("Resource_pekt7"), SubResource("Resource_vbpcr"), SubResource("Resource_qngft"), SubResource("Resource_5mixu"), SubResource("Resource_kxmra"), SubResource("Resource_siafh"), SubResource("Resource_s732t"), SubResource("Resource_j1t84"), SubResource("Resource_g7e3b"), SubResource("Resource_oirgf"), SubResource("Resource_1pump"), SubResource("Resource_fxm05"), SubResource("Resource_mfxjg"), SubResource("Resource_upxps"), SubResource("Resource_430ei"), SubResource("Resource_svk4l"), SubResource("Resource_i62a2")])
+theme_color_swaps = Array[ExtResource("4_0efyb")]([SubResource("Resource_ub5ur"), SubResource("Resource_5rv7m"), SubResource("Resource_xqbwo"), SubResource("Resource_a2t6i"), SubResource("Resource_pekt7"), SubResource("Resource_vbpcr"), SubResource("Resource_qngft"), SubResource("Resource_5mixu"), SubResource("Resource_kxmra"), SubResource("Resource_siafh"), SubResource("Resource_s732t"), SubResource("Resource_j1t84"), SubResource("Resource_g7e3b"), SubResource("Resource_oirgf"), SubResource("Resource_1pump"), SubResource("Resource_fxm05"), SubResource("Resource_mfxjg"), SubResource("Resource_upxps"), SubResource("Resource_430ei"), SubResource("Resource_svk4l"), SubResource("Resource_i62a2"), SubResource("Resource_0m7hk")])

--- a/material_maker/theme/default light.tres
+++ b/material_maker/theme/default light.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" script_class="EnhancedTheme" load_steps=55 format=3 uid="uid://u00kx2lkkx8j"]
+[gd_resource type="Theme" script_class="EnhancedTheme" load_steps=56 format=3 uid="uid://u00kx2lkkx8j"]
 
 [ext_resource type="Theme" uid="uid://b628lwfk6ig2c" path="res://material_maker/theme/default.tres" id="1_ugsao"]
 [ext_resource type="Script" uid="uid://3ga2k3abkk0d" path="res://material_maker/theme/enhanced_theme_system/color_swap.gd" id="4_rhf2q"]
@@ -209,7 +209,6 @@ target = Color(0.912935, 0.916904, 0.924811, 1)
 script = ExtResource("4_rhf2q")
 name = "RichTextLabel"
 orig = Color(1, 1, 1, 1)
-target = Color(0, 0, 0, 1)
 metadata/_custom_type_script = "uid://3ga2k3abkk0d"
 
 [sub_resource type="Resource" id="Resource_sgt8g"]
@@ -331,9 +330,15 @@ orig = Color(0.301961, 0.305882, 0.309804, 1)
 target = Color(0.2134, 0.2167, 0.22, 0.470588)
 metadata/_custom_type_script = "uid://3ga2k3abkk0d"
 
+[sub_resource type="Resource" id="Resource_2d8ce"]
+script = ExtResource("4_rhf2q")
+name = "GraphEditConnectionKnife"
+orig = Color(0.99215686, 0.9843137, 1, 1)
+metadata/_custom_type_script = "uid://3ga2k3abkk0d"
+
 [resource]
 script = ExtResource("5_fagh3")
 base_theme = ExtResource("1_ugsao")
 font_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_silay"), SubResource("Resource_eavso"), SubResource("Resource_1jhxl"), SubResource("Resource_qiwix"), SubResource("Resource_5yhcl"), SubResource("Resource_vdnfu"), SubResource("Resource_21aar"), SubResource("Resource_us4qf"), SubResource("Resource_3wcad"), SubResource("Resource_mhcke")])
 icon_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_cisvi"), SubResource("Resource_j2h7k"), SubResource("Resource_8dhbo"), SubResource("Resource_5oh4i"), SubResource("Resource_jh8b5")])
-theme_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_ub5ur"), SubResource("Resource_5rv7m"), SubResource("Resource_xqbwo"), SubResource("Resource_a2t6i"), SubResource("Resource_pekt7"), SubResource("Resource_vbpcr"), SubResource("Resource_qngft"), SubResource("Resource_5mixu"), SubResource("Resource_kxmra"), SubResource("Resource_siafh"), SubResource("Resource_s732t"), SubResource("Resource_j1t84"), SubResource("Resource_g7e3b"), SubResource("Resource_oirgf"), SubResource("Resource_1pump"), SubResource("Resource_fxm05"), SubResource("Resource_mfxjg"), SubResource("Resource_upxps"), SubResource("Resource_upxps"), SubResource("Resource_lk0mo"), SubResource("Resource_sgt8g"), SubResource("Resource_p6yfp"), SubResource("Resource_mntha"), SubResource("Resource_5l403"), SubResource("Resource_qx1ic"), SubResource("Resource_skxhu"), SubResource("Resource_gf74u"), SubResource("Resource_6iwcg"), SubResource("Resource_emwrq"), SubResource("Resource_g0345"), SubResource("Resource_mqr67"), SubResource("Resource_enwto"), SubResource("Resource_t0kvp"), SubResource("Resource_tw3yc"), SubResource("Resource_5w06f"), SubResource("Resource_m8hbw"), SubResource("Resource_xnhnj")])
+theme_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_ub5ur"), SubResource("Resource_5rv7m"), SubResource("Resource_xqbwo"), SubResource("Resource_a2t6i"), SubResource("Resource_pekt7"), SubResource("Resource_vbpcr"), SubResource("Resource_qngft"), SubResource("Resource_5mixu"), SubResource("Resource_kxmra"), SubResource("Resource_siafh"), SubResource("Resource_s732t"), SubResource("Resource_j1t84"), SubResource("Resource_g7e3b"), SubResource("Resource_oirgf"), SubResource("Resource_1pump"), SubResource("Resource_fxm05"), SubResource("Resource_mfxjg"), SubResource("Resource_upxps"), SubResource("Resource_upxps"), SubResource("Resource_lk0mo"), SubResource("Resource_sgt8g"), SubResource("Resource_p6yfp"), SubResource("Resource_mntha"), SubResource("Resource_5l403"), SubResource("Resource_qx1ic"), SubResource("Resource_skxhu"), SubResource("Resource_gf74u"), SubResource("Resource_6iwcg"), SubResource("Resource_emwrq"), SubResource("Resource_g0345"), SubResource("Resource_mqr67"), SubResource("Resource_enwto"), SubResource("Resource_t0kvp"), SubResource("Resource_tw3yc"), SubResource("Resource_5w06f"), SubResource("Resource_m8hbw"), SubResource("Resource_xnhnj"), SubResource("Resource_2d8ce")])

--- a/material_maker/theme/default.tres
+++ b/material_maker/theme/default.tres
@@ -1112,6 +1112,7 @@ CodeEdit/styles/normal = SubResource("StyleBoxFlat_oy0ko")
 FileDialog/colors/file_disabled_color = Color(0.301961, 0.305882, 0.309804, 1)
 FileDialog/colors/file_icon_color = Color(0.698039, 0.698039, 0.698039, 1)
 FileDialog/colors/folder_icon_color = Color(0.698039, 0.698039, 0.698039, 1)
+GraphEdit/colors/connection_knife = Color(0.99215686, 0.9843137, 1, 1)
 GraphEdit/colors/grid_major = Color(0.137255, 0.141176, 0.152941, 1)
 GraphEdit/colors/grid_minor = Color(0.137255, 0.141176, 0.152941, 1)
 GraphEdit/constants/port_hotzone_inner_extent = 8


### PR DESCRIPTION
Small improvement so it is a bit more legible (polyline thickness 0.5 > 1.0) and fixed light/dark colors in themes

Dark / Light / Classic:

![preview](https://github.com/user-attachments/assets/528532d7-a01f-4d22-a762-5926822fc210)
