### PR TITLE
Improve buffer timing legibility

### DIFF
--- a/material_maker/nodes/base.gd
+++ b/material_maker/nodes/base.gd
@@ -223,8 +223,11 @@ func _draw() -> void:
 		draw_style_box(get_theme_stylebox("node_highlight"), Rect2(Vector2.ZERO, size))
 	if generator.rendering_time > 0:
 		var time_color : Color = get_rendering_time_color(generator.rendering_time)
-		@warning_ignore("narrowing_conversion")
-		draw_string(font, Vector2i(0, size.y+12), str(generator.rendering_time)+"ms", HORIZONTAL_ALIGNMENT_CENTER, size.x, 12, time_color)
+		var buffer_timing_font : Font = preload("res://material_maker/theme/font_rubik/Rubik-416.ttf")
+		@warning_ignore_start("narrowing_conversion")
+		draw_string_outline(buffer_timing_font, Vector2i(0, size.y+12), str(generator.rendering_time)+"ms", HORIZONTAL_ALIGNMENT_CENTER, size.x, 12, 4, Color.BLACK)
+		draw_string(buffer_timing_font, Vector2i(0, size.y+12), str(generator.rendering_time)+"ms", HORIZONTAL_ALIGNMENT_CENTER, size.x, 12, time_color)
+		@warning_ignore_restore("narrowing_conversion")
 	if generator != null and generator.preview >= 0 and get_output_port_count() > 0:
 		var conn_pos = get_output_port_position(generator.preview)
 		draw_circle(conn_pos, 3, portpreview_color, true)


### PR DESCRIPTION
Makes buffer timings more legible, especially on light theme

Current vs PR (120% zoom in graph)

<img width="2295" height="1440" alt="Artboard" src="https://github.com/user-attachments/assets/d21b7286-0ea6-465b-b1ef-969204358fc2" />