### PR TITLE
Added node inputs swapping (Alt+S)

### DIFF
--- a/material_maker/doc/user_interface_main_menu.rst
+++ b/material_maker/doc/user_interface_main_menu.rst
@@ -65,6 +65,9 @@ Edit menu
 
 * *Duplicate with inputs* is similar to *Duplicate*, but with input links kept
 
+* *Swap node inputs* swap inputs of the selected node. When there is exactly one
+  input, this cycles through compatible slots of for the existing connection. 
+
 * *Frame selected nodes* creates a comment node that frames selected nodes
 
 * *Select all* selects all nodes in the current graph view

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -74,6 +74,7 @@ const MENU : Array[Dictionary] = [
 	{ menu="Edit/Paste", command="edit_paste", shortcut="Control+V" },
 	{ menu="Edit/Duplicate", command="edit_duplicate", shortcut="Control+D" },
 	{ menu="Edit/Duplicate with inputs", command="edit_duplicate_with_inputs", shortcut="Control+Shift+D" },
+	{ menu="Edit/Swap node inputs", command="edit_swap_node_inputs", shortcut="Alt+S"},
 	{ menu="Edit/-" },
 	{ menu="Edit/Frame selected nodes", command="frame_nodes", shortcut="Control+Shift+F" },
 	{ menu="Edit/-" },
@@ -874,6 +875,11 @@ func edit_duplicate_with_inputs() -> void:
 
 func edit_duplicate_with_inputs_is_disabled() -> bool:
 	return edit_cut_is_disabled()
+
+func edit_swap_node_inputs() -> void:
+	var graph_edit : MMGraphEdit = get_current_graph_edit()
+	if graph_edit != null:
+		graph_edit.swap_node_inputs()
 
 func edit_select_all() -> void:
 	var graph_edit : MMGraphEdit = get_current_graph_edit()


### PR DESCRIPTION
Add node input swapping similar to Blender(Alt-S), based on suggestion via discord

> allow swapping node connections by holding shift+drag or something similar (in blender its alt). sometimes when using the Blend node i want to swap background & layer1 and then you have to move one then grab the output of the other node and reconnect that one.

https://github.com/user-attachments/assets/439ac6e8-9f1a-4c71-beba-3ad5584ab421

