### PR TITLE
Improve GradientEdit peformance

### DIFF
--- a/material_maker/widgets/gradient_editor/gradient_edit.tscn
+++ b/material_maker/widgets/gradient_editor/gradient_edit.tscn
@@ -39,7 +39,6 @@ layout_mode = 2
 theme_override_constants/separation = 0
 
 [node name="PanelContainer" type="Panel" parent="HBoxContainer"]
-clip_children = 1
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 2


### PR DESCRIPTION
This sets the container's `Clip Children` property to `Disabled`.

https://github.com/user-attachments/assets/ac981909-85f5-4944-8dc2-a4add342fdcf

Round corners are gone(around the gradient) as a result but I think this is worth it until the issue gets fixed in Godot
- https://github.com/godotengine/godot/issues/114510