### PR TITLE
Fixed mesh map node not working in macOS

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -140,6 +140,7 @@ limits/debugger/max_chars_per_second=204800000
 
 [rendering]
 
+rendering_device/driver.macos="vulkan"
 textures/vram_compression/import_etc2_astc=true
 shading/overrides/force_lambert_over_burley.mobile=false
 environment/defaults/default_environment="res://default_env.tres"


### PR DESCRIPTION
This is fixed in 4.6 via https://github.com/godotengine/godot/commit/edbfb7a6ece0edf228ba9531bc9428cfa183124a but until we can update to 4.6 this changes the rendering backend to Vulkan to workaround the issue:

**Metal:**
<img width="700" alt="metal" src="https://github.com/user-attachments/assets/7322ad93-bfa5-41a0-81a0-16108f162f7c" />


**Vulkan:**
<img width="700" alt="vulkan" src="https://github.com/user-attachments/assets/d6ec0969-9dd0-4e10-ba7c-3f2a63cb97eb" />
