### PR TITLE
Removed `sips` step for mac in dev-desktop-builds

### DIFF
--- a/.github/workflows/dev-desktop-builds.yml
+++ b/.github/workflows/dev-desktop-builds.yml
@@ -171,8 +171,6 @@ jobs:
           unzip -a ./build/mac/material_maker.zip -d ./build/mac
           chmod +x "./build/mac/Material Maker.app/Contents/MacOS/Material Maker"
           rm ./build/mac/material_maker.zip
-      - name: Fix application icon 🖼
-        run: sips -s format icns "./build/mac/Material Maker.app/Contents/Resources/icon.icns" --out "./build/mac/Material Maker.app/Contents/Resources/icon.icns"
       - name: Get documentation 🚀
         if: ${{ github.event.inputs.gen_doc == 'true' }}
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Resulting icon is missing a lot of the sizes (Current)

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ee9b682e-0487-48a7-8784-8ce1431317e4" />

PR

<img width="500" alt="image" src="https://github.com/user-attachments/assets/09d4ee54-161c-4136-9387-a11a7e4bc117" />
