### PR TITLE
Fixed share asset dialog size on hidpi displays

### DIFF
--- a/material_maker/tools/share/upload_dialog.gd
+++ b/material_maker/tools/share/upload_dialog.gd
@@ -63,7 +63,7 @@ func ask(data : Dictionary) -> Dictionary:
 	return {}
 
 func _on_MarginContainer_minimum_size_changed():
-	size = $MarginContainer.get_minimum_size()
+	size = $MarginContainer.get_minimum_size() * get_tree().root.content_scale_factor
 
 func validate_form():
 	var valid = true


### PR DESCRIPTION
Fixes controls being clipped when the dialog is shown.

Current

<img width="500" alt="before" src="https://github.com/user-attachments/assets/59882ea2-0b25-42ac-9e4a-b5b622c17728" />

PR

<img width="500" alt="after" src="https://github.com/user-attachments/assets/3648225e-ca6f-4c9a-a285-fc1dac4db649" />
