### PR TITLE
Retain subgraph offsets

### DIFF
--- a/addons/material_maker/engine/nodes/gen_graph.gd
+++ b/addons/material_maker/engine/nodes/gen_graph.gd
@@ -13,6 +13,7 @@ var transmits_seed : bool = true
 
 var current_mesh : Mesh = null
 
+var scroll_offset = null
 
 signal graph_changed()
 signal connections_changed(removed_connections, added_connections)
@@ -426,7 +427,7 @@ func create_subgraph(gens : Array) -> MMGenGraph:
 	var right_bound = -65536
 	var upper_bound = 65536
 	var count = 0
-	# Filter group nodes and calculate boundin box
+	# Filter group nodes and calculate bounding box
 	for g in gens:
 		if g.name != "Material" and g.name != "Brush" and g.name != "gen_inputs" and g.name != "gen_outputs":
 			generators.push_back(g)
@@ -534,6 +535,8 @@ func _serialize(data: Dictionary) -> Dictionary:
 		data.nodes.append(c.serialize())
 	#data.connections = connections_to_compact(connections)
 	data.connections = connections
+	if scroll_offset:
+		data.scroll_offset = { x=scroll_offset.x, y=scroll_offset.y }
 	return data
 
 func _deserialize(data : Dictionary) -> void:
@@ -550,6 +553,8 @@ func _deserialize(data : Dictionary) -> void:
 			connection_array = data.connections
 		elif data.connections is Dictionary:
 			connection_array = connections_from_compact(data.connections)
+	if data.has("scroll_offset"):
+		scroll_offset = Vector2(data.scroll_offset.x, data.scroll_offset.y)
 	var new_stuff = await mm_loader.add_to_gen_graph(self, nodes, connection_array)
 
 #region Node Graph Diff

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -564,6 +564,7 @@ func center_view() -> void:
 func update_view(g) -> void:
 	if generator != null and is_instance_valid(generator):
 		generator.disconnect("connections_changed", Callable(self, "on_connections_changed"))
+		generator.set_deferred("scroll_offset", scroll_offset)
 	clear_view()
 	generator = g
 	if generator != null:
@@ -574,14 +575,16 @@ func update_view(g) -> void:
 	$GraphUI/SubGraphUI/Description.short_description = generator.shortdesc
 	$GraphUI/SubGraphUI/Description.long_description = generator.longdesc
 	$GraphUI/SubGraphUI/Description.update_tooltip()
-	center_view()
 	if generator.get_parent() is MMGenGraph:
 		button_transmits_seed.visible = true
 		button_transmits_seed.button_pressed = generator.transmits_seed
 	else:
 		button_transmits_seed.visible = false
+	if generator.scroll_offset:
+		set_deferred("scroll_offset", generator.scroll_offset)
+	else:
+		center_view()
 	emit_signal("view_updated", generator)
-
 
 func clear_material() -> void:
 	if top_generator != null:
@@ -987,6 +990,7 @@ func _drop_data(node_position, data) -> void:
 
 func on_ButtonUp_pressed() -> void:
 	if generator != top_generator and generator.get_parent() is MMGenGraph:
+		generator.scroll_offset = scroll_offset
 		call_deferred("update_view", generator.get_parent())
 
 func _on_Label_text_changed(new_text) -> void:
@@ -1017,6 +1021,7 @@ func _on_ButtonShowTree_pressed() -> void:
 func edit_subgraph(g : MMGenGraph) -> void:
 	if !g.is_editable():
 		g.toggle_editable()
+	generator.scroll_offset = scroll_offset
 	update_view(g)
 
 func _on_ButtonTransmitsSeed_toggled(button_pressed) -> void:


### PR DESCRIPTION
- Should resolve https://github.com/RodZill4/material-maker/issues/779

Fixes the issue by saving `scroll_offset` to the `MMGenGraph` generator and restored when re-entering(centers the view if there's none - i.e. for newly created subgraphs).

The offset is also added to the data model so they are persisted across sessions.

**PR**

https://github.com/user-attachments/assets/cb113f5d-59d1-4308-a73f-a07d3760ee13

**Current**

https://github.com/user-attachments/assets/c636d545-8e19-4719-beb1-d1f95a539cad


