### PR TITLE
Fix out-of-bounds error when closing last tab

### DIFF
--- a/material_maker/widgets/tabs/tabs.gd
+++ b/material_maker/widgets/tabs/tabs.gd
@@ -112,7 +112,8 @@ func move_active_tab_to(idx_to) -> void:
 	current_tab = idx_to
 
 func set_tab_title(index, title) -> void:
-	$TabBar.set_tab_title(index, title)
+	if $TabBar.get_tab_count() != 0:
+		$TabBar.set_tab_title(index, title)
 
 func get_current_tab_control() -> Node:
 	if current_tab >= 0 and current_tab < $TabBar.get_tab_count():


### PR DESCRIPTION
Fixes index out of bounds error when closing the last tab

```
E 0:00:07:850   tabs.gd:116 @ set_tab_title(): Index p_tab = 0 is out of bounds (tabs.size() = 0).
```