### PR TITLE
Fix small FloatEdit sizes in pixel editor

### DIFF
--- a/material_maker/widgets/float_edit/float_edit.tscn
+++ b/material_maker/widgets/float_edit/float_edit.tscn
@@ -8,7 +8,7 @@ content_margin_right = 3.0
 
 [node name="FloatEdit" type="Control"]
 clip_children = 1
-custom_minimum_size = Vector2(60, 0)
+custom_minimum_size = Vector2(60, 20)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0


### PR DESCRIPTION
Fixes the issue by adding a custom min height for FloatEdit

Current

<img width="169" height="119" alt="image" src="https://github.com/user-attachments/assets/079c2f24-bd4f-4b1e-8d44-fc796bfebdd9" />

PR

<img width="161" height="151" alt="image" src="https://github.com/user-attachments/assets/d8d11375-b627-4e3c-a0fc-e0e850e0997c" />
