### PR TITLE
Fix classic theme floatedit style in splines dialog

### DIFF
--- a/material_maker/theme/classic_base.tres
+++ b/material_maker/theme/classic_base.tres
@@ -1060,6 +1060,7 @@ MM_PanelMenuBar/base_type = &"PanelContainer"
 MM_PanelMenuBar/constants/separation = 3
 MM_PanelMenuBar/styles/panel = SubResource("StyleBoxEmpty_meah8")
 MM_PanelMenuButton/font_sizes/font_size = 14
+MM_PanelMenuFloatEdit/base_type = &"MM_NodeFloatEdit"
 MM_PanelMenuSeparator/constants/separation = 2
 MM_PanelMenuSeparator/styles/separator = SubResource("StyleBoxFlat_5e0gw")
 MM_PanelMenuSubPanel/base_type = &"PanelContainer"


### PR DESCRIPTION
**PR**

<img width="202" height="45" alt="image" src="https://github.com/user-attachments/assets/3c902ee5-06ff-4d9f-9696-85c570f002dd" />


**Current**

<img width="250" height="49" alt="image" src="https://github.com/user-attachments/assets/d2af2914-4b0e-44fb-8c87-061746d20675" />
