### PR TITLE
Improve console link navigation

### DIFF
--- a/material_maker/console.gd
+++ b/material_maker/console.gd
@@ -37,7 +37,7 @@ func string_to_bbcode(s : String) -> String:
 					match data.type:
 						"nodesection":
 							url_string = data.section+" section of node "+data.node
-				s = s.left(l)+"[url="+url+"]"+url_string+"[/url]"+s.right(-l2-2)
+				s = s.left(l)+"[color=\"#5884d6\"][url="+url+"]"+url_string+"[/url][/color]"+s.right(-l2-2)
 	return s
 
 func write(l: String, m : String):
@@ -55,7 +55,15 @@ func _on_rich_text_label_meta_clicked(meta):
 	match data.type:
 		"nodesection":
 			generator = instance_from_id(data.nodeid.right(-1).to_int())
-			generator.edit(self, data.section)
+			if generator == null:
+					return
+			if Input.is_key_pressed(KEY_ALT):
+				generator.edit(self, data.section)
+			else:
+				var graph : MMGraphEdit = mm_globals.main_window.get_current_graph_edit()
+				graph.update_view(generator.get_parent())
+				var node : GraphNode = graph.get_node("node_" + generator.name)
+				graph.scroll_offset = (node.position_offset + 0.5*node.size) * graph.zoom - 0.5*graph.size
 
 func update_shader_generator(shader_model) -> void:
 	generator.set_shader_model(shader_model)
@@ -64,7 +72,6 @@ func toggle():
 	visible = not visible
 	%ConsoleResizer.visible = visible
 	mm_globals.set_config("ui_console_open", visible)
-		
 
 func _on_console_resizer_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion and (event.button_mask & MOUSE_BUTTON_MASK_LEFT) != 0:
@@ -73,3 +80,9 @@ func _on_console_resizer_gui_input(event: InputEvent) -> void:
 			toggle()
 		custom_minimum_size.y = min(max(custom_minimum_size.y, 100),650)
 		mm_globals.set_config("ui_console_height", custom_minimum_size.y)
+
+func _on_rich_text_label_meta_hover_ended(_meta: Variant) -> void:
+	mm_globals.set_tip_text("")
+
+func _on_rich_text_label_meta_hover_started(_meta: Variant) -> void:
+	mm_globals.set_tip_text("#LMB: Show Node, Alt+#LMB: Edit Node")

--- a/material_maker/main_window.tscn
+++ b/material_maker/main_window.tscn
@@ -288,6 +288,8 @@ visible = false
 [connection signal="gui_input" from="VBoxContainer/ConsoleResizer/ResizerBar" to="VBoxContainer/Console" method="_on_console_resizer_gui_input"]
 [connection signal="mouse_exited" from="VBoxContainer/ConsoleResizer/ResizerBar" to="VBoxContainer/Console" method="_on_console_resizer_mouse_exited"]
 [connection signal="meta_clicked" from="VBoxContainer/Console/RichTextLabel" to="VBoxContainer/Console" method="_on_rich_text_label_meta_clicked"]
+[connection signal="meta_hover_ended" from="VBoxContainer/Console/RichTextLabel" to="VBoxContainer/Console" method="_on_rich_text_label_meta_hover_ended"]
+[connection signal="meta_hover_started" from="VBoxContainer/Console/RichTextLabel" to="VBoxContainer/Console" method="_on_rich_text_label_meta_hover_started"]
 [connection signal="timeout" from="VBoxContainer/StatusBar/HBox/Tip/Timer" to="." method="_on_Tip_Timer_timeout"]
 [connection signal="pressed" from="VBoxContainer/StatusBar/HBox/ConsoleButton" to="VBoxContainer/Console" method="toggle"]
 [connection signal="timeout" from="VBoxContainer/StatusBar/HBox/ClipBoardAnalyzer/Timer" to="VBoxContainer/StatusBar/HBox/ClipBoardAnalyzer" method="_on_Timer_timeout"]


### PR DESCRIPTION
Addresses suggestion via discord.

This PR make it so that clicking a link centers on the broken node, and Alt-Click opens the node editor.

> can we get something like ctrl+click on the broken node to show it in the node tree window? Currently it opens the node, but if someone cant fix the code, its not very useful.

https://github.com/user-attachments/assets/839c668f-79a6-45b4-b113-c5f80d1f0a71

- Added tip text when link is hovered

<img width="274" height="52" alt="image" src="https://github.com/user-attachments/assets/0a1a1cef-3bb9-4029-8020-c1d7d060b741" />

- Highlighted link w/ color

<img width="391" height="274" alt="image" src="https://github.com/user-attachments/assets/bb22f406-e188-46de-9168-98ba051aea43" />
