### PR TITLE
Improved $node to use node title in 2d export

### DIFF
--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -235,3 +235,14 @@ func interpret_file_name(file_name: String, path:="", file_extension:="",additio
 			file_name = file_name.replace("$idx", str(1).pad_zeros(2))
 
 	return file_name
+
+func get_node_title_from_gen(generator : MMGenBase) -> String:
+	# Get GraphNode title from generator (in current graph)
+	if generator != null:
+		var graph : MMGraphEdit = main_window.get_current_graph_edit()
+		if graph != null:
+			var node_path := NodePath("node_" + generator.name)
+			if graph.has_node(node_path):
+				var gnode : GraphNode = graph.get_node(node_path)
+				return gnode.title.to_snake_case()
+	return "unnamed"

--- a/material_maker/nodes/reroute/reroute.tscn
+++ b/material_maker/nodes/reroute/reroute.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=3 uid="uid://dj08rlr43tqxj"]
 
-[ext_resource type="Script" path="res://material_maker/nodes/reroute/reroute.gd" id="1"]
+[ext_resource type="Script" uid="uid://bfkmqgx6bd2i4" path="res://material_maker/nodes/reroute/reroute.gd" id="1"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 corner_radius_top_left = 12
@@ -45,6 +45,7 @@ custom_minimum_size = Vector2(24, 24)
 offset_right = 24.0
 offset_bottom = 24.0
 theme = SubResource("3")
+title = "Reroute"
 slot/0/left_enabled = true
 slot/0/left_type = 42
 slot/0/left_color = Color(1, 1, 1, 1)

--- a/material_maker/panels/preview_2d/export_menu.gd
+++ b/material_maker/panels/preview_2d/export_menu.gd
@@ -10,6 +10,8 @@ var export_settings := {
 
 const RESOLUTION_CUSTOM := 8
 
+var additional_ids := {"$node":"unnamed"}
+
 func _ready() -> void:
 	for val in export_settings.values():
 		val = val.replace("$SUFFIX", owner.config_var_suffix)
@@ -48,6 +50,8 @@ func _open() -> void:
 
 
 func update() -> void:
+	additional_ids["$node"] = mm_globals.get_node_title_from_gen(owner.generator)
+
 	if not is_visible_in_tree():
 		return
 
@@ -169,10 +173,8 @@ func interpret_file_name(file_name: String, path:="") -> String:
 	if path.is_empty():
 		path = %ExportFolder.text
 
-	var additional_ids := {"$node":"unnamed"}
-
-	if owner.generator:
-		additional_ids["$node"] = owner.generator.name
+	if not owner.generator:
+		additional_ids["$name"] = "unnamed"
 
 	var extension := ""
 	match %FileType.selected:


### PR DESCRIPTION
Use graph node's title instead of its generator's (internal node) name which tends to be random

https://github.com/user-attachments/assets/07c4bf68-eb61-43db-8355-9b70cf608b7b