### PR TITLE
Improve export node to support $ variables

### DIFF
--- a/material_maker/doc/node_miscellaneous_export.rst
+++ b/material_maker/doc/node_miscellaneous_export.rst
@@ -3,7 +3,8 @@ Export node
 
 The **Export** node defines a texture that will be saved together with the
 material textures when exporting the project. This node can also be triggered
-manually via **Quick Export** under material exports.
+manually via **Quick Export** under material exports without exporting a full
+materaial.
 
 .. image:: images/node_miscellaneous_export.png
 	:align: center
@@ -11,7 +12,7 @@ manually via **Quick Export** under material exports.
 Inputs
 ++++++
 
-The **Export** node has an input that will be saved when exporting the project.
+The **Export** node has an input that will be saved when exporting the project or triggered via **Quick Export**.
 
 Outputs
 +++++++
@@ -23,8 +24,8 @@ Parameters
 
 The **Export** node has three parameters:
 
-* the resolution size of the exported file
+* *Resolution* size of the exported file
 
-* the format of the exported file (i.e. PNG, JPG, WebP or EXR)
+* *Format* of the exported file (i.e. PNG, JPG, WebP or EXR)
 
-* the suffix of the file that will be created
+* *Filename* of the created file. $node, $project, $idx and $resolution can be used.

--- a/material_maker/nodes/reroute/reroute.tscn
+++ b/material_maker/nodes/reroute/reroute.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=3 uid="uid://dj08rlr43tqxj"]
 
-[ext_resource type="Script" path="res://material_maker/nodes/reroute/reroute.gd" id="1"]
+[ext_resource type="Script" uid="uid://bfkmqgx6bd2i4" path="res://material_maker/nodes/reroute/reroute.gd" id="1"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 corner_radius_top_left = 12
@@ -45,6 +45,7 @@ custom_minimum_size = Vector2(24, 24)
 offset_right = 24.0
 offset_bottom = 24.0
 theme = SubResource("3")
+title = "Reroute"
 slot/0/left_enabled = true
 slot/0/left_type = 42
 slot/0/left_color = Color(1, 1, 1, 1)


### PR DESCRIPTION
Addresses suggestion via Discord
> being able to batch export them with this function would also accelerate my workflow. Having the tokens like the regular Export instead of only the suffix would also help ($project, $node, etc).

<img width="800" alt="export" src="https://github.com/user-attachments/assets/02d96582-9eed-4bbc-a2cd-68cd9a39194a" />