### PR TITLE
Fix transparency preview/export

### DIFF
--- a/addons/material_maker/nodes/material.mmg
+++ b/addons/material_maker/nodes/material.mmg
@@ -189,6 +189,9 @@
 							"subsurf_scatter_strength = $(param:sss)",
 							"subsurf_scatter_texture = ExtResource( 6 )",
 							"$fi",
+							"$if $(connected:opacity_tex) and $(param:flags_transparent)",
+							"flags_transparent = true",
+							"$fi",
 							""
 						],
 						"type": "template"
@@ -291,6 +294,9 @@
 							"subsurf_scatter_enabled = true",
 							"subsurf_scatter_strength = $(param:sss)",
 							"subsurf_scatter_texture = ExtResource( 6 )",
+							"$fi",
+							"$if $(connected:opacity_tex) and $(param:flags_transparent)",
+							"transparency = 1",
 							"$fi",
 							""
 						],
@@ -406,6 +412,9 @@
 							"subsurf_scatter_enabled = true",
 							"subsurf_scatter_strength = $(param:sss)",
 							"subsurf_scatter_texture = ExtResource( 6 )",
+							"$fi",
+							"$if $(connected:opacity_tex) and $(param:flags_transparent)",
+							"transparency = 1",
 							"$fi",
 							""
 						],
@@ -3344,7 +3353,6 @@
 			"\tAO_LIGHT_AFFECT = $ao;",
 			"$if $(connected:opacity_tex) and $(param:flags_transparent)",
 			"\tALPHA = albedo_tex.a;",
-			"\tALPHA_SCISSOR_THRESHOLD = 0.01;",
 			"$fi",
 			"$if $(connected:sss_tex)",
 			"\tfloat sss_tex = texture(texture_subsurface_scattering, base_uv).r;",

--- a/addons/material_maker/nodes/material_tesselated.mmg
+++ b/addons/material_maker/nodes/material_tesselated.mmg
@@ -187,7 +187,11 @@
 							"subsurf_scatter_enabled = true",
 							"subsurf_scatter_strength = $(param:sss)",
 							"subsurf_scatter_texture = ExtResource( 6 )",
-							"$fi"
+							"$fi",
+							"$if $(connected:opacity_tex) and $(param:flags_transparent)",
+							"flags_transparent = true",
+							"$fi",
+							""
 						],
 						"type": "template"
 					}
@@ -286,7 +290,11 @@
 							"subsurf_scatter_enabled = true",
 							"subsurf_scatter_strength = $(param:sss)",
 							"subsurf_scatter_texture = ExtResource( 6 )",
-							"$fi"
+							"$fi",
+							"$if $(connected:opacity_tex) and $(param:flags_transparent)",
+							"transparency = 1",
+							"$fi",
+							""
 						],
 						"type": "template"
 					}
@@ -397,7 +405,11 @@
 							"subsurf_scatter_enabled = true",
 							"subsurf_scatter_strength = $(param:sss)",
 							"subsurf_scatter_texture = ExtResource( 6 )",
-							"$fi"
+							"$fi",
+							"$if $(connected:opacity_tex) and $(param:flags_transparent)",
+							"transparency = 1",
+							"$fi",
+							""
 						],
 						"type": "template"
 					}
@@ -3168,7 +3180,7 @@
 			"shader_type spatial;",
 			"render_mode blend_mix,cull_back,diffuse_burley,specular_schlick_ggx",
 			"$if $(connected:opacity_tex) and $(param:flags_transparent)",
-			",depth_draw_alpha_prepass",
+			",depth_prepass_alpha",
 			"$fi",
 			";",
 			"",


### PR DESCRIPTION
- Resolves https://github.com/RodZill4/material-maker/issues/741#issuecomment-3822852523

This PR:
- Adds missing transparency(flag) export to Static mats: Godot 4 ORM/Standard and Godot 3 Spatial materials
- Removed `ALPHA_SCISSOR_THRESHOLD` in `material.mmg` preview shader to follow `material_tesselated.mmg`