### PR TITLE
Fix export index showing as a float

### DIFF
--- a/material_maker/windows/material_editor/export_editor.gd
+++ b/material_maker/windows/material_editor/export_editor.gd
@@ -108,7 +108,7 @@ func select_file(i : int) -> void:
 		match f.type:
 			"texture":
 				export_file_type.select(0)
-				export_file_expression.text = str(f.output) if f.has("output") else f.expression
+				export_file_expression.text = str(int(f.output)) if f.has("output") else f.expression
 			"template","buffer_templates":
 				export_file_type.select(1 if f.type == "template" else 3)
 				var file_export_context = {}


### PR DESCRIPTION
Fix export output index displaying as a float which causes the expression dialog to display nothing when edited

**Current**

<img width="743" height="330" alt="image" src="https://github.com/user-attachments/assets/eaece027-f258-4b3b-a1a1-bd644ae38b30" />


**PR**

<img width="752" height="337" alt="image" src="https://github.com/user-attachments/assets/249e7734-25a9-4141-a7c4-1b5a5d66686e" />
