### PR TITLE
Fix preview2d center shortcut not activating

### DIFF
--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -206,6 +206,8 @@ func propagate_shortcuts(control : Control, event : InputEvent):
 		return
 	if not control.shortcut_context.get_global_rect().has_point(control.get_global_mouse_position()):
 		return
+	if not control.is_visible_in_tree():
+		return
 	do_propagate_shortcuts(control, event)
 
 


### PR DESCRIPTION
Fixed a case where preview 2d's reset view button's shortcut not triggering if preview2d(2) is docked in the same panel

i.e. 
<img width="294" height="115" alt="image" src="https://github.com/user-attachments/assets/74389c02-b637-4a74-91bb-8c5899ecf853" />