### PR TITLE
Revert "Remove AO export for Blender export target"

### DIFF
--- a/addons/material_maker/nodes/material.mmg
+++ b/addons/material_maker/nodes/material.mmg
@@ -75,6 +75,12 @@
 						"file_name": "$(path_prefix)_emission.png",
 						"output": 2,
 						"type": "texture"
+					},
+					{
+						"conditions": "$(connected:ao_tex)",
+						"file_name": "$(path_prefix)_occlusion.exr",
+						"output": 9,
+						"type": "texture"
 					}
 				]
 			},

--- a/addons/material_maker/nodes/material_tesselated.mmg
+++ b/addons/material_maker/nodes/material_tesselated.mmg
@@ -76,6 +76,12 @@
 						"file_name": "$(path_prefix)_emission.png",
 						"output": 2,
 						"type": "texture"
+					},
+					{
+						"conditions": "$(connected:ao_tex)",
+						"file_name": "$(path_prefix)_occlusion.exr",
+						"output": 9,
+						"type": "texture"
 					}
 				]
 			},


### PR DESCRIPTION
- Reverts RodZill4/material-maker#898

Suggestion via Discord
> I'm not sure it's a good idea as I use the Blender export template as a general export for a PBR full set of textures.
And, as MM exports just what is connected, I found more natural that if I don't want AO I leave the AO input unconnected, if I connect something is because I need it.

> In my opinion it's easier as the AO is exported just if you put something on it...so, if you use time and effort to create an AO nodes network is because you need it, regardless if it's physical realistic or not in Cycles (or EEVEE)...so, if you connect to it, I'm expecting it will exported with no further operations like it's for diffuse, roughness, normal and so on.