### PR TITLE
Fix undoredo for framing nodes

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -1049,13 +1049,15 @@ func create_subgraph() -> void:
 func frame_nodes() -> void:
 	var graph_edit : MMGraphEdit = get_current_graph_edit()
 	if graph_edit != null and get_selected_nodes().size():
+		graph_edit.undoredo.start_group()
 		var nodes : Array = await graph_edit.create_nodes(
-				{"type":"comment", "title":"Frame"}, Vector2())
+				{"type":"comment", "title":"Frame"})
 		if nodes.size():
 			# Avoid calling resize twice
 			if not mm_globals.get_config("auto_size_comment"):
 				nodes[0].resize_to_selection()
 			nodes[0].selected = true
+		graph_edit.undoredo.end_group()
 
 func make_selected_nodes_editable() -> void:
 	var selected_nodes = get_selected_nodes()

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -1254,7 +1254,8 @@ func undoredo_command(command : Dictionary) -> void:
 			var parent_generator = get_node_from_hier_name(command.parent)
 			for k in command.positions.keys():
 				if parent_generator == generator:
-					get_node("node_"+k).do_set_position(command.positions[k])
+					if has_node("node_"+k):
+						get_node("node_"+k).do_set_position(command.positions[k])
 				else:
 					parent_generator.get_node(k).set_position(command.positions[k])
 		"resize_comment":


### PR DESCRIPTION
Fix node framing not being a single undoredo action and undoing sometimes causes errors for "move_generators" actions