### PR TITLE
Fixed controller input throwing an error on option edit

### DIFF
--- a/material_maker/widgets/option_edit/option_edit.gd
+++ b/material_maker/widgets/option_edit/option_edit.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 
 
 func _gui_input(event: InputEvent) -> void:
-	if event.is_command_or_control_pressed() and event is InputEventMouseButton and event.pressed:
+	if event is InputEventMouseButton and event.is_command_or_control_pressed() and event.pressed:
 
 		if event.button_index == MOUSE_BUTTON_WHEEL_DOWN or event.button_index == MOUSE_BUTTON_WHEEL_UP:
 			roll(event.button_index == MOUSE_BUTTON_WHEEL_DOWN)


### PR DESCRIPTION
Super minor bugfix. I have a controller (presumably with some stick drift) sitting on my desk and the controller input is throwing an exception here because the Joypad input events don't have the `is_command_or_control_pressed` method.  