### PR TITLE
Support single-window mode

### DIFF
--- a/addons/flexible_layout/flexible_layout.gd
+++ b/addons/flexible_layout/flexible_layout.gd
@@ -542,11 +542,14 @@ class FlexWindow:
 	var overlay : Control
 	
 	func _init(main_control : Control, first_panel : Control = null):
-		content_scale_factor = main_control.get_window().content_scale_factor
-		if OS.get_name() == "macOS":
-			unfocusable = true
+		if not main_control.get_window().gui_embed_subwindows:
+			content_scale_factor = main_control.get_window().content_scale_factor
+			if OS.get_name() == "macOS":
+				unfocusable = true
 		if first_panel:
-			position = Vector2i(first_panel.get_global_rect().position*content_scale_factor)+first_panel.get_window().position
+			position = Vector2i(first_panel.get_global_rect().position*content_scale_factor)
+			if not main_control.get_window().gui_embed_subwindows:
+				position += first_panel.get_window().position
 			size = first_panel.size*content_scale_factor
 		panel = Control.new()
 		add_child(panel)

--- a/addons/material_maker/engine/nodes/gen_sdf.gd
+++ b/addons/material_maker/engine/nodes/gen_sdf.gd
@@ -194,6 +194,4 @@ func edit(node, tab : String = "") -> void:
 		edit_window.set_sdf_scene(scene)
 		edit_window.connect("node_changed", Callable(node, "update_sdf_generator"))
 		edit_window.connect("editor_window_closed", Callable(node, "finalize_generator_update"))
-		edit_window.get_window().content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
-		edit_window.get_window().min_size = Vector2(800, 400) * edit_window.get_window().content_scale_factor
 		edit_window.popup_centered()

--- a/addons/material_maker/engine/nodes/gen_shader.gd
+++ b/addons/material_maker/engine/nodes/gen_shader.gd
@@ -817,7 +817,7 @@ func do_edit(node, edit_window_scene : PackedScene, tab : String = "") -> void:
 		mm_globals.main_window.add_dialog(edit_window)
 		edit_window.set_model_data(get_shader_model_for_edit())
 		edit_window.node_changed.connect(node.update_shader_generator)
-		edit_window.get_window().content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+		edit_window.get_window().content_scale_factor = mm_globals.ui_scale_factor()
 		edit_window.get_window().min_size = Vector2(950, 450) * edit_window.get_window().content_scale_factor
 		edit_window.hide()
 		edit_window.popup_centered()

--- a/addons/material_maker/sdf_builder/sdf_builder.tscn
+++ b/addons/material_maker/sdf_builder/sdf_builder.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=80 format=3 uid="uid://bvsuo5y7vh1y2"]
+[gd_scene load_steps=89 format=3 uid="uid://bvsuo5y7vh1y2"]
 
 [ext_resource type="Script" uid="uid://d16yu8rdgx4hx" path="res://addons/material_maker/sdf_builder/sdf2d/shapes/circle.gd" id="1"]
 [ext_resource type="Script" uid="uid://c5mnqww2iagdf" path="res://addons/material_maker/sdf_builder/sdf_builder.gd" id="2"]

--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -60,6 +60,7 @@ const DEFAULT_CONFIG : Dictionary = {
 	dialog_dim_background = true,
 	node_minimize_button = false,
 	node_close_button = false,
+	ui_single_window_mode = false,
 }
 
 
@@ -180,8 +181,7 @@ func popup_menu(menu : PopupMenu, parent : Control):
 	var zoom_fac = 1.0
 	if parent is GraphNode:
 		zoom_fac *= mm_globals.main_window.get_current_graph_edit().zoom
-	
-	var content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	var content_scale_factor : float = mm_globals.ui_scale_factor()
 	menu.popup(Rect2(parent.get_local_mouse_position()*content_scale_factor*zoom_fac + parent.get_screen_position(), Vector2(0, 0)))
 
 func set_tip_text(tip : String, timeout : float = 0.0, priority: int = 0):
@@ -228,3 +228,8 @@ func get_node_title_from_gen(generator : MMGenBase) -> String:
 				var gnode : GraphNode = graph.get_node(node_path)
 				return gnode.title.to_snake_case()
 	return "unnamed"
+
+func ui_scale_factor() -> float:
+	if get_tree().root.gui_embed_subwindows:
+		return 1.0
+	return get_tree().root.content_scale_factor

--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -58,8 +58,9 @@ const DEFAULT_CONFIG : Dictionary = {
 	ui_use_native_file_dialogs = true,
 	win_tablet_driver = 0,
 	dialog_dim_background = true,
-	node_minimize_button = true,
-	node_close_button = true,
+	node_minimize_button = false,
+	node_close_button = false,
+	ui_single_window_mode = false,
 }
 
 
@@ -180,8 +181,7 @@ func popup_menu(menu : PopupMenu, parent : Control):
 	var zoom_fac = 1.0
 	if parent is GraphNode:
 		zoom_fac *= mm_globals.main_window.get_current_graph_edit().zoom
-	
-	var content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	var content_scale_factor : float = mm_globals.ui_scale_factor()
 	menu.popup(Rect2(parent.get_local_mouse_position()*content_scale_factor*zoom_fac + parent.get_screen_position(), Vector2(0, 0)))
 
 func set_tip_text(tip : String, timeout : float = 0.0, priority: int = 0):
@@ -228,3 +228,8 @@ func get_node_title_from_gen(generator : MMGenBase) -> String:
 				var gnode : GraphNode = graph.get_node(node_path)
 				return gnode.title.to_snake_case()
 	return "unnamed"
+
+func ui_scale_factor() -> float:
+	if get_tree().root.gui_embed_subwindows:
+		return 1.0
+	return get_tree().root.content_scale_factor

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -131,7 +131,6 @@ func _ready() -> void:
 	get_window().borderless = false
 	get_window().transparent = false
 	get_window().grab_focus()
-	get_window().gui_embed_subwindows = false
 
 	get_window().close_requested.connect(self.on_close_requested)
 
@@ -336,6 +335,9 @@ func on_config_changed() -> void:
 				c.update_node()
 			if c.has_method("update"):
 				c.update()
+
+	if not get_window().gui_embed_subwindows:
+		get_window().gui_embed_subwindows = mm_globals.get_config("ui_single_window_mode")
 
 func get_panel(panel_name : String) -> Control:
 	return layout.get_panel(panel_name)
@@ -996,7 +998,7 @@ func edit_save_selection() -> void:
 
 func edit_preferences() -> void:
 	var dialog = load("res://material_maker/windows/preferences/preferences.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.edit_preferences(mm_globals.config)
 
 func edit_align_start() -> void:
@@ -1091,7 +1093,7 @@ func add_selection_to_library(index: int, should_ask_item_name: bool = true, upd
 		current_item_name = library.get_selected_item_name()
 	if should_ask_item_name:
 		var dialog = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
-		dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+		dialog.content_scale_factor = mm_globals.ui_scale_factor()
 		dialog.min_size = Vector2(250, 90) * dialog.content_scale_factor
 		add_child(dialog)
 		var status = await dialog.enter_text("New library element", "Select a name for the new library element", current_item_name)
@@ -1118,7 +1120,7 @@ func create_menu_add_brush_to_library(menu : MMMenuManager.MenuBase) -> void:
 
 func add_brush_to_library(index) -> void:
 	var dialog = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.min_size = Vector2(250, 90) * dialog.content_scale_factor
 	add_child(dialog)
 	var status = await dialog.enter_text("New library element", "Select a name for the new library element", brushes.get_selected_item_name())
@@ -1330,7 +1332,7 @@ func generate_graph_screenshot():
 	graph_edit.zoom = 1
 	await get_tree().process_frame
 	var graph_edit_rect = graph_edit.get_global_rect()
-	var scale_factor : float = get_window().content_scale_factor
+	var scale_factor : float = mm_globals.ui_scale_factor()
 	graph_edit_rect = Rect2(graph_edit_rect.position+Vector2(15, 80), graph_edit_rect.size-Vector2(25, 90))
 	graph_edit_rect = Rect2(scale_factor*graph_edit_rect.position, scale_factor*graph_edit_rect.size)
 	var graph_rect = null

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -136,7 +136,6 @@ func _ready() -> void:
 	get_window().borderless = false
 	get_window().transparent = false
 	get_window().grab_focus()
-	get_window().gui_embed_subwindows = false
 
 	get_window().close_requested.connect(self.on_close_requested)
 
@@ -341,6 +340,9 @@ func on_config_changed() -> void:
 				c.update_node()
 			if c.has_method("update"):
 				c.update()
+
+	if not get_window().gui_embed_subwindows:
+		get_window().gui_embed_subwindows = mm_globals.get_config("ui_single_window_mode")
 
 func get_panel(panel_name : String) -> Control:
 	return layout.get_panel(panel_name)
@@ -1052,7 +1054,7 @@ func edit_save_selection() -> void:
 
 func edit_preferences() -> void:
 	var dialog = load("res://material_maker/windows/preferences/preferences.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.edit_preferences(mm_globals.config)
 
 func edit_align_start() -> void:
@@ -1150,7 +1152,7 @@ func add_selection_to_library(index: int, should_ask_item_name: bool = true, upd
 		current_item_name = library.get_selected_item_name()
 	if should_ask_item_name:
 		var dialog = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
-		dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+		dialog.content_scale_factor = mm_globals.ui_scale_factor()
 		dialog.min_size = Vector2(250, 90) * dialog.content_scale_factor
 		add_child(dialog)
 		var status = await dialog.enter_text("New library element", "Select a name for the new library element", current_item_name)
@@ -1177,7 +1179,7 @@ func create_menu_add_brush_to_library(menu : MMMenuManager.MenuBase) -> void:
 
 func add_brush_to_library(index) -> void:
 	var dialog = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.min_size = Vector2(250, 90) * dialog.content_scale_factor
 	add_child(dialog)
 	var status = await dialog.enter_text("New library element", "Select a name for the new library element", brushes.get_selected_item_name())
@@ -1389,7 +1391,7 @@ func generate_graph_screenshot():
 	graph_edit.zoom = 1
 	await get_tree().process_frame
 	var graph_edit_rect = graph_edit.get_global_rect()
-	var scale_factor : float = get_window().content_scale_factor
+	var scale_factor : float = mm_globals.ui_scale_factor()
 	graph_edit_rect = Rect2(graph_edit_rect.position+Vector2(15, 80), graph_edit_rect.size-Vector2(25, 90))
 	graph_edit_rect = Rect2(scale_factor*graph_edit_rect.position, scale_factor*graph_edit_rect.size)
 	var graph_rect = null

--- a/material_maker/nodes/base.gd
+++ b/material_maker/nodes/base.gd
@@ -458,7 +458,7 @@ func _on_menu_id_pressed(id : int) -> void:
 				status.append({ ok=false, message="The following outputs do not have a short and a long description: "+", ".join(bad) })
 			# Show warning dialog
 			var dialog = preload("res://material_maker/tools/share/share_node_dialog.tscn").instantiate()
-			dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+			dialog.content_scale_factor = mm_globals.ui_scale_factor()
 			dialog.min_size = Vector2(600, 400) * dialog.content_scale_factor
 			var result = await dialog.ask(status)
 			if result != "ok":

--- a/material_maker/nodes/comment/comment.gd
+++ b/material_maker/nodes/comment/comment.gd
@@ -136,7 +136,7 @@ func _on_text_focus_exited():
 func _on_change_color_pressed():
 	var light_theme = "light" in mm_globals.main_window.theme.resource_path
 	accept_event()
-	var content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	var content_scale_factor : float = mm_globals.ui_scale_factor()
 	$Popup.get_window().content_scale_factor = content_scale_factor
 	$Popup.get_window().size = $Popup.get_window().get_contents_minimum_size() * content_scale_factor
 	$Popup.position = get_screen_transform() * get_local_mouse_position()
@@ -181,7 +181,7 @@ func _on_ColorChooser_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
 		accept_event()
 		$Popup.hide()
-		var content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+		var content_scale_factor : float = mm_globals.ui_scale_factor()
 		$PopupSelector.get_window().content_scale_factor = content_scale_factor
 		$PopupSelector.get_window().min_size = $PopupSelector.get_window().get_contents_minimum_size() * content_scale_factor
 		$PopupSelector.get_window().position = get_global_mouse_position() * content_scale_factor
@@ -232,15 +232,12 @@ func _on_raise_request():
 			get_parent().move_child(self, i)
 			break
 
-
 func _context_menu_about_to_popup(context_menu : PopupMenu) -> void:
 	context_menu.position = get_screen_transform() * get_local_mouse_position()
-
 
 func _on_title_edit_ready() -> void:
 	%TitleEdit.get_menu().about_to_popup.connect(
 			_context_menu_about_to_popup.bind(%TitleEdit.get_menu()))
-
 
 func _on_text_ready() -> void:
 	%Text.get_menu().about_to_popup.connect(

--- a/material_maker/nodes/comment/comment.tscn
+++ b/material_maker/nodes/comment/comment.tscn
@@ -140,8 +140,8 @@ texture = ExtResource("3")
 [node name="PanelContainer" type="PanelContainer" parent="PopupSelector"]
 offset_left = 4.0
 offset_top = 4.0
-offset_right = 302.0
-offset_bottom = 545.0
+offset_right = 96.0
+offset_bottom = 96.0
 
 [node name="ColorPicker" type="ColorPicker" parent="PopupSelector/PanelContainer"]
 layout_mode = 2
@@ -157,10 +157,8 @@ edit_alpha = false
 [connection signal="resize_request" from="." to="." method="_on_resize_request"]
 [connection signal="gui_input" from="PanelContainer/MarginContainer/VBox/TitleBar/Title" to="." method="_on_Title_gui_input"]
 [connection signal="focus_exited" from="PanelContainer/MarginContainer/VBox/TitleBar/TitleEdit" to="." method="_on_title_edit_focus_exited"]
-[connection signal="ready" from="PanelContainer/MarginContainer/VBox/TitleBar/TitleEdit" to="." method="_on_title_edit_ready"]
 [connection signal="text_submitted" from="PanelContainer/MarginContainer/VBox/TitleBar/TitleEdit" to="." method="_on_title_edit_text_submitted"]
 [connection signal="pressed" from="PanelContainer/MarginContainer/VBox/TitleBar/ChangeColor" to="." method="_on_change_color_pressed"]
 [connection signal="pressed" from="PanelContainer/MarginContainer/VBox/TitleBar/Close" to="." method="_on_close_pressed"]
 [connection signal="focus_exited" from="PanelContainer/MarginContainer/VBox/Text" to="." method="_on_text_focus_exited"]
-[connection signal="ready" from="PanelContainer/MarginContainer/VBox/Text" to="." method="_on_text_ready"]
 [connection signal="gui_input" from="Popup/GridContainer/ColorChooser" to="." method="_on_ColorChooser_gui_input"]

--- a/material_maker/nodes/debug/debug_popup.gd
+++ b/material_maker/nodes/debug/debug_popup.gd
@@ -5,7 +5,7 @@ var src_code
 const GENFUNCTIONS : Array = [ "generate_shadertoy", "generate_godot_canvasitem", "generate_godot_spatial" ]
 
 func _on_ready() -> void:
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = Vector2(500 ,500) * content_scale_factor
 
 func show_code(s) -> void:

--- a/material_maker/nodes/remote/named_parameter_dialog.gd
+++ b/material_maker/nodes/remote/named_parameter_dialog.gd
@@ -3,7 +3,7 @@ extends Window
 signal return_values(values)
 
 func _ready():
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = Vector2(450, 60) * content_scale_factor
 
 func _on_OK_pressed() -> void:

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -752,12 +752,11 @@ func load_file(filename) -> bool:
 	else:
 		var dialog : AcceptDialog = AcceptDialog.new()
 		add_child(dialog)
-		var content_scale_factor = (mm_globals.main_window
-				.get_window().content_scale_factor)
+		var content_scale_factor : float = mm_globals.ui_scale_factor()
 		dialog.content_scale_factor = content_scale_factor
+		dialog.min_size = dialog.get_contents_minimum_size() * content_scale_factor
 		dialog.title = "Load failed!"
 		dialog.dialog_text = "Failed to load "+filename
-		dialog.min_size = dialog.get_contents_minimum_size() * content_scale_factor
 		dialog.connect("popup_hide", Callable(dialog, "queue_free"))
 		dialog.popup_centered()
 		return false
@@ -1857,8 +1856,11 @@ func colorize_nodes() -> void:
 		mm_globals.set_config("color_picker_color_mode", picker.color_mode)
 		mm_globals.set_config("color_picker_shape", picker.picker_shape))
 
-	popup.content_scale_factor = csf
-	popup.min_size = popup.get_contents_minimum_size() * csf
+	if get_tree().root.gui_embed_subwindows:
+		csf = 1.0
+	else:
+		popup.content_scale_factor = csf
+		popup.min_size = popup.get_contents_minimum_size() * csf
 	popup.position = get_screen_position() + get_local_mouse_position() * csf
 
 	picker.color = nodes[0].generator.color

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -767,12 +767,11 @@ func load_file(filename) -> bool:
 	else:
 		var dialog : AcceptDialog = AcceptDialog.new()
 		add_child(dialog)
-		var content_scale_factor = (mm_globals.main_window
-				.get_window().content_scale_factor)
+		var content_scale_factor : float = mm_globals.ui_scale_factor()
 		dialog.content_scale_factor = content_scale_factor
+		dialog.min_size = dialog.get_contents_minimum_size() * content_scale_factor
 		dialog.title = "Load failed!"
 		dialog.dialog_text = "Failed to load "+filename
-		dialog.min_size = dialog.get_contents_minimum_size() * content_scale_factor
 		dialog.connect("popup_hide", Callable(dialog, "queue_free"))
 		dialog.popup_centered()
 		return false
@@ -1891,8 +1890,11 @@ func colorize_nodes() -> void:
 		mm_globals.set_config("color_picker_color_mode", picker.color_mode)
 		mm_globals.set_config("color_picker_shape", picker.picker_shape))
 
-	popup.content_scale_factor = csf
-	popup.min_size = popup.get_contents_minimum_size() * csf
+	if get_tree().root.gui_embed_subwindows:
+		csf = 1.0
+	else:
+		popup.content_scale_factor = csf
+		popup.min_size = popup.get_contents_minimum_size() * csf
 	popup.position = get_screen_position() + get_local_mouse_position() * csf
 
 	picker.color = nodes[0].generator.color

--- a/material_maker/panels/layers/layers.gd
+++ b/material_maker/panels/layers/layers.gd
@@ -26,7 +26,7 @@ func _on_Add_pressed():
 	menu.connect("id_pressed", Callable(menu, "queue_free"))
 	menu.connect("popup_hide", Callable(menu, "queue_free"))
 	menu.popup(Rect2(Vector2(button_rect.position.x, button_rect.end.y) *
-		mm_globals.main_window.get_window().content_scale_factor, Vector2(0, 0)))
+		mm_globals.ui_scale_factor(), Vector2(0, 0)))
 
 func _on_add_layer_menu(id):
 	layers.add_layer(id)
@@ -60,7 +60,7 @@ func _on_Config_pressed():
 		if layer.get_layer_type() == MMLayer.LAYER_MASK:
 			return
 		var popup = preload("res://material_maker/panels/layers/layer_config_popup.tscn").instantiate()
-		popup.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+		popup.content_scale_factor = mm_globals.ui_scale_factor()
 		popup.min_size = Vector2(228, 245) * popup.content_scale_factor
 		add_child(popup)
 		popup.configure_layer(layers, current.get_meta("layer"))

--- a/material_maker/panels/library/create_lib_dialog.gd
+++ b/material_maker/panels/library/create_lib_dialog.gd
@@ -10,7 +10,7 @@ signal return_info(status)
 
 
 func _ready():
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	%FilePickerButton.set_mode(FileDialog.FILE_MODE_OPEN_DIR)
 	%FilePickerButton.icon = get_parent().get_theme_icon("folder", "MM_Icons")
 	hide()

--- a/material_maker/panels/library/library.gd
+++ b/material_maker/panels/library/library.gd
@@ -22,13 +22,8 @@ const MENU_LOAD_LIBRARY : int =   1001
 
 const default_theme : Theme = preload("res://material_maker/theme/default.tres")
 
-func _context_menu_about_to_popup(context_menu : PopupMenu) -> void:
-	context_menu.position = get_window().position+ Vector2i(
-			get_global_mouse_position() * get_window().content_scale_factor)
 
 func _ready() -> void:
-	%Filter.get_menu().about_to_popup.connect(
-			_context_menu_about_to_popup.bind(%Filter.get_menu()))
 	# Setup tree
 	tree.set_column_expand(0, true)
 	tree.set_column_expand(1, false)
@@ -230,7 +225,7 @@ func generate_screenshots(graph_edit : GraphEdit, parent_item : TreeItem = null)
 			var new_nodes = graph_edit.create_nodes(item.get_metadata(0))
 			await get_tree().create_timer(0.05).timeout
 			var image = get_viewport().get_texture().get_image()
-			var csf = mm_globals.main_window.get_window().content_scale_factor
+			var csf : float = mm_globals.ui_scale_factor()
 			image = image.get_region(Rect2(csf*(new_nodes[0].global_position-Vector2(6, 6)),csf*(new_nodes[0].size+Vector2(14, 12))))
 			# Make background transparent
 			image.convert(Image.FORMAT_RGBA8)
@@ -404,7 +399,7 @@ func _on_PopupMenu_index_pressed(index):
 	match index:
 		0: # Rename
 			var dialog = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
-			dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+			dialog.content_scale_factor = mm_globals.ui_scale_factor()
 			dialog.min_size = Vector2(250, 90) * dialog.content_scale_factor
 			add_child(dialog)
 			var status = await dialog.enter_text("Rename item", "Enter the new name for this item", item_path)
@@ -424,7 +419,7 @@ func _on_PopupMenu_index_pressed(index):
 		5: # Define aliases
 			var aliases = library_manager.get_aliases(item_path)
 			var dialog = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
-			dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+			dialog.content_scale_factor = mm_globals.ui_scale_factor()
 			dialog.min_size = Vector2(400, 90) * dialog.content_scale_factor
 			add_child(dialog)
 			var status = await dialog.enter_text("Library item aliases", "Updated aliases for "+item_path, aliases)

--- a/material_maker/panels/parameters/parameters.tscn
+++ b/material_maker/panels/parameters/parameters.tscn
@@ -3,17 +3,14 @@
 [ext_resource type="Script" uid="uid://chqn6bm8u2bjm" path="res://material_maker/panels/parameters/parameters.gd" id="1"]
 
 [node name="BrushParams" type="ScrollContainer"]
+custom_minimum_size = Vector2(200, 250)
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-custom_minimum_size = Vector2(200, 250)
 size_flags_horizontal = 3
-scroll_horizontal_enabled = false
 script = ExtResource("1")
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Parameters" type="GridContainer" parent="."]
-offset_right = 1280.0
+layout_mode = 2
 size_flags_horizontal = 3
 columns = 2

--- a/material_maker/panels/preview_2d/preview_2d_panel.gd
+++ b/material_maker/panels/preview_2d/preview_2d_panel.gd
@@ -75,7 +75,7 @@ const CHECKER_BRIGHTNESS_OPTIONS: Array[Vector2] = [
 ]
 
 func _ready():
-	var content_scale_factor = mm_globals.get_window().content_scale_factor
+	var content_scale_factor : float = mm_globals.ui_scale_factor()
 	%GuidesColor.get_popup().content_scale_factor = content_scale_factor
 	%GuidesColor.get_popup().min_size = %GuidesColor.get_popup().get_contents_minimum_size() * content_scale_factor
 

--- a/material_maker/panels/preview_3d/mesh_config_popup.gd
+++ b/material_maker/panels/preview_3d/mesh_config_popup.gd
@@ -5,7 +5,7 @@ var mesh : MeshInstance3D
 const config_key : String = "3D_preview_objects/%s_uv_scale"
 
 func _ready() -> void:
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = get_contents_minimum_size() * content_scale_factor
 	%ScaleLinked.icon = get_theme_icon("link", "MM_Icons")
 

--- a/material_maker/theme/classic_base.tres
+++ b/material_maker/theme/classic_base.tres
@@ -698,14 +698,14 @@ corner_detail = 4
 content_margin_top = 3.0
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_a74kv"]
-bg_color = Color(0.3137255, 0.3137255, 0.34901962, 1)
+bg_color = Color(0.06666667, 0.06666667, 0.078431375, 1)
 corner_radius_top_left = 11
 corner_radius_top_right = 11
 corner_radius_bottom_right = 11
 corner_radius_bottom_left = 11
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nmkov"]
-bg_color = Color(0.42352942, 0.42352942, 0.4627451, 1)
+bg_color = Color(0.06666667, 0.06666667, 0.078431375, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
@@ -991,6 +991,34 @@ border_width_left = 4
 border_width_right = 4
 border_color = Color(0, 0, 0, 0.11764706)
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ppdpb"]
+bg_color = Color(0.19685599, 0.22558257, 0.2973433, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+corner_detail = 4
+expand_margin_left = 4.0
+expand_margin_top = 35.0
+expand_margin_right = 4.0
+expand_margin_bottom = 4.0
+shadow_color = Color(0, 0, 0, 0.2)
+shadow_size = 8
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_btb0w"]
+bg_color = Color(0.1525, 0.18175, 0.25, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+corner_detail = 4
+expand_margin_left = 4.0
+expand_margin_top = 35.0
+expand_margin_right = 4.0
+expand_margin_bottom = 4.0
+shadow_color = Color(0, 0, 0, 0.2)
+shadow_size = 8
+
 [resource]
 default_font = ExtResource("4_7b2nb")
 default_font_size = 15
@@ -1270,3 +1298,5 @@ VScrollBar/styles/grabber = SubResource("StyleBoxFlat_fw8f4")
 VScrollBar/styles/grabber_highlight = SubResource("StyleBoxFlat_wbe58")
 VScrollBar/styles/grabber_pressed = SubResource("StyleBoxFlat_wbe58")
 VScrollBar/styles/scroll = SubResource("StyleBoxFlat_ropwn")
+Window/styles/embedded_border = SubResource("StyleBoxFlat_ppdpb")
+Window/styles/embedded_unfocused_border = SubResource("StyleBoxFlat_btb0w")

--- a/material_maker/theme/default dark.tres
+++ b/material_maker/theme/default dark.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" script_class="EnhancedTheme" load_steps=42 format=3 uid="uid://dhuhq2immquoh"]
+[gd_resource type="Theme" script_class="EnhancedTheme" format=3 uid="uid://dhuhq2immquoh"]
 
 [ext_resource type="Theme" uid="uid://b628lwfk6ig2c" path="res://material_maker/theme/default.tres" id="3_xjelh"]
 [ext_resource type="Script" uid="uid://3ga2k3abkk0d" path="res://material_maker/theme/enhanced_theme_system/color_swap.gd" id="4_0efyb"]

--- a/material_maker/theme/default light.tres
+++ b/material_maker/theme/default light.tres
@@ -384,9 +384,23 @@ name = "RichTextLabelDefaultColor"
 orig = Color(1, 1, 1, 1)
 metadata/_custom_type_script = "uid://3ga2k3abkk0d"
 
+[sub_resource type="Resource" id="Resource_d2i8i"]
+script = ExtResource("4_rhf2q")
+name = "EmbedBorder"
+orig = Color(0.21960784, 0.22352941, 0.24313726, 1)
+target = Color(0.37560064, 0.3756013, 0.38014168, 1)
+metadata/_custom_type_script = "uid://3ga2k3abkk0d"
+
+[sub_resource type="Resource" id="Resource_jbrv2"]
+script = ExtResource("4_rhf2q")
+name = "EmbedBorderUnfocus"
+orig = Color(0.1764706, 0.18039216, 0.19607843, 1)
+target = Color(0.301, 0.301, 0.307, 1)
+metadata/_custom_type_script = "uid://3ga2k3abkk0d"
+
 [resource]
 script = ExtResource("5_fagh3")
 base_theme = ExtResource("1_ugsao")
 font_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_silay"), SubResource("Resource_eavso"), SubResource("Resource_1jhxl"), SubResource("Resource_qiwix"), SubResource("Resource_5yhcl"), SubResource("Resource_vdnfu"), SubResource("Resource_21aar"), SubResource("Resource_us4qf"), SubResource("Resource_3wcad"), SubResource("Resource_mhcke"), SubResource("Resource_41atc")])
 icon_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_cisvi"), SubResource("Resource_j2h7k"), SubResource("Resource_8dhbo"), SubResource("Resource_5oh4i")])
-theme_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_ub5ur"), SubResource("Resource_5rv7m"), SubResource("Resource_xqbwo"), SubResource("Resource_a2t6i"), SubResource("Resource_pekt7"), SubResource("Resource_vbpcr"), SubResource("Resource_qngft"), SubResource("Resource_5mixu"), SubResource("Resource_kxmra"), SubResource("Resource_siafh"), SubResource("Resource_s732t"), SubResource("Resource_j1t84"), SubResource("Resource_g7e3b"), SubResource("Resource_oirgf"), SubResource("Resource_1pump"), SubResource("Resource_fxm05"), SubResource("Resource_mfxjg"), SubResource("Resource_upxps"), SubResource("Resource_upxps"), SubResource("Resource_lk0mo"), SubResource("Resource_sgt8g"), SubResource("Resource_p6yfp"), SubResource("Resource_mntha"), SubResource("Resource_5l403"), SubResource("Resource_qx1ic"), SubResource("Resource_skxhu"), SubResource("Resource_gf74u"), SubResource("Resource_6iwcg"), SubResource("Resource_emwrq"), SubResource("Resource_g0345"), SubResource("Resource_mqr67"), SubResource("Resource_enwto"), SubResource("Resource_t0kvp"), SubResource("Resource_tw3yc"), SubResource("Resource_5w06f"), SubResource("Resource_m8hbw"), SubResource("Resource_xnhnj"), SubResource("Resource_jh8b5"), SubResource("Resource_2d8ce"), SubResource("Resource_qqxbn"), SubResource("Resource_4naeq"), SubResource("Resource_pu57y"), SubResource("Resource_wwbst"), SubResource("Resource_q74a5"), SubResource("Resource_41atc"), SubResource("Resource_kh8x1")])
+theme_color_swaps = Array[ExtResource("4_rhf2q")]([SubResource("Resource_ub5ur"), SubResource("Resource_5rv7m"), SubResource("Resource_xqbwo"), SubResource("Resource_a2t6i"), SubResource("Resource_pekt7"), SubResource("Resource_vbpcr"), SubResource("Resource_qngft"), SubResource("Resource_5mixu"), SubResource("Resource_kxmra"), SubResource("Resource_siafh"), SubResource("Resource_s732t"), SubResource("Resource_j1t84"), SubResource("Resource_g7e3b"), SubResource("Resource_oirgf"), SubResource("Resource_1pump"), SubResource("Resource_fxm05"), SubResource("Resource_mfxjg"), SubResource("Resource_upxps"), SubResource("Resource_upxps"), SubResource("Resource_lk0mo"), SubResource("Resource_sgt8g"), SubResource("Resource_p6yfp"), SubResource("Resource_mntha"), SubResource("Resource_5l403"), SubResource("Resource_qx1ic"), SubResource("Resource_skxhu"), SubResource("Resource_gf74u"), SubResource("Resource_6iwcg"), SubResource("Resource_emwrq"), SubResource("Resource_g0345"), SubResource("Resource_mqr67"), SubResource("Resource_enwto"), SubResource("Resource_t0kvp"), SubResource("Resource_tw3yc"), SubResource("Resource_5w06f"), SubResource("Resource_m8hbw"), SubResource("Resource_xnhnj"), SubResource("Resource_jh8b5"), SubResource("Resource_2d8ce"), SubResource("Resource_qqxbn"), SubResource("Resource_4naeq"), SubResource("Resource_pu57y"), SubResource("Resource_wwbst"), SubResource("Resource_q74a5"), SubResource("Resource_41atc"), SubResource("Resource_kh8x1"), SubResource("Resource_d2i8i"), SubResource("Resource_jbrv2")])

--- a/material_maker/theme/default.tres
+++ b/material_maker/theme/default.tres
@@ -1195,6 +1195,34 @@ corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_iyaen"]
+bg_color = Color(0.21965832, 0.22426346, 0.2426776, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+corner_detail = 4
+expand_margin_left = 4.0
+expand_margin_top = 35.0
+expand_margin_right = 4.0
+expand_margin_bottom = 4.0
+shadow_color = Color(0, 0, 0, 0.2)
+shadow_size = 8
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5k62t"]
+bg_color = Color(0.1764706, 0.18039216, 0.19607843, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+corner_detail = 4
+expand_margin_left = 4.0
+expand_margin_top = 35.0
+expand_margin_right = 4.0
+expand_margin_bottom = 4.0
+shadow_color = Color(0, 0, 0, 0.2)
+shadow_size = 8
+
 [resource]
 default_font = ExtResource("1_5tfb1")
 default_font_size = 16
@@ -1540,3 +1568,5 @@ VScrollBar/styles/grabber = SubResource("StyleBoxFlat_fs6qc")
 VScrollBar/styles/grabber_highlight = SubResource("StyleBoxFlat_70aex")
 VScrollBar/styles/grabber_pressed = SubResource("StyleBoxFlat_70aex")
 VScrollBar/styles/scroll = SubResource("StyleBoxFlat_w0re2")
+Window/styles/embedded_border = SubResource("StyleBoxFlat_iyaen")
+Window/styles/embedded_unfocused_border = SubResource("StyleBoxFlat_5k62t")

--- a/material_maker/tools/environment_manager/environment_manager.gd
+++ b/material_maker/tools/environment_manager/environment_manager.gd
@@ -190,7 +190,7 @@ func read_hdr(index : int, url : String) -> bool:
 		accept_dialog = AcceptDialog.new()
 		accept_dialog.title = "HDRI download error"
 		accept_dialog.dialog_text = "Failed to download %s" % url
-		accept_dialog.content_scale_factor = get_window().content_scale_factor
+		accept_dialog.content_scale_factor = mm_globals.ui_scale_factor()
 		accept_dialog.min_size = accept_dialog.get_contents_minimum_size() * accept_dialog.content_scale_factor
 		accept_dialog.min_size.y = 40
 		mm_globals.main_window.add_child(accept_dialog)

--- a/material_maker/tools/share/login_dialog.gd
+++ b/material_maker/tools/share/login_dialog.gd
@@ -5,7 +5,7 @@ signal return_status(status)
 
 
 func _ready():
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	await get_tree().process_frame
 	_on_MarginContainer_minimum_size_changed()
 

--- a/material_maker/tools/share/share_button.gd
+++ b/material_maker/tools/share/share_button.gd
@@ -138,7 +138,7 @@ func find_in_parameter_values(node : Dictionary, keywords : Array) -> bool:
 func send_asset(asset_type : String, asset_data : Dictionary, preview_textures : Array[Texture2D], preview_texture_names : Array[String] = []) -> void:
 	var data : Dictionary = { type=asset_type, previews=preview_textures, preview_names=preview_texture_names, licenses=licenses, my_assets=my_assets }
 	var upload_dialog = load("res://material_maker/tools/share/upload_dialog.tscn").instantiate()
-	upload_dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	upload_dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	upload_dialog.min_size = Vector2(600, 500) * upload_dialog.content_scale_factor
 	var asset_info = await upload_dialog.ask(data)
 	if asset_info.is_empty():

--- a/material_maker/widgets/code_editor/code_editor.gd
+++ b/material_maker/widgets/code_editor/code_editor.gd
@@ -22,14 +22,7 @@ const FUNCTIONS : Array[String] = [ "radians", "degrees", "sin", "cos", "tan", "
 									"smoothstep", "length", "distance", "dot", "cross",
 									"normalize" ]
 
-func _context_menu_about_to_popup() -> void:
-	var content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
-	get_menu().position = get_window().position + Vector2i(
-			get_global_mouse_position() * content_scale_factor)
-
 func _ready():
-	if not get_menu().about_to_popup.is_connected(_context_menu_about_to_popup):
-		get_menu().about_to_popup.connect(_context_menu_about_to_popup)
 	syntax_highlighter.clear_color_regions()
 	for t in KEYWORDS:
 		syntax_highlighter.add_keyword_color(t, get_theme_color("keyword_color", "CodeEdit"))

--- a/material_maker/widgets/color_picker_button/color_picker_button.gd
+++ b/material_maker/widgets/color_picker_button/color_picker_button.gd
@@ -10,7 +10,7 @@ func _ready():
 	connect("color_changed",Callable(self,"on_color_changed"))
 	connect("picker_created",Callable(self,"on_picker_created"))
 	connect("popup_closed",Callable(self,"on_popup_closed"))
-	get_popup().content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	get_popup().content_scale_factor = mm_globals.ui_scale_factor()
 	get_popup().min_size = get_popup().get_contents_minimum_size() * get_popup().content_scale_factor
 
 func set_color(c):

--- a/material_maker/widgets/color_picker_popup/color_picker_popup.tscn
+++ b/material_maker/widgets/color_picker_popup/color_picker_popup.tscn
@@ -1,11 +1,12 @@
 [gd_scene format=3 uid="uid://85acplyebptc"]
 
 [node name="ColorPickerPopup" type="PopupPanel"]
-size = Vector2i(298, 576)
+oversampling_override = 1.0
+size = Vector2i(306, 615)
 visible = true
 
 [node name="ColorPicker" type="ColorPicker" parent="."]
 offset_left = 4.0
 offset_top = 4.0
-offset_right = 294.0
-offset_bottom = 572.0
+offset_right = 302.0
+offset_bottom = 611.0

--- a/material_maker/widgets/curve_edit/curve_edit.gd
+++ b/material_maker/widgets/curve_edit/curve_edit.gd
@@ -18,7 +18,7 @@ func set_value(v) -> void:
 
 func _on_CurveEdit_pressed():
 	var dialog = preload("res://material_maker/widgets/curve_edit/curve_dialog.tscn").instantiate()
-	var content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	var content_scale_factor : float = mm_globals.ui_scale_factor()
 	dialog.content_scale_factor = content_scale_factor
 	dialog.min_size = Vector2(500, 500)*content_scale_factor
 	mm_globals.main_window.add_dialog(dialog)

--- a/material_maker/widgets/desc_button/desc_button.gd
+++ b/material_maker/widgets/desc_button/desc_button.gd
@@ -19,7 +19,7 @@ func update_tooltip() -> void:
 
 func _on_Button_pressed() -> void:
 	var dialog = preload("res://material_maker/windows/desc_dialog/desc_dialog.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.min_size = Vector2(350, 150) * dialog.content_scale_factor
 	add_child(dialog)
 	var result = await dialog.edit_descriptions(description_type, short_description, long_description)

--- a/material_maker/widgets/float_edit/expression_editor.gd
+++ b/material_maker/widgets/float_edit/expression_editor.gd
@@ -8,16 +8,10 @@ var accept_empty : bool = false
 @onready var editor = $MarginContainer/VBoxContainer/TextEdit
 @onready var parser = load("res://addons/material_maker/parser/glsl_parser.gd").new()
 
-func _context_menu_about_to_popup(context_menu):
-	context_menu.position =  get_window().position + Vector2i(
-			get_mouse_position() * mm_globals.main_window.get_window().content_scale_factor)
-
 func _ready():
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = Vector2(300, 100) * content_scale_factor
-	
-	editor.get_menu().about_to_popup.connect(
-			_context_menu_about_to_popup.bind(editor.get_menu()))
+
 
 func edit_parameter(wt : String, value : String, o : Object, m : String, ep : Array = [], ae : bool = false):
 	object = o

--- a/material_maker/widgets/gradient_editor/gradient_edit.gd
+++ b/material_maker/widgets/gradient_editor/gradient_edit.gd
@@ -133,15 +133,17 @@ func select_color(cursor:GradientEditCursor) -> void:
 				hex.grab_focus()
 				hex.select_all()
 
-	var content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	var content_scale_factor : float = mm_globals.ui_scale_factor()
 	color_picker_popup.content_scale_factor = content_scale_factor
 	color_picker_popup.min_size = color_picker_popup.get_contents_minimum_size() * content_scale_factor
 
 	var _scale := get_global_transform().get_scale()
-	
+
 	color_picker_popup.position.x = (global_position.x + size.x*_scale.x) * content_scale_factor
 	color_picker_popup.position.y = global_position.y * content_scale_factor
-	color_picker_popup.position += get_window().position
+
+	if not get_tree().root.gui_embed_subwindows:
+		color_picker_popup.position += get_window().position
 
 	color_picker_popup.popup_hide.connect(color_picker_popup.queue_free)
 	color_picker_popup.popup_hide.connect(set.bind("mode", Modes.IDLE))

--- a/material_maker/widgets/graph_tree/graph_tree.gd
+++ b/material_maker/widgets/graph_tree/graph_tree.gd
@@ -5,7 +5,7 @@ signal item_icon_double_clicked(generator)
 @onready var tree = $Tree
 
 func _ready() -> void:
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = Vector2(500, 500) * content_scale_factor
 
 func init(graph_name : String, generator : MMGenGraph) -> void:

--- a/material_maker/widgets/lattice_edit/lattice_dialog.gd
+++ b/material_maker/widgets/lattice_edit/lattice_dialog.gd
@@ -10,7 +10,7 @@ signal return_lattice(lattice)
 
 
 func _ready():
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = $VBoxContainer.get_combined_minimum_size() * content_scale_factor
 
 func set_closed(c : bool = true):

--- a/material_maker/widgets/pixels_edit/pixels_edit.gd
+++ b/material_maker/widgets/pixels_edit/pixels_edit.gd
@@ -21,7 +21,7 @@ func set_value(v) -> void:
 
 func _on_PixelsEdit_pressed():
 	var dialog = preload("res://material_maker/widgets/pixels_edit/pixels_dialog.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.min_size = Vector2(500, 500) * dialog.content_scale_factor
 	mm_globals.main_window.add_dialog(dialog)
 	dialog.pixels_changed.connect(self.on_value_changed)

--- a/material_maker/widgets/pixels_edit/pixels_editor.gd
+++ b/material_maker/widgets/pixels_edit/pixels_editor.gd
@@ -53,8 +53,8 @@ func update_color_buttons() -> void:
 			var color_button : ColorPickerButton = ColorPickerButton.new()
 			color_button.ready.connect(func():
 				var popup = color_button.get_popup()
-				popup.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
-				popup.min_size =popup.get_contents_minimum_size() * popup.content_scale_factor)
+				popup.content_scale_factor = mm_globals.ui_scale_factor()
+				popup.min_size = popup.get_contents_minimum_size() * popup.content_scale_factor)
 			color_button.custom_minimum_size = Vector2i(25, 25)
 			color_button.theme_type_variation = "MM_PanelMenuButton"
 			color_button.tooltip_text = "Click to select; Right click to change color"

--- a/material_maker/widgets/polygon_edit/polygon_edit.gd
+++ b/material_maker/widgets/polygon_edit/polygon_edit.gd
@@ -21,7 +21,7 @@ func set_value(v) -> void:
 
 func _on_PolygonEdit_pressed():
 	var dialog = preload("res://material_maker/widgets/polygon_edit/polygon_dialog.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.min_size = Vector2(500, 500) * dialog.content_scale_factor
 	dialog.set_closed(closed)
 	mm_globals.main_window.add_dialog(dialog)

--- a/material_maker/widgets/splines_edit/splines_editor.gd
+++ b/material_maker/widgets/splines_edit/splines_editor.gd
@@ -37,10 +37,10 @@ func _ready():
 		get_parent().add_menu_bar(menu_bar, self)
 	
 	await get_tree().process_frame
-	get_window().content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
-	get_window().min_size = get_window().get_contents_minimum_size() * get_window().content_scale_factor
 
 	if get_window().get_window_id() != DisplayServer.MAIN_WINDOW_ID:
+		get_window().content_scale_factor = mm_globals.ui_scale_factor()
+		get_window().min_size = get_window().get_contents_minimum_size() * get_window().content_scale_factor
 		get_window().hide()
 		get_window().popup_centered()
 

--- a/material_maker/widgets/text_line_edit/text_editor_dialog.gd
+++ b/material_maker/widgets/text_line_edit/text_editor_dialog.gd
@@ -6,18 +6,9 @@ var method : String
 @onready var editor = $MarginContainer/VBoxContainer/TextEdit
 
 func _on_ready() -> void:
-	var editor_context : PopupMenu = editor.get_menu()
-	editor_context.about_to_popup.connect(
-			_context_menu_about_to_popup.bind(editor_context))
-	
-	var csf = mm_globals.main_window.get_window().content_scale_factor
+	var csf : float = mm_globals.ui_scale_factor()
 	get_window().content_scale_factor = csf
 	get_window().min_size = size * csf
-
-
-func _context_menu_about_to_popup(context_menu : PopupMenu) -> void:
-	context_menu.position =  get_window().position + Vector2i(
-			get_mouse_position() * content_scale_factor)
 
 
 func edit_text(wt : String, value : String, o : Object, m : String):

--- a/material_maker/windows/about/about.gd
+++ b/material_maker/windows/about/about.gd
@@ -55,7 +55,7 @@ const PATRONS2 = [
 ]
 
 func _ready() -> void:
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = Vector2(600, 500) * content_scale_factor
 	if Engine.is_editor_hint():
 		application_name_label.text = "Material Maker"

--- a/material_maker/windows/accept_dialog/accept_dialog.gd
+++ b/material_maker/windows/accept_dialog/accept_dialog.gd
@@ -3,10 +3,6 @@ extends AcceptDialog
 
 signal return_status(status)
 
-
-func _ready() -> void:
-	pass
-
 func _on_AcceptDialog_confirmed() -> void:
 	emit_signal("return_status", "ok")
 
@@ -18,7 +14,7 @@ func _on_AcceptDialog_popup_hide() -> void:
 	emit_signal("return_status", "cancel")
 
 func ask() -> String:
-	get_window().content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	get_window().content_scale_factor = mm_globals.ui_scale_factor()
 	get_window().set_size(get_contents_minimum_size()*get_window().content_scale_factor)
 	hide()
 	popup_centered()

--- a/material_maker/windows/add_node_popup/add_node_popup.gd
+++ b/material_maker/windows/add_node_popup/add_node_popup.gd
@@ -23,12 +23,6 @@ func _ready() -> void:
 	filter.connect("text_submitted", Callable(self, "filter_entered"))
 	%List.set_drag_forwarding(get_list_drag_data, Callable(), Callable())
 	update_list()
-	%Filter.get_menu().about_to_popup.connect(
-		_context_menu_about_to_popup.bind(%Filter.get_menu()))
-
-func _context_menu_about_to_popup(context_menu : PopupMenu) -> void:
-	context_menu.position = get_window().position + Vector2i(
-			get_mouse_position() * get_window().content_scale_factor)
 
 func filter_entered(_filter) -> void:
 	_on_list_item_activated(0)
@@ -68,7 +62,8 @@ func todo_renamed_hide() -> void:
 
 
 func show_popup(node_name : String = "", slot : int = -1, slot_type : int = -1, is_output : bool = false) -> void:
-	get_window().content_scale_factor = get_tree().root.content_scale_factor
+	if not get_tree().root.gui_embed_subwindows:
+		get_window().content_scale_factor = get_tree().root.content_scale_factor
 	var current_graph = get_current_graph()
 	insert_position = current_graph.offset_from_global_position(current_graph.get_global_mouse_position())
 	popup()

--- a/material_maker/windows/desc_dialog/desc_dialog.gd
+++ b/material_maker/windows/desc_dialog/desc_dialog.gd
@@ -26,19 +26,5 @@ func _on_Cancel_pressed():
 func _on_WindowDialog_popup_hide():
 	emit_signal("close", false)
 
-
 func _on_WindowDialog_minimum_size_changed():
 	size = $VBoxContainer.size+Vector2(4, 4)
-
-func _context_menu_about_to_popup(context_menu : PopupMenu) -> void:
-	context_menu.position = get_window().position+ Vector2i(
-			get_mouse_position() * get_window().content_scale_factor)
-
-func _on_ready() -> void:
-	var context_menus : Array[PopupMenu] = [
-		$VBoxContainer/LongDesc.get_menu(),
-		$VBoxContainer/HBoxContainer/ShortDesc.get_menu()
-	]
-	for context_menu in context_menus:
-		context_menu.about_to_popup.connect(
-				_context_menu_about_to_popup.bind(context_menu))

--- a/material_maker/windows/desc_dialog/desc_dialog.tscn
+++ b/material_maker/windows/desc_dialog/desc_dialog.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://3rcb1a63iu8s" path="res://material_maker/windows/desc_dialog/desc_dialog.gd" id="1"]
 
 [node name="Window" type="Window"]
+oversampling_override = 1.0
 position = Vector2i(0, 36)
 size = Vector2i(300, 150)
 script = ExtResource("1")
@@ -50,6 +51,5 @@ size_flags_horizontal = 3
 text = "Cancel"
 
 [connection signal="close_requested" from="." to="." method="_on_Cancel_pressed"]
-[connection signal="ready" from="." to="." method="_on_ready"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer2/OK" to="." method="_on_OK_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer2/Cancel" to="." method="_on_Cancel_pressed"]

--- a/material_maker/windows/environment_editor/environment_editor.gd
+++ b/material_maker/windows/environment_editor/environment_editor.gd
@@ -16,7 +16,7 @@ var new_environment_icon = preload("res://material_maker/windows/environment_edi
 var current_environment = -1
 
 func _ready():
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = Vector2(900, 600) * content_scale_factor
 	
 	for color_picker in $Main/HSplitContainer/UI.get_children():

--- a/material_maker/windows/environment_editor/environment_editor.tscn
+++ b/material_maker/windows/environment_editor/environment_editor.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://rflulhsuy3ax" path="res://material_maker/widgets/float_edit/float_edit.tscn" id="3"]
 
 [node name="EnvironmentEditor" type="Window"]
+oversampling_override = 1.0
 position = Vector2i(0, 36)
 exclusive = true
 script = ExtResource("2")

--- a/material_maker/windows/export_animation/export_animation.gd
+++ b/material_maker/windows/export_animation/export_animation.gd
@@ -27,7 +27,7 @@ const BUFFER_NAMES = [ "export_animation_buffer_begin", "export_animation_buffer
 
 
 func _ready():
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = $VBox.get_combined_minimum_size() * content_scale_factor
 	for i in range(BUFFER_NAMES.size()):
 		mm_deps.create_buffer(BUFFER_NAMES[i], self)

--- a/material_maker/windows/export_taa/export_taa.gd
+++ b/material_maker/windows/export_taa/export_taa.gd
@@ -11,7 +11,7 @@ var force_update : bool = false
 var render_size : Vector2i = Vector2i(512, 512)
 
 func _ready():
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = $VBoxContainer.get_combined_minimum_size() * content_scale_factor
 	acc_texture = MMTexture.new()
 	avg_texture = MMTexture.new()

--- a/material_maker/windows/file_dialog/file_dialog.gd
+++ b/material_maker/windows/file_dialog/file_dialog.gd
@@ -19,20 +19,7 @@ func _ready() -> void:
 		ok_button_text = tr("Save")
 
 	use_native_dialog = mm_globals.get_config("ui_use_native_file_dialogs")
-	_content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
-	content_scale_factor = _content_scale_factor
-	
-	for child in get_children(true):
-		if child is PopupMenu:
-			child.about_to_popup.connect(_context_menu_about_to_popup.bind(child))
-	
-	for hbox in get_vbox().get_children():
-		if hbox is HBoxContainer:
-			for line_edit in hbox.get_children():
-				if line_edit is LineEdit:
-					var context_menu : PopupMenu = line_edit.get_menu()
-					context_menu.about_to_popup.connect(
-							_context_menu_about_to_popup.bind(context_menu))
+	content_scale_factor = mm_globals.ui_scale_factor()
 
 	min_size = _content_scale_factor * get_contents_minimum_size()
 	min_size = Vector2i(750, 500) * int(_content_scale_factor)
@@ -86,7 +73,7 @@ func select_files() -> Array:
 
 func _on_child_entered_tree(node: Node) -> void:
 	if node is ConfirmationDialog or node is AcceptDialog:
-		node.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+		node.content_scale_factor = mm_globals.ui_scale_factor()
 		var min_size_scale = Vector2(0,0)
 		match node.title:
 			"Alert!":

--- a/material_maker/windows/line_dialog/line_dialog.gd
+++ b/material_maker/windows/line_dialog/line_dialog.gd
@@ -36,12 +36,5 @@ func enter_text(window_title : String, label : String, value : String) -> Dictio
 func _on_VBoxContainer_minimum_size_changed():
 	size = ($VBoxContainer.get_minimum_size() + Vector2(20, 4))*content_scale_factor
 
-func _context_menu_about_to_popup(context_menu : PopupMenu) -> void:
-	context_menu.position =  get_window().position + Vector2i(
-			get_mouse_position() * content_scale_factor)
-
 func _on_ready() -> void:
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
-	var line_edit_context : PopupMenu = $VBoxContainer/LineEdit.get_menu()
-	line_edit_context.about_to_popup.connect(
-			_context_menu_about_to_popup.bind(line_edit_context))
+	content_scale_factor = mm_globals.ui_scale_factor()

--- a/material_maker/windows/line_dialog/line_dialog.tscn
+++ b/material_maker/windows/line_dialog/line_dialog.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://brjipglk57vch" path="res://material_maker/windows/line_dialog/line_dialog.gd" id="1"]
 
 [node name="LineDialog" type="Window"]
+oversampling_override = 1.0
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/material_maker/windows/load_from_website/load_from_website.gd
+++ b/material_maker/windows/load_from_website/load_from_website.gd
@@ -76,7 +76,7 @@ func fill_list(filter : String):
 func select_asset(type : int = 0, return_index : bool = false) -> Dictionary:
 	# Hide the window until the asset list is loaded
 	visible = false
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	mm_globals.main_window.add_dialog(self)
 	var error = $HTTPRequest.request(MMPaths.WEBSITE_ADDRESS+"/api/getMaterials")
 	if error == OK:

--- a/material_maker/windows/material_editor/export_editor.gd
+++ b/material_maker/windows/material_editor/export_editor.gd
@@ -25,24 +25,9 @@ const GEN_MATERIAL = preload("res://addons/material_maker/engine/nodes/gen_mater
 signal node_changed(model_data)
 signal editor_window_closed
 
-func _context_menu_about_to_popup(context_menu : PopupMenu) -> void:
-	context_menu.position =  get_window().position + Vector2i(
-			get_mouse_position() * content_scale_factor)
-
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	export_file_expression.parent_dialog = self
-	var context_menus : Array[PopupMenu] = [
-		export_custom_script.get_menu(),
-		export_file_template.get_menu(),
-		export_file_name.get_menu(),
-		export_file_conditions.get_menu(),
-		export_file_expression.get_menu(),
-		export_extension_edit.get_menu(),
-	]
-	for context_menu in context_menus:
-		context_menu.about_to_popup.connect(
-			_context_menu_about_to_popup.bind(context_menu))
 	# fix button icon colors (light theme)
 	for button in $MarginContainer/VBoxContainer/Export.get_children():
 		if button is Button:
@@ -126,7 +111,7 @@ func select_file(i : int) -> void:
 
 func _on_Create_Export_pressed():
 	var dialog = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.min_size = Vector2(250, 90) * dialog.content_scale_factor
 	add_child(dialog)
 	var status = await dialog.enter_text("Export", "Enter the export target name", "")
@@ -183,7 +168,7 @@ func _on_Rename_Export_pressed():
 		return
 	var old_export : String = export_target.get_item_text(old_export_index)
 	var dialog = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.min_size = Vector2(250, 90) * dialog.content_scale_factor
 	add_child(dialog)
 	var status = await dialog.enter_text("Export", "Enter the export target name", old_export)
@@ -210,7 +195,7 @@ func _on_Duplicate_Export_pressed():
 		return
 	var old_export : String = export_target.get_item_text(old_export_index)
 	var dialog = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
-	dialog.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	dialog.content_scale_factor = mm_globals.ui_scale_factor()
 	dialog.min_size = Vector2(250, 90) * dialog.content_scale_factor
 	add_child(dialog)
 	var status = await dialog.enter_text("Export", "Enter the export target name", old_export)

--- a/material_maker/windows/new_painter/new_painter.gd
+++ b/material_maker/windows/new_painter/new_painter.gd
@@ -18,7 +18,7 @@ signal return_status(status : Dictionary)
 
 
 func _ready():
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	min_size = Vector2(500, 300) * content_scale_factor
 	if mesh_material:
 		mesh_instance.set_surface_override_material(0, mesh_material)

--- a/material_maker/windows/node_editor/node_editor.gd
+++ b/material_maker/windows/node_editor/node_editor.gd
@@ -20,26 +20,8 @@ const OutputEditor = preload("res://material_maker/windows/node_editor/output.ts
 signal node_changed(model_data)
 signal editor_window_closed
 
-func _context_menu_about_to_popup(context_menu : PopupMenu) -> void:
-	context_menu.position =  get_window().position + Vector2i(
-			get_mouse_position() * content_scale_factor)
-
-func _on_ready() -> void:
-	await get_tree().process_frame
-	var context_menus : Array[PopupMenu] = [
-		$"Sizer/TabBar/Global Functions/Includes/Includes".get_menu(),
-		$Sizer/TabBar/General/Name/Name.get_menu(),
-	]
-	for menu in context_menus:
-		menu.about_to_popup.connect(_context_menu_about_to_popup.bind(menu))
-
 func add_item(parent, scene) -> Node:
 	var object = scene.instantiate()
-	if object is HBoxContainer:
-		for child in object.get_children():
-			if child is LineEdit:
-				child.get_menu().about_to_popup.connect(
-						_context_menu_about_to_popup.bind(child.get_menu()))
 	parent.add_child(object)
 	parent.move_child(object, parent.get_child_count()-2)
 	return object
@@ -161,7 +143,7 @@ func _on_Functions_text_changed():
 				error_label.text = "Syntax error line "+str(globals_error_line+1)+": "+result.msg
 
 func _on_Sizer_minimum_size_changed():
-	size = $Sizer.size+Vector2(4, 4)
+	size = $Sizer.get_combined_minimum_size() + Vector2(4, 4)
 
 # OK/Apply/Cancel buttons
 

--- a/material_maker/windows/node_editor/parameter.gd
+++ b/material_maker/windows/node_editor/parameter.gd
@@ -7,7 +7,7 @@ func _ready() -> void:
 	for child in $Types/color.get_children():
 		if child is ColorPickerButton:
 			var picker_popup = child.get_popup()
-			picker_popup.content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+			picker_popup.content_scale_factor = mm_globals.ui_scale_factor()
 			picker_popup.min_size = picker_popup.get_contents_minimum_size() * picker_popup.content_scale_factor
 	_on_Type_item_selected($Type.selected)
 

--- a/material_maker/windows/node_editor/parameter_enum.gd
+++ b/material_maker/windows/node_editor/parameter_enum.gd
@@ -47,7 +47,7 @@ func update_enum_list() -> void:
 
 func _on_EnumValues_item_selected(id) -> void:
 	id = $EnumValues.get_item_id(id)
-	var content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	var content_scale_factor : float = mm_globals.ui_scale_factor()
 	if id >= 0 and id < enum_values.size():
 		enum_current = id
 	elif id == ENUM_EDIT:

--- a/material_maker/windows/preferences/language_download.gd
+++ b/material_maker/windows/preferences/language_download.gd
@@ -34,7 +34,7 @@ func _ready():
 		$ScrollContainer/Languages.add_child(button)
 		button.connect("pressed", Callable(self, "download_language").bind(l))
 	var minimum_size : Vector2i = $ScrollContainer/Languages.get_minimum_size()
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	minimum_size *= content_scale_factor
 	popup(Rect2i($ScrollContainer.get_global_mouse_position()*content_scale_factor, minimum_size))
 

--- a/material_maker/windows/preferences/preferences.gd
+++ b/material_maker/windows/preferences/preferences.gd
@@ -13,6 +13,7 @@ func edit_preferences(c : ConfigFile) -> void:
 	var main_window = mm_globals.main_window
 	main_window.add_dialog(self)
 	config_changed.connect(main_window.on_config_changed)
+	content_scale_factor = mm_globals.ui_scale_factor()
 	update_controls(self)
 	size *= content_scale_factor
 	hide()

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://3lo2jh781ten" path="res://material_maker/windows/preferences/float_option.tscn" id="3"]
 [ext_resource type="Script" path="res://material_maker/windows/preferences/preferences_tree.gd" id="3_mlqij"]
 [ext_resource type="Script" uid="uid://gmystrme5ayw" path="res://material_maker/windows/preferences/lang_option.gd" id="4"]
-[ext_resource type="Script" path="res://material_maker/windows/preferences/enum_option.gd" id="5_vp06c"]
+[ext_resource type="Script" uid="uid://d3h4xmek7b2vq" path="res://material_maker/windows/preferences/enum_option.gd" id="5_vp06c"]
 
 [node name="Preferences" type="Window"]
 oversampling_override = 1.0
@@ -190,6 +190,23 @@ tooltip_text = "Toggle background dimming when a dialog is visible."
 text = "On"
 flat = false
 config_variable = "dialog_dim_background"
+
+[node name="GuiSingleWindowMode" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/GuiSingleWindowMode"]
+layout_mode = 2
+mouse_filter = 1
+text = "Single window mode (requires restart)"
+
+[node name="GuiSingleWindowMode" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/GuiSingleWindowMode" instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+tooltip_text = "Enables single-window mode."
+text = "On"
+flat = false
+config_variable = "ui_single_window_mode"
 
 [node name="Spacer5" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 custom_minimum_size = Vector2(0, 10)

--- a/material_maker/windows/progress_window/progress_window.gd
+++ b/material_maker/windows/progress_window/progress_window.gd
@@ -1,7 +1,7 @@
 extends Popup
 
 func _ready() -> void:
-	content_scale_factor = mm_globals.main_window.get_window().content_scale_factor
+	content_scale_factor = mm_globals.ui_scale_factor()
 	popup_centered()
 
 func set_text(t) -> void:

--- a/material_maker/windows/sdf_builder/sdf_builder.gd
+++ b/material_maker/windows/sdf_builder/sdf_builder.gd
@@ -43,6 +43,12 @@ func _ready():
 	for c in [ "ViewModeLabel", "ViewMode", "PostProcessingLabel", "PostProcessing" ]:
 		viewmenu_panel_grid.get_node(c).visible = false
 
+	await get_tree().process_frame
+	content_scale_factor = mm_globals.ui_scale_factor()
+	min_size = Vector2(800, 400) * content_scale_factor
+	size = min_size
+	move_to_center()
+
 func get_next_index() -> int:
 	next_index += 1
 	return next_index

--- a/material_maker/windows/sdf_builder/sdf_builder.tscn
+++ b/material_maker/windows/sdf_builder/sdf_builder.tscn
@@ -25,6 +25,7 @@ atlas = ExtResource("6")
 region = Rect2(48, 0, 16, 16)
 
 [node name="Control" type="Window"]
+oversampling_override = 1.0
 position = Vector2i(0, 36)
 exclusive = true
 script = ExtResource("3")

--- a/project.godot
+++ b/project.godot
@@ -61,6 +61,7 @@ window/size/transparent=true
 window/size/window_width_override=1
 window/size/window_height_override=1
 window/per_pixel_transparency/allowed=true
+window/subwindows/embed_subwindows=false
 window/handheld/orientation.Android="sensor_landscape"
 
 [editor]


### PR DESCRIPTION
Adds support for single-window mode

This may be useful for Linux users where multi-window mode can be unstable(at least until godot resolves the problem),

- i.e. https://github.com/RodZill4/material-maker/issues/1154
- https://github.com/RodZill4/material-maker/issues/1385

This PR
- Respects `--single-window` argument via command line
- Adds option in preferences to enable single-window mode (defaults to disabled)
- Adds theme styles(embedded border) for single-window mode
- Fixes for window/popup scale/positions under single-window mode
- Remove unnecessary context menu popup position fixes 