### PR TITLE
Fix crash when adjusting BPP in pixels node

### DIFF
--- a/addons/material_maker/types/pixels.gd
+++ b/addons/material_maker/types/pixels.gd
@@ -46,7 +46,7 @@ func set_size(w : int, h : int, b : int) -> void:
 	var old : MMPixels = duplicate()
 	size.x = w
 	size.y = h
-	bpp = b
+	bpp = maxi(b, 1)
 	update_data()
 	for x in range(w):
 		for y in range(h):


### PR DESCRIPTION
Resolves issue via discord

> Crash when adding a pixels node and scrolling Bits per Pixel toward 0