### PR TITLE
Keep thumbnail when updating library item

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -1077,7 +1077,7 @@ func create_menu_add_to_library(menu : MMMenuManager.MenuBase, manager, function
 func create_menu_add_selection_to_library(menu : MMMenuManager.MenuBase) -> void:
 	create_menu_add_to_library(menu, node_library_manager, "add_selection_to_library")
 
-func add_selection_to_library(index: int, should_ask_item_name: bool = true) -> void:
+func add_selection_to_library(index: int, should_ask_item_name: bool = true, update_thumbnail := true) -> void:
 	var selected_nodes = get_selected_nodes()
 	if selected_nodes.is_empty():
 		return
@@ -1101,9 +1101,11 @@ func add_selection_to_library(index: int, should_ask_item_name: bool = true) -> 
 	elif graph_edit != null:
 		data = graph_edit.serialize_selection()
 	# Create thumbnail
-	var result = await selected_nodes[0].generator.render(self, 0, 64, true)
-	var image : Image = result.get_image()
-	result.release(self)
+	var image : Image = null
+	if update_thumbnail:
+		var result = await selected_nodes[0].generator.render(self, 0, 64, true)
+		image = result.get_image()
+		result.release(self)
 	node_library_manager.add_item_to_library(index, current_item_name, image, data)
 
 func create_menu_add_brush_to_library(menu : MMMenuManager.MenuBase) -> void:

--- a/material_maker/panels/library/library.gd
+++ b/material_maker/panels/library/library.gd
@@ -401,7 +401,7 @@ func _on_PopupMenu_index_pressed(index):
 			var image : Image = await current_node.generator.render_output(0, Vector2i(64, 64))
 			library_manager.update_item_icon_in_library(library_index, item_path, image)
 		2: # Update item
-			mm_globals.main_window.add_selection_to_library(library_index, false)
+			mm_globals.main_window.add_selection_to_library(library_index, false, false)
 		3: # Delete item
 			library_manager.remove_item_from_library(library_index, item_path)
 		5: # Define aliases

--- a/material_maker/tools/library_manager/library.gd
+++ b/material_maker/tools/library_manager/library.gd
@@ -163,8 +163,12 @@ func add_item(item_name : String, image : Image, data : Dictionary) -> void:
 	if read_only:
 		return
 	data.tree_item = item_name
-	data.icon_data = Marshalls.raw_to_base64(image.save_png_to_buffer())
 	data.display_name = data.tree_item.get_slice('/', data.tree_item.get_slice_count('/') - 1)
+
+	var current_library_item = get_item(item_name)
+	if current_library_item and current_library_item.item.has("icon_data"):
+		data.icon_data = current_library_item.item.icon_data
+
 	var new_library_items = []
 	var inserted = false
 	for i in library_items:
@@ -177,9 +181,12 @@ func add_item(item_name : String, image : Image, data : Dictionary) -> void:
 		new_library_items.push_back(data)
 	library_items = new_library_items
 	library_items_by_name[item_name] = data
-	var texture : ImageTexture = ImageTexture.new()
-	texture.set_image(image)
-	library_icons[item_name] = texture
+
+	if image != null:
+		data.icon_data = Marshalls.raw_to_base64(image.save_png_to_buffer())
+		var texture : ImageTexture = ImageTexture.new()
+		texture.set_image(image)
+		library_icons[item_name] = texture
 	save_library()
 
 func remove_item(item_name : String) -> void:


### PR DESCRIPTION
suggestion via discord

> on the library tab, when updating a node with "update item", it would be nice for the thumbnail to not get deleted