### PR TITLE
Allow closing named param dialog via window button

### DIFF
--- a/material_maker/nodes/remote/named_parameter_dialog.gd
+++ b/material_maker/nodes/remote/named_parameter_dialog.gd
@@ -25,3 +25,6 @@ func configure_param(minimum : float = 0.0, maximum : float = 1.0, step : float 
 	var result = await self.return_values
 	queue_free()
 	return result
+
+func _on_close_requested() -> void:
+	_on_Cancel_pressed()

--- a/material_maker/nodes/remote/named_parameter_dialog.tscn
+++ b/material_maker/nodes/remote/named_parameter_dialog.tscn
@@ -80,6 +80,7 @@ custom_minimum_size = Vector2(60, 0)
 layout_mode = 2
 text = "Cancel"
 
+[connection signal="close_requested" from="." to="." method="_on_close_requested"]
 [connection signal="value_changed" from="VBoxContainer/float/Min" to="VBoxContainer/float" method="_on_Min_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/float/Max" to="VBoxContainer/float" method="_on_Max_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/float/Step" to="VBoxContainer/float" method="_on_Step_value_changed"]


### PR DESCRIPTION
issue via discord

> if I edit the parameter, the window only closes if I click on ok or cancel, the 'X' in the corner doesn't do anything.