### PR TITLE
Make dialogs dismissable via `ui_cancel` action

### DIFF
--- a/material_maker/nodes/debug/debug_popup.gd
+++ b/material_maker/nodes/debug/debug_popup.gd
@@ -104,3 +104,7 @@ func generate_godot_spatial() -> String:
 	code = code.replace("uniform", "const")
 	code = code.replace("const sampler2D", "uniform sampler2D")
 	return code
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		queue_free()

--- a/material_maker/nodes/remote/named_parameter_dialog.gd
+++ b/material_maker/nodes/remote/named_parameter_dialog.gd
@@ -28,3 +28,7 @@ func configure_param(minimum : float = 0.0, maximum : float = 1.0, step : float 
 
 func _on_close_requested() -> void:
 	_on_Cancel_pressed()
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		queue_free()

--- a/material_maker/panels/library/create_lib_dialog.gd
+++ b/material_maker/panels/library/create_lib_dialog.gd
@@ -71,3 +71,8 @@ func enter_info(value : String = "") -> Dictionary:
 func _on_VBoxContainer_minimum_size_changed():
 	min_size = $MarginContainer.get_combined_minimum_size() * content_scale_factor
 	max_size = Vector2(max_size.x, $MarginContainer.get_minimum_size().y)
+
+
+func _on_window_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		queue_free()

--- a/material_maker/panels/library/create_lib_dialog.tscn
+++ b/material_maker/panels/library/create_lib_dialog.tscn
@@ -6,6 +6,7 @@
 [sub_resource type="ImageTexture" id="ImageTexture_8pecb"]
 
 [node name="CreateLibDialog" type="Window"]
+oversampling_override = 1.0
 title = "Create Library"
 position = Vector2i(0, 36)
 size = Vector2i(400, 1)
@@ -83,6 +84,7 @@ layout_mode = 2
 text = "Cancel"
 
 [connection signal="close_requested" from="." to="." method="_on_close_requested"]
+[connection signal="window_input" from="." to="." method="_on_window_input"]
 [connection signal="minimum_size_changed" from="MarginContainer/VBoxContainer" to="." method="_on_VBoxContainer_minimum_size_changed"]
 [connection signal="text_changed" from="MarginContainer/VBoxContainer/GridContainer/LibraryNameLineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="text_submitted" from="MarginContainer/VBoxContainer/GridContainer/LibraryNameLineEdit" to="." method="_on_LineEdit_text_entered"]

--- a/material_maker/tools/share/login_dialog.gd
+++ b/material_maker/tools/share/login_dialog.gd
@@ -41,3 +41,7 @@ func _on_MarginContainer_minimum_size_changed():
 
 func _on_RegisterButton_pressed():
 	OS.shell_open(MMPaths.WEBSITE_ADDRESS+"/register")
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		queue_free()

--- a/material_maker/tools/share/share_node_dialog.gd
+++ b/material_maker/tools/share/share_node_dialog.gd
@@ -41,3 +41,7 @@ func ask(status : Array) -> String:
 
 func _on_MarginContainer_minimum_size_changed():
 	size = $MarginContainer.get_minimum_size()+Vector2(4, 4)
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		queue_free()

--- a/material_maker/windows/desc_dialog/desc_dialog.gd
+++ b/material_maker/windows/desc_dialog/desc_dialog.gd
@@ -42,3 +42,7 @@ func _on_ready() -> void:
 	for context_menu in context_menus:
 		context_menu.about_to_popup.connect(
 				_context_menu_about_to_popup.bind(context_menu))
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		queue_free()

--- a/material_maker/windows/line_dialog/line_dialog.gd
+++ b/material_maker/windows/line_dialog/line_dialog.gd
@@ -45,3 +45,7 @@ func _on_ready() -> void:
 	var line_edit_context : PopupMenu = $VBoxContainer/LineEdit.get_menu()
 	line_edit_context.about_to_popup.connect(
 			_context_menu_about_to_popup.bind(line_edit_context))
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		queue_free()


### PR DESCRIPTION
Makes the following dialogs dimissable via the `ui_cancel` input action(i.e. Esc Key) to be consistent with other dialogs(e.g. preferences, envionment editor):
- Debug node popup
- Named parameter dialog
- Create library dialog
- Login dialog
- Share node dialog
- Description dialog
- Line dialog