### PR TITLE
Add MCP server addon for AI-powered material creation

### DIFF
--- a/TODO_MCP.md
+++ b/TODO_MCP.md
@@ -1,0 +1,69 @@
+# Material Maker MCP Integration — Fork Todo
+
+> Development tasks for integrating MCP server into the Material Maker fork.
+> Repository: derekrhiggins/material-maker (fork of RodZill4/material-maker)
+
+---
+
+### Phase F1 — Addon Integration
+
+- [x] **F1.** Create `addons/material_maker_mcp/` directory in MM source tree
+- [x] **F2.** Copy and adapt `addon.gd` — fix main_window reference to use `mm_globals.main_window`, add async dispatch support
+- [x] **F3.** Copy command handlers (`commands/scene.gd`, `graph.gd`, `parameters.gd`, `export.gd`, `utils.gd`)
+- [x] **F4.** Register autoload in `project.godot`: `mm_mcp="*res://addons/material_maker_mcp/addon.gd"`
+- [ ] **F5.** Verify TCP server starts automatically on MM launch — test with `nc -z localhost 9002`
+- [ ] **F6.** Test basic ping/pong round-trip from Python MCP server to forked MM
+
+---
+
+### Phase F2 — Wire Up Real MM APIs
+
+> The command handlers were written against assumed APIs. Now we validate and fix against real MM internals.
+
+- [x] **F7.** Audit `scene.gd` — rewritten to use `graph_edit.save_path`, `need_save`, `save_file()`, `do_load_project()`, `new_material()`, `.ptex` extension
+- [x] **F8.** Audit `graph.gd` — rewritten to use `graph_edit.create_nodes()` (async), `graph.remove_generator()`, `graph.connect_children()`, `graph.disconnect_children()`
+- [x] **F9.** Audit `graph.gd` — `get_graph_info` reads `graph.get_children()` and `graph.connections` directly
+- [x] **F10.** Audit `graph.gd` — `list_available_nodes` uses `mm_loader.get_generator_list()` / `NodeLibraryManager`
+- [x] **F11.** Audit `parameters.gd` — uses `get_parameter()`/`set_parameter()` with correct type coercion (`"boolean"` not `"bool"`)
+- [x] **F12.** Audit `export.gd` — rewritten to use `render_output()` for individual maps and `export_material(prefix, profile)` for engine export
+- [x] **F13.** All API mismatches fixed — handlers rewritten against real MM source code
+
+---
+
+### Phase F3 — Preview / Visual Feedback
+
+- [ ] **F14.** Implement `get_preview_image` command in GDScript — capture a node's 2D texture preview as PNG bytes
+- [ ] **F15.** Implement `get_3d_preview` command — capture the 3D material preview viewport as PNG bytes
+- [ ] **F16.** Add `get_preview_image` tool to Python MCP server — return base64 PNG as MCP image content
+- [ ] **F17.** Add `get_3d_preview` tool to Python MCP server
+- [ ] **F18.** Test preview capture round-trip — verify Claude Code can receive and interpret the images
+
+---
+
+### Phase F4 — End-to-End Testing
+
+- [ ] **F19.** Create a test script that builds a complete material (e.g. procedural brick) via MCP commands
+- [ ] **F20.** Verify full workflow: new_project → create nodes → connect → set params → preview → export
+- [ ] **F21.** Test with Claude Code as the MCP client — have Claude create a material from a text description
+- [ ] **F22.** Stress test: rapid sequential commands, large graphs (50+ nodes), parameter sweeps
+- [ ] **F23.** Test error paths: invalid node types, bad connections, missing parameters
+
+---
+
+### Phase F5 — Polish & Upstream Sync
+
+- [ ] **F24.** Add MCP server status indicator to MM UI (optional panel or status bar text)
+- [ ] **F25.** Document how to build and run the forked MM with MCP support
+- [ ] **F26.** Set up upstream sync workflow — periodically merge from RodZill4/material-maker master
+- [ ] **F27.** Create release builds (Windows, Linux, macOS) of the MCP-enabled MM fork
+- [ ] **F28.** Update material-maker-mcp README to point to the fork for the MM side (instead of manual addon install)
+
+---
+
+### Notes
+
+- MM's main window is accessed via `mm_globals.main_window` (the `mm_globals` autoload)
+- Node library is at `main_window.node_library_manager`
+- Current graph is accessed through the projects panel: `main_window.projects_panel`
+- MM uses `node_factory.gd` for creating nodes programmatically
+- Export pipeline is in `addons/material_maker/engine/`

--- a/addons/material_maker_mcp/addon.gd
+++ b/addons/material_maker_mcp/addon.gd
@@ -1,0 +1,376 @@
+## addon.gd — Material Maker MCP TCP Server Plugin
+##
+## This is the main plugin file for the Material Maker MCP bridge. It runs a
+## lightweight TCP socket server inside Material Maker, accepting newline-delimited
+## JSON commands from the Python MCP server (or any compatible client) and
+## dispatching them to the appropriate command handlers.
+##
+## Architecture:
+##   [Claude / AI Client] <--MCP/stdio--> [Python MCP Server] <--TCP:9002--> [This Plugin]
+##
+## Material Maker plugins extend Node (NOT EditorPlugin). They are loaded by
+## MM's own Plugin Manager, not by the Godot editor plugin system.
+##
+## Written for Godot 4.x. Godot 3.x compatibility notes are included inline
+## where the APIs diverge.
+
+extends Node
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+## Default TCP port. Avoids conflict with Blender MCP which uses 9001.
+const DEFAULT_PORT: int = 9002
+
+## Maximum bytes to read from a client per _process tick. Keeps the main
+## thread responsive even if a client sends a large payload.
+const MAX_READ_BYTES_PER_TICK: int = 65536
+
+## Protocol version — sent in handshake so the Python side can detect
+## incompatibilities early.
+const PROTOCOL_VERSION: String = "0.1.0"
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+## The TCP server instance.
+## Godot 4: TCPServer   |   Godot 3: TCP_Server (note the underscore)
+var _server: TCPServer = null
+
+## Currently connected clients. We support multiple simultaneous connections
+## (e.g. one from the MCP server and one from a debug tool).
+## Each entry maps a StreamPeerTCP to its per-client state dictionary.
+var _clients: Dictionary = {}
+
+## The port the server is actually listening on (after startup).
+var _port: int = DEFAULT_PORT
+
+## Command handler modules — instantiated in _ready().
+var _scene_commands: RefCounted = null
+var _graph_commands: RefCounted = null
+var _parameter_commands: RefCounted = null
+var _export_commands: RefCounted = null
+var _utils_commands: RefCounted = null
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+func _ready() -> void:
+	# Read port from environment variable, falling back to the default.
+	# The Python MCP server passes this via env so both sides agree.
+	var env_port: String = OS.get_environment("MM_MCP_PORT")
+	if env_port != "" and env_port.is_valid_int():
+		_port = env_port.to_int()
+
+	# Initialize command handler modules.
+	# mm_globals is an autoload that holds a reference to the real MainWindow.
+	# We must wait a frame for autoloads and the main scene to be ready.
+	await get_tree().process_frame
+	var main_window = get_node("/root/mm_globals").main_window
+	if main_window == null:
+		push_error("[MCP] Could not find Material Maker main window. MCP server will not start.")
+		return
+
+	_scene_commands = preload("res://addons/material_maker_mcp/commands/scene.gd").new()
+	_scene_commands.init(main_window)
+	_graph_commands = preload("res://addons/material_maker_mcp/commands/graph.gd").new()
+	_graph_commands.init(main_window)
+	_parameter_commands = preload("res://addons/material_maker_mcp/commands/parameters.gd").new()
+	_parameter_commands.init(main_window)
+	_export_commands = preload("res://addons/material_maker_mcp/commands/export.gd").new()
+	_export_commands.init(main_window)
+	_utils_commands = preload("res://addons/material_maker_mcp/commands/utils.gd").new()
+	_utils_commands.init(main_window)
+
+	_server = TCPServer.new()
+
+	# Godot 4: listen() returns an Error enum.
+	# Godot 3: listen() also returns an Error but the class is TCP_Server.
+	var err: Error = _server.listen(_port, "127.0.0.1")
+	if err != OK:
+		push_error("[MCP] Failed to start TCP server on port %d (Error %d)" % [_port, err])
+		print("[MCP] ERROR: Could not bind to port %d — is another instance running?" % _port)
+		return
+
+	print("[MCP] Server listening on 127.0.0.1:%d  (protocol v%s)" % [_port, PROTOCOL_VERSION])
+
+
+func _exit_tree() -> void:
+	# Clean shutdown: disconnect every client, then stop the server.
+	print("[MCP] Shutting down server...")
+
+	for peer: StreamPeerTCP in _clients.keys():
+		peer.disconnect_from_host()
+	_clients.clear()
+
+	if _server != null:
+		_server.stop()
+		_server = null
+
+	print("[MCP] Server stopped.")
+
+
+# ---------------------------------------------------------------------------
+# Main loop — runs every frame
+# ---------------------------------------------------------------------------
+
+func _process(_delta: float) -> void:
+	if _server == null:
+		return
+
+	# ------------------------------------------------------------------
+	# Accept new connections
+	# ------------------------------------------------------------------
+	# Godot 4: is_connection_available() / take_connection()
+	# Godot 3: is_connection_available() / take_connection() — same API
+	while _server.is_connection_available():
+		var peer: StreamPeerTCP = _server.take_connection()
+		if peer != null:
+			# Disable Nagle's algorithm for lower latency on small JSON messages.
+			peer.set_no_delay(true)
+			# Initialise per-client state with an empty receive buffer.
+			_clients[peer] = {
+				"buffer": ""  # Accumulates partial reads until we see a newline.
+			}
+			print("[MCP] Client connected (%d total)." % _clients.size())
+
+	# ------------------------------------------------------------------
+	# Read from existing clients
+	# ------------------------------------------------------------------
+	# We iterate over a snapshot of the keys because we may remove clients
+	# inside the loop if they disconnect.
+	var peers: Array = _clients.keys()
+	for peer: StreamPeerTCP in peers:
+		# Godot 4: poll() must be called each frame to drive the connection
+		# state machine. Godot 3 does this internally.
+		peer.poll()
+
+		var status: StreamPeerTCP.Status = peer.get_status()
+
+		if status == StreamPeerTCP.STATUS_NONE or status == StreamPeerTCP.STATUS_ERROR:
+			# Client disconnected or errored out — remove it.
+			_remove_client(peer)
+			continue
+
+		if status != StreamPeerTCP.STATUS_CONNECTED:
+			# Still connecting — nothing to read yet.
+			continue
+
+		# Read available bytes (up to the per-tick cap).
+		var available: int = peer.get_available_bytes()
+		if available <= 0:
+			continue
+
+		var bytes_to_read: int = mini(available, MAX_READ_BYTES_PER_TICK)
+		# Godot 4: get_data() returns [Error, PackedByteArray].
+		# Godot 3: get_data() returns [Error, PoolByteArray].
+		var result: Array = peer.get_data(bytes_to_read)
+		var err: Error = result[0]
+		if err != OK:
+			push_warning("[MCP] Read error on client (Error %d), disconnecting." % err)
+			_remove_client(peer)
+			continue
+
+		var data: PackedByteArray = result[1]
+		var text: String = data.get_string_from_utf8()
+
+		# Append to this client's buffer.
+		var client_state: Dictionary = _clients[peer]
+		client_state["buffer"] += text
+
+		# Guard against oversized payloads (> 1 MB).
+		if client_state["buffer"].length() > 1048576:
+			send_response(peer, "error", {"message": "Request too large (buffer exceeded 1 MB limit)"})
+			_remove_client(peer)
+			continue
+
+		# Process complete lines (newline-delimited JSON protocol).
+		_process_buffer(peer, client_state)
+
+
+# ---------------------------------------------------------------------------
+# Buffer processing — extract complete JSON lines and dispatch
+# ---------------------------------------------------------------------------
+
+func _process_buffer(peer: StreamPeerTCP, client_state: Dictionary) -> void:
+	# Split on newline. The last element may be an incomplete line — keep it.
+	while true:
+		var newline_pos: int = client_state["buffer"].find("\n")
+		if newline_pos == -1:
+			break
+
+		var line: String = client_state["buffer"].substr(0, newline_pos).strip_edges()
+		client_state["buffer"] = client_state["buffer"].substr(newline_pos + 1)
+
+		if line.is_empty():
+			continue
+
+		# Try to parse the JSON command.
+		var json := JSON.new()
+		# Godot 4: JSON.parse() returns an Error; parsed data lives in .data.
+		# Godot 3: JSON.parse() returns a JSONParseResult object.
+		var parse_err: Error = json.parse(line)
+		if parse_err != OK:
+			push_warning("[MCP] Invalid JSON from client: %s" % json.get_error_message())
+			send_response(peer, "error", {"message": "Invalid JSON: %s" % json.get_error_message()})
+			continue
+
+		var command: Variant = json.data
+		if typeof(command) != TYPE_DICTIONARY:
+			send_response(peer, "error", {"message": "Expected a JSON object, got %s" % type_string(typeof(command))})
+			continue
+
+		# Dispatch the command.
+		_handle_command(peer, command as Dictionary)
+
+
+# ---------------------------------------------------------------------------
+# Command dispatcher
+# ---------------------------------------------------------------------------
+
+## Routes an incoming command dictionary to the appropriate handler based on
+## the "type" field. This is the central dispatch table — new command modules
+## (graph.gd, parameters.gd, etc.) will register their handlers here.
+##
+## Many MM APIs are async (use await), so this function is async and uses
+## _dispatch_async() which awaits the handler result before sending a response.
+func _handle_command(peer: StreamPeerTCP, command: Dictionary) -> void:
+	if not command.has("type"):
+		send_response(peer, "error", {"message": "Command missing required 'type' field."})
+		return
+
+	var cmd_type: String = command.get("type", "")
+	var params: Dictionary = command.get("params", {})
+
+	# ----- Scene / Project commands -----
+	match cmd_type:
+		"get_scene_info":
+			_dispatch(peer, _scene_commands.get_scene_info(params))
+		"save_project":
+			_dispatch(peer, _scene_commands.save_project(params))
+		"load_project":
+			await _dispatch_async(peer, _scene_commands.load_project(params))
+		"new_project":
+			await _dispatch_async(peer, _scene_commands.new_project(params))
+
+		# ----- Graph / Node commands -----
+		"create_node":
+			await _dispatch_async(peer, _graph_commands.create_node(params))
+		"delete_node":
+			_dispatch(peer, _graph_commands.delete_node(params))
+		"connect_nodes":
+			_dispatch(peer, _graph_commands.connect_nodes(params))
+		"disconnect_nodes":
+			_dispatch(peer, _graph_commands.disconnect_nodes(params))
+		"get_graph_info":
+			_dispatch(peer, _graph_commands.get_graph_info(params))
+		"list_available_nodes":
+			_dispatch(peer, _graph_commands.list_available_nodes(params))
+
+		# ----- Parameter commands -----
+		"get_node_parameters":
+			_dispatch(peer, _parameter_commands.get_node_parameters(params))
+		"set_node_parameter":
+			_dispatch(peer, _parameter_commands.set_node_parameter(params))
+		"set_multiple_parameters":
+			_dispatch(peer, _parameter_commands.set_multiple_parameters(params))
+
+		# ----- Export commands -----
+		"export_material":
+			await _dispatch_async(peer, _export_commands.export_material(params))
+		"export_for_engine":
+			await _dispatch_async(peer, _export_commands.export_for_engine(params))
+		"list_export_profiles":
+			_dispatch(peer, _export_commands.list_export_profiles(params))
+
+		# ----- Utility / escape hatch -----
+		"execute_mm_script":
+			_dispatch(peer, _utils_commands.execute_mm_script(params))
+
+		# ----- Ping / health check -----
+		"ping":
+			send_response(peer, "ok", {
+				"pong": true,
+				"protocol_version": PROTOCOL_VERSION,
+				"port": _port,
+			})
+
+		# ----- Unknown command -----
+		_:
+			send_response(peer, "error", {
+				"message": "Unknown command type: '%s'" % cmd_type,
+				"available_commands": [
+					"ping",
+					"get_scene_info", "save_project", "load_project", "new_project",
+					"create_node", "delete_node", "connect_nodes", "disconnect_nodes",
+					"get_graph_info", "list_available_nodes",
+					"get_node_parameters", "set_node_parameter", "set_multiple_parameters",
+					"export_material", "export_for_engine", "list_export_profiles",
+					"execute_mm_script",
+				],
+			})
+
+
+# ---------------------------------------------------------------------------
+# Dispatch helper — routes command handler results to send_response
+# ---------------------------------------------------------------------------
+
+## Takes the Dictionary returned by a command handler and sends the appropriate
+## response. If the result contains an "error" key, it's sent as an error.
+func _dispatch(peer: StreamPeerTCP, result: Dictionary) -> void:
+	if result.has("error") and result["error"] == true:
+		send_response(peer, "error", {"message": result.get("message", "Unknown error")})
+	else:
+		send_response(peer, "ok", result)
+
+
+## Async version of _dispatch — awaits the handler result before sending.
+## Used for MM APIs that require await (create_node, load_project, export, etc.).
+func _dispatch_async(peer: StreamPeerTCP, result) -> void:
+	var resolved: Dictionary = await result
+	_dispatch(peer, resolved)
+
+
+# ---------------------------------------------------------------------------
+# Response helper
+# ---------------------------------------------------------------------------
+
+## Serialise a response dictionary and send it to the peer as a single
+## newline-terminated JSON line. This is the only function that writes to the
+## socket — all command handlers call this.
+func send_response(peer: StreamPeerTCP, status: String, data: Dictionary) -> void:
+	var response: Dictionary = {
+		"status": status,
+	}
+
+	# Merge data into the response. For "ok" responses the payload goes under
+	# "result"; for "error" responses the message is top-level.
+	if status == "ok":
+		response["result"] = data
+	else:
+		# Flatten error fields (typically just "message") into the response root.
+		response.merge(data)
+
+	var json_str: String = JSON.stringify(response)
+	var payload: PackedByteArray = (json_str + "\n").to_utf8_buffer()
+
+	# Godot 4: put_data() returns an Error.
+	# Godot 3: put_data() also returns an Error.
+	var err: Error = peer.put_data(payload)
+	if err != OK:
+		push_warning("[MCP] Failed to send response to client (Error %d)." % err)
+
+
+# ---------------------------------------------------------------------------
+# Client management helpers
+# ---------------------------------------------------------------------------
+
+## Remove a client from the tracking dictionary and disconnect it.
+func _remove_client(peer: StreamPeerTCP) -> void:
+	if _clients.has(peer):
+		_clients.erase(peer)
+	peer.disconnect_from_host()
+	print("[MCP] Client disconnected (%d remaining)." % _clients.size())

--- a/addons/material_maker_mcp/commands/export.gd
+++ b/addons/material_maker_mcp/commands/export.gd
@@ -1,0 +1,278 @@
+## export.gd — Export command handlers for Material Maker MCP
+##
+## Handles export_material, export_for_engine, and list_export_profiles commands.
+## Uses the real Material Maker APIs:
+##   - graph_edit.get_material_node() -> MMGenMaterial
+##   - material_node.render_output(output_index, size_vec) -> Image  (async)
+##   - material_node.export_material(prefix, profile, size, command_line)  (async)
+##   - material_node.get_export_profiles() -> Array[String]
+##
+## Written for Godot 4.x.
+
+extends RefCounted
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+## Supported output image formats.
+const SUPPORTED_FORMATS: Dictionary = {
+	"png": "png",
+	"exr": "exr",
+	"jpg": "jpg",
+}
+
+## Map type names to MMGenMaterial output indices.
+## These correspond to the outputs defined in material.mmg.
+const MAP_OUTPUT_INDEX: Dictionary = {
+	"albedo": 0,       # Albedo + Opacity (rgba)
+	"orm": 1,          # ORM combined: AO/Roughness/Metallic as RGB
+	"emission": 2,     # Emission (rgb)
+	"normal": 3,       # Normal OpenGL (rgb)
+	"depth": 4,        # Depth (f)
+	"sss": 5,          # Subsurface scattering (f)
+	"ao": 9,           # Ambient occlusion only (f)
+	"metallic": 12,    # Metallic only (f)
+	"roughness": 13,   # Roughness only (f)
+}
+
+## All map types available for individual rendering.
+const ALL_MAP_TYPES: Array[String] = [
+	"albedo", "orm", "emission", "normal", "depth",
+	"sss", "ao", "metallic", "roughness",
+]
+
+## Engine name to MM export profile mapping.
+const ENGINE_PROFILES: Dictionary = {
+	"godot": "Godot/Godot 4 ORM",
+	"unity": "Unity/3D",
+	"unreal": "Unreal/Unreal Engine 5",
+	"blender": "Blender",
+}
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+var _main_window = null
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+func init(main_window) -> void:
+	_main_window = main_window
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+## Get the current MMGraphEdit from the main window.
+func _get_graph_edit():
+	if _main_window == null:
+		return null
+	return _main_window.get_current_graph_edit()
+
+
+## Get the MMGenMaterial node from the current graph.
+func _get_material_node():
+	var graph_edit = _get_graph_edit()
+	if graph_edit == null:
+		return null
+	return graph_edit.get_material_node()
+
+
+## Convert pixel resolution to MM's power-of-two exponent.
+## e.g. 1024 -> 10, 2048 -> 11, 4096 -> 12
+func _resolution_to_exponent(resolution: int) -> int:
+	return int(log(float(resolution)) / log(2.0))
+
+
+## Ensure a directory exists, creating it recursively if needed.
+func _ensure_directory(path: String) -> Error:
+	if DirAccess.dir_exists_absolute(path):
+		return OK
+	return DirAccess.make_dir_recursive_absolute(path)
+
+
+## Save an Image to disk in the specified format.
+func _save_image(image: Image, file_path: String, format: String) -> Error:
+	match format:
+		"png":
+			return image.save_png(file_path)
+		"jpg":
+			return image.save_jpg(file_path, 0.9)
+		"exr":
+			return image.save_exr(file_path, false)
+		_:
+			return ERR_INVALID_PARAMETER
+
+
+## Construct a standardised error dictionary.
+func _error(message: String) -> Dictionary:
+	return { "error": true, "message": message }
+
+# ---------------------------------------------------------------------------
+# export_material
+# ---------------------------------------------------------------------------
+
+## Export the current material as individual texture map files.
+##
+## Params:
+##   output_path : String — Directory to write files into.
+##   format      : String — "png", "exr", or "jpg" (default "png").
+##   resolution  : int    — Render resolution in pixels (default 1024).
+##   maps        : Array  — Optional list of map type names to export.
+##                          Defaults to all available map types.
+##
+## Uses render_output() per map for full control over format and naming.
+func export_material(params: Dictionary):
+	# Validate output_path
+	if not params.has("output_path") or str(params["output_path"]).strip_edges().is_empty():
+		return _error("Missing required parameter: output_path")
+	var output_path: String = str(params["output_path"]).strip_edges()
+
+	# Validate format
+	var format: String = str(params.get("format", "png")).strip_edges().to_lower()
+	if not SUPPORTED_FORMATS.has(format):
+		return _error("Unsupported format '%s'. Must be one of: %s" % [format, ", ".join(SUPPORTED_FORMATS.keys())])
+
+	# Validate resolution
+	var resolution: int = int(params.get("resolution", 1024))
+	if resolution <= 0 or (resolution & (resolution - 1)) != 0:
+		return _error("Invalid resolution %d. Must be a positive power of two." % resolution)
+
+	# Determine which maps to export
+	var maps: Array = []
+	if params.has("maps") and params["maps"] is Array:
+		for map_name in params["maps"]:
+			var name_str: String = str(map_name).strip_edges().to_lower()
+			if not MAP_OUTPUT_INDEX.has(name_str):
+				return _error("Unknown map type '%s'. Must be one of: %s" % [name_str, ", ".join(ALL_MAP_TYPES)])
+			maps.append(name_str)
+	else:
+		maps = ALL_MAP_TYPES.duplicate()
+
+	if maps.is_empty():
+		return _error("No map types specified for export.")
+
+	# Ensure output directory exists
+	var dir_err: Error = _ensure_directory(output_path)
+	if dir_err != OK:
+		return _error("Failed to create output directory '%s' (Error %d)." % [output_path, dir_err])
+
+	# Get the material node
+	var material_node = _get_material_node()
+	if material_node == null:
+		return _error("No material node found in the current graph. Is a project loaded?")
+
+	# Render and save each requested map
+	var exported_files: Array = []
+	var render_size := Vector2i(resolution, resolution)
+
+	for map_type in maps:
+		var output_index: int = MAP_OUTPUT_INDEX[map_type]
+		var file_name: String = "%s.%s" % [map_type, SUPPORTED_FORMATS[format]]
+		var file_path: String = output_path.path_join(file_name)
+
+		var image = await material_node.render_output(output_index, render_size)
+		if image == null or not (image is Image):
+			push_warning("[MCP Export] render_output returned null for '%s' (output %d), skipping." % [map_type, output_index])
+			continue
+
+		var save_err: Error = _save_image(image, file_path, format)
+		if save_err != OK:
+			push_warning("[MCP Export] Failed to save '%s' (Error %d), skipping." % [file_path, save_err])
+			continue
+
+		exported_files.append({
+			"map": map_type,
+			"path": file_path,
+			"resolution": resolution,
+		})
+
+	if exported_files.is_empty():
+		return _error("Failed to export any maps. Check that the material graph has valid output nodes.")
+
+	return { "exported_files": exported_files }
+
+# ---------------------------------------------------------------------------
+# export_for_engine
+# ---------------------------------------------------------------------------
+
+## Export the material using MM's built-in engine export profiles.
+##
+## Params:
+##   output_path : String — Directory to write files into. The last path
+##                          component is used as the file prefix.
+##   engine      : String — "godot", "unity", "unreal", or "blender".
+##   resolution  : int    — Render resolution in pixels (default 1024).
+##
+## Uses MMGenMaterial.export_material(prefix, profile, size, command_line).
+func export_for_engine(params: Dictionary):
+	# Validate output_path
+	if not params.has("output_path") or str(params["output_path"]).strip_edges().is_empty():
+		return _error("Missing required parameter: output_path")
+	var output_path: String = str(params["output_path"]).strip_edges()
+
+	# Validate engine
+	if not params.has("engine") or str(params["engine"]).strip_edges().is_empty():
+		return _error("Missing required parameter: engine")
+	var engine: String = str(params["engine"]).strip_edges().to_lower()
+	if not ENGINE_PROFILES.has(engine):
+		return _error("Unsupported engine '%s'. Must be one of: %s" % [engine, ", ".join(ENGINE_PROFILES.keys())])
+	var profile: String = ENGINE_PROFILES[engine]
+
+	# Validate resolution
+	var resolution: int = int(params.get("resolution", 1024))
+	if resolution <= 0 or (resolution & (resolution - 1)) != 0:
+		return _error("Invalid resolution %d. Must be a positive power of two." % resolution)
+	var size_exponent: int = _resolution_to_exponent(resolution)
+
+	# Ensure output directory exists
+	var dir_err: Error = _ensure_directory(output_path)
+	if dir_err != OK:
+		return _error("Failed to create output directory '%s' (Error %d)." % [output_path, dir_err])
+
+	# Get the material node
+	var material_node = _get_material_node()
+	if material_node == null:
+		return _error("No material node found in the current graph. Is a project loaded?")
+
+	# Build file prefix: output_path/base_name
+	var base_name: String = output_path.get_file()
+	if base_name.is_empty():
+		base_name = "material"
+	var prefix: String = output_path.path_join(base_name)
+
+	# Call MM's built-in export pipeline (async).
+	# export_material(prefix, profile, size, command_line)
+	#   size = power-of-two exponent (0 = use material's default)
+	#   command_line = true suppresses UI dialogs
+	await material_node.export_material(prefix, profile, size_exponent, true)
+
+	return {
+		"engine": engine,
+		"profile": profile,
+		"output_path": output_path,
+		"prefix": prefix,
+		"resolution": resolution,
+	}
+
+# ---------------------------------------------------------------------------
+# list_export_profiles
+# ---------------------------------------------------------------------------
+
+## List all available export profiles from the current material node.
+##
+## Params: none required.
+##
+## Returns an array of profile name strings (e.g. "Godot/Godot 4 ORM").
+func list_export_profiles(params: Dictionary) -> Dictionary:
+	var material_node = _get_material_node()
+	if material_node == null:
+		return _error("No material node found in the current graph. Is a project loaded?")
+
+	var profiles = material_node.get_export_profiles()
+
+	return { "profiles": profiles }

--- a/addons/material_maker_mcp/commands/graph.gd
+++ b/addons/material_maker_mcp/commands/graph.gd
@@ -1,0 +1,330 @@
+## graph.gd -- Graph and node command handlers for Material Maker MCP
+##
+## Handles: create_node, delete_node, connect_nodes, disconnect_nodes,
+##          get_graph_info, list_available_nodes
+##
+## Uses real Material Maker APIs:
+##   - _main_window.get_current_graph_edit() -> MMGraphEdit
+##   - graph_edit.generator -> MMGenGraph (current sub-graph)
+##   - graph_edit.top_generator -> MMGenGraph (root graph)
+##   - graph.get_children() -> Array of MMGenBase nodes
+##   - graph.connections -> Array of {from, from_port, to, to_port}
+
+extends RefCounted
+
+var _main_window = null
+
+
+func init(main_window) -> void:
+	_main_window = main_window
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+## Return the currently active MMGraphEdit from the main window.
+func _get_graph_edit():
+	if _main_window == null:
+		return null
+	return _main_window.get_current_graph_edit()
+
+
+## Return the current MMGenGraph (the generator graph being viewed).
+func _get_graph():
+	var graph_edit = _get_graph_edit()
+	if graph_edit == null:
+		return null
+	return graph_edit.generator
+
+
+## Build a standardised error dictionary.
+func _error(message: String) -> Dictionary:
+	return {"error": true, "message": message}
+
+
+# ---------------------------------------------------------------------------
+# Command: create_node
+# ---------------------------------------------------------------------------
+
+## Create a new node in the current material graph.
+##
+## Params:
+##   node_type  : String  -- e.g. "noise_perlin", "bricks", "normal_map"
+##   position_x : float   -- X position in graph space (default 0)
+##   position_y : float   -- Y position in graph space (default 0)
+##
+## Returns: { node_id, node_type, position: { x, y } }
+func create_node(params: Dictionary):
+	var node_type: String = params.get("node_type", "")
+	if node_type.is_empty():
+		return _error("Missing required parameter: node_type")
+
+	var graph_edit = _get_graph_edit()
+	if graph_edit == null:
+		return _error("No active graph. Is a project open in Material Maker?")
+
+	var pos_x: float = float(params.get("position_x", 0.0))
+	var pos_y: float = float(params.get("position_y", 0.0))
+	var position := Vector2(pos_x, pos_y)
+
+	# create_nodes is async -- returns an array of created UI nodes.
+	var node_data := {"type": node_type, "parameters": {}}
+	var created_nodes = await graph_edit.create_nodes(node_data, position)
+
+	if created_nodes == null or created_nodes.is_empty():
+		return _error("Failed to create node of type '%s'. Is the type name valid?" % node_type)
+
+	var ui_node = created_nodes[0]
+	var generator = ui_node.generator
+	var node_id: String = generator.name
+	var final_pos: Vector2 = generator.position
+
+	return {
+		"node_id": node_id,
+		"node_type": node_type,
+		"position": {"x": final_pos.x, "y": final_pos.y},
+	}
+
+
+# ---------------------------------------------------------------------------
+# Command: delete_node
+# ---------------------------------------------------------------------------
+
+## Delete a node from the current graph by its ID (generator name).
+##
+## Params:
+##   node_id : String -- the generator's name in the graph
+##
+## Returns: { deleted: true, node_id }
+func delete_node(params: Dictionary) -> Dictionary:
+	var node_id: String = params.get("node_id", "")
+	if node_id.is_empty():
+		return _error("Missing required parameter: node_id")
+
+	var graph = _get_graph()
+	if graph == null:
+		return _error("No active graph. Is a project open in Material Maker?")
+
+	var generator = graph.get_node(NodePath(node_id))
+	if generator == null:
+		return _error("Node '%s' not found in the current graph." % node_id)
+
+	if generator.has_method("can_be_deleted") and not generator.can_be_deleted():
+		return _error("Node '%s' cannot be deleted (e.g. the Material output node)." % node_id)
+
+	var removed: bool = graph.remove_generator(generator)
+	if not removed:
+		return _error("Failed to remove node '%s' from the graph." % node_id)
+
+	return {"deleted": true, "node_id": node_id}
+
+
+# ---------------------------------------------------------------------------
+# Command: connect_nodes
+# ---------------------------------------------------------------------------
+
+## Connect an output port of one node to an input port of another.
+##
+## Params:
+##   from_node_id : String -- source generator name
+##   from_port    : int    -- output port index
+##   to_node_id   : String -- destination generator name
+##   to_port      : int    -- input port index
+##
+## Returns: { connected: true, from: { node_id, port }, to: { node_id, port } }
+func connect_nodes(params: Dictionary) -> Dictionary:
+	var from_node_id: String = params.get("from_node_id", "")
+	var to_node_id: String = params.get("to_node_id", "")
+	if from_node_id.is_empty() or to_node_id.is_empty():
+		return _error("Missing required parameters: from_node_id and to_node_id")
+
+	var from_port: int = int(params.get("from_port", 0))
+	var to_port: int = int(params.get("to_port", 0))
+
+	var graph = _get_graph()
+	var graph_edit = _get_graph_edit()
+	if graph == null or graph_edit == null:
+		return _error("No active graph. Is a project open in Material Maker?")
+
+	var from_gen = graph.get_node(NodePath(from_node_id))
+	if from_gen == null:
+		return _error("Source node '%s' not found." % from_node_id)
+
+	var to_gen = graph.get_node(NodePath(to_node_id))
+	if to_gen == null:
+		return _error("Destination node '%s' not found." % to_node_id)
+
+	# Connect at the data model level (triggers shader recompilation).
+	var ok: bool = graph.connect_children(from_gen, from_port, to_gen, to_port)
+	if not ok:
+		return _error(
+			"Failed to connect %s:%d -> %s:%d. Check port indices."
+			% [from_node_id, from_port, to_node_id, to_port]
+		)
+
+	# Sync the UI layer. UI node names are prefixed with "node_".
+	graph_edit.connect_node(
+		"node_" + from_node_id, from_port,
+		"node_" + to_node_id, to_port
+	)
+
+	return {
+		"connected": true,
+		"from": {"node_id": from_node_id, "port": from_port},
+		"to": {"node_id": to_node_id, "port": to_port},
+	}
+
+
+# ---------------------------------------------------------------------------
+# Command: disconnect_nodes
+# ---------------------------------------------------------------------------
+
+## Remove a connection between two nodes.
+##
+## Params:
+##   from_node_id : String -- source generator name
+##   from_port    : int    -- output port index
+##   to_node_id   : String -- destination generator name
+##   to_port      : int    -- input port index
+##
+## Returns: { disconnected: true, from_node_id, from_port, to_node_id, to_port }
+func disconnect_nodes(params: Dictionary) -> Dictionary:
+	var from_node_id: String = params.get("from_node_id", "")
+	var to_node_id: String = params.get("to_node_id", "")
+	if from_node_id.is_empty() or to_node_id.is_empty():
+		return _error("Missing required parameters: from_node_id and to_node_id")
+
+	var from_port: int = int(params.get("from_port", 0))
+	var to_port: int = int(params.get("to_port", 0))
+
+	var graph = _get_graph()
+	var graph_edit = _get_graph_edit()
+	if graph == null or graph_edit == null:
+		return _error("No active graph. Is a project open in Material Maker?")
+
+	var from_gen = graph.get_node(NodePath(from_node_id))
+	if from_gen == null:
+		return _error("Source node '%s' not found." % from_node_id)
+
+	var to_gen = graph.get_node(NodePath(to_node_id))
+	if to_gen == null:
+		return _error("Destination node '%s' not found." % to_node_id)
+
+	# Disconnect at the data model level.
+	var ok: bool = graph.disconnect_children(from_gen, from_port, to_gen, to_port)
+	if not ok:
+		return _error(
+			"Failed to disconnect %s:%d -> %s:%d. Connection may not exist."
+			% [from_node_id, from_port, to_node_id, to_port]
+		)
+
+	# Sync the UI layer.
+	graph_edit.disconnect_node(
+		"node_" + from_node_id, from_port,
+		"node_" + to_node_id, to_port
+	)
+
+	return {
+		"disconnected": true,
+		"from_node_id": from_node_id,
+		"from_port": from_port,
+		"to_node_id": to_node_id,
+		"to_port": to_port,
+	}
+
+
+# ---------------------------------------------------------------------------
+# Command: get_graph_info
+# ---------------------------------------------------------------------------
+
+## Serialize the entire current graph: all nodes with types, positions,
+## parameters, and all connections between them.
+##
+## Params: (none)
+##
+## Returns: { nodes: [...], connections: [...] }
+func get_graph_info(params: Dictionary) -> Dictionary:
+	var graph = _get_graph()
+	if graph == null:
+		return _error("No active graph. Is a project open in Material Maker?")
+
+	# Collect nodes from graph children (each child is an MMGenBase).
+	var nodes_array: Array = []
+	for child in graph.get_children():
+		if not child.has_method("get_type"):
+			continue
+
+		var node_info: Dictionary = {
+			"node_id": str(child.name),
+			"node_type": child.get_type(),
+			"position": {"x": child.position.x, "y": child.position.y},
+			"parameters": child.parameters.duplicate() if child.parameters else {},
+		}
+		nodes_array.append(node_info)
+
+	# Connections are stored as an Array of {from, from_port, to, to_port} dicts.
+	var connections_array: Array = []
+	for conn in graph.connections:
+		connections_array.append({
+			"from_node": str(conn["from"]),
+			"from_port": int(conn["from_port"]),
+			"to_node": str(conn["to"]),
+			"to_port": int(conn["to_port"]),
+		})
+
+	return {
+		"nodes": nodes_array,
+		"connections": connections_array,
+	}
+
+
+# ---------------------------------------------------------------------------
+# Command: list_available_nodes
+# ---------------------------------------------------------------------------
+
+## Return available node types from Material Maker's node library.
+##
+## Params:
+##   category : String (optional) -- filter to a specific category
+##
+## Returns: { node_types: [...] } or { categories: {...} }
+func list_available_nodes(params: Dictionary) -> Dictionary:
+	var category_filter: String = params.get("category", "")
+
+	# Try the flat sorted list from mm_loader first.
+	var mm_loader = _main_window.get_node_or_null("/root/mm_loader")
+	if mm_loader != null and mm_loader.has_method("get_generator_list"):
+		var generator_list: Array = mm_loader.get_generator_list()
+		if not category_filter.is_empty():
+			# Filter by category prefix (e.g. "noise" matches "noise_perlin").
+			var filtered: Array = []
+			for gen_type in generator_list:
+				if str(gen_type).begins_with(category_filter):
+					filtered.append(str(gen_type))
+			return {"node_types": filtered}
+		return {"node_types": generator_list}
+
+	# Fallback: use NodeLibraryManager for categorized results.
+	var node_library_manager = _main_window.get_node_or_null("NodeLibraryManager")
+	if node_library_manager == null:
+		return _error("Cannot access node library. Neither mm_loader nor NodeLibraryManager found.")
+
+	var categories: Dictionary = {}
+	var items: Array = node_library_manager.get_items(category_filter)
+	for item in items:
+		if typeof(item) != TYPE_DICTIONARY:
+			continue
+		var name: String = item.get("name", "")
+		var tree_item = item.get("item", {})
+		var category: String = "uncategorized"
+		if typeof(tree_item) == TYPE_DICTIONARY and tree_item.has("tree_item"):
+			var tree_path: String = str(tree_item["tree_item"])
+			var slash_pos: int = tree_path.rfind("/")
+			if slash_pos >= 0:
+				category = tree_path.substr(0, slash_pos)
+		if not categories.has(category):
+			categories[category] = []
+		categories[category].append(name)
+
+	return {"categories": categories}

--- a/addons/material_maker_mcp/commands/parameters.gd
+++ b/addons/material_maker_mcp/commands/parameters.gd
@@ -1,0 +1,315 @@
+## parameters.gd — Parameter get/set command handlers for Material Maker MCP
+##
+## Handles reading and writing node parameters over the MCP bridge.
+## Uses the real Material Maker API: MMGenGraph children accessed via
+## get_current_graph_edit().generator, parameters via get_parameter_defs(),
+## get_parameter(), and set_parameter().
+##
+## Written for Godot 4.x / Material Maker 1.4+.
+
+extends RefCounted
+
+var _main_window = null
+
+
+func init(main_window) -> void:
+	_main_window = main_window
+
+
+# ---------------------------------------------------------------------------
+# Graph / node lookup
+# ---------------------------------------------------------------------------
+
+## Returns the current MMGenGraph (data model) from the active graph editor.
+func _get_graph():
+	if _main_window == null:
+		return null
+	var graph_edit = _main_window.get_current_graph_edit()
+	if graph_edit == null:
+		return null
+	return graph_edit.generator
+
+
+## Finds a generator node (MMGenBase subclass) by its node ID within the
+## current graph. Generator children are direct children of MMGenGraph.
+func _find_node(node_id: String):
+	var graph = _get_graph()
+	if graph == null:
+		return null
+	return graph.get_node(NodePath(node_id))
+
+
+# ---------------------------------------------------------------------------
+# Public command handlers
+# ---------------------------------------------------------------------------
+
+## get_node_parameters — Return all parameter values and metadata for a node.
+func get_node_parameters(params: Dictionary) -> Dictionary:
+	if not params.has("node_id"):
+		return _error("Missing required parameter: 'node_id'.")
+
+	var node_id: String = str(params["node_id"])
+
+	var node = _find_node(node_id)
+	if node == null:
+		return _error("Node not found: '%s'." % node_id)
+
+	var defs: Array = node.get_parameter_defs()
+	var parameters: Dictionary = {}
+
+	for def_dict: Dictionary in defs:
+		var pname: String = def_dict.get("name", "")
+		if pname.is_empty():
+			continue
+
+		var ptype: String = str(def_dict.get("type", "unknown"))
+		var value = node.get_parameter(pname)
+
+		var entry: Dictionary = {
+			"value": _serialize_value(value),
+			"type": ptype,
+		}
+
+		if def_dict.has("label"):
+			entry["label"] = def_dict["label"]
+		if def_dict.has("shortdesc"):
+			entry["shortdesc"] = def_dict["shortdesc"]
+		if def_dict.has("longdesc"):
+			entry["longdesc"] = def_dict["longdesc"]
+		if def_dict.has("default"):
+			entry["default"] = _serialize_value(def_dict["default"])
+		if def_dict.has("min"):
+			entry["min"] = def_dict["min"]
+		if def_dict.has("max"):
+			entry["max"] = def_dict["max"]
+		if def_dict.has("step"):
+			entry["step"] = def_dict["step"]
+		if def_dict.has("control"):
+			entry["control"] = def_dict["control"]
+		if def_dict.has("values"):
+			entry["values"] = def_dict["values"]
+
+		parameters[pname] = entry
+
+	return {
+		"node_id": node_id,
+		"parameters": parameters,
+	}
+
+
+## set_node_parameter — Set a single parameter on a node.
+## set_parameter() triggers recompile/update automatically.
+func set_node_parameter(params: Dictionary) -> Dictionary:
+	if not params.has("node_id"):
+		return _error("Missing required parameter: 'node_id'.")
+	if not params.has("parameter"):
+		return _error("Missing required parameter: 'parameter'.")
+	if not params.has("value"):
+		return _error("Missing required parameter: 'value'.")
+
+	var node_id: String = str(params["node_id"])
+	var parameter: String = str(params["parameter"])
+	var new_value = params["value"]
+
+	var node = _find_node(node_id)
+	if node == null:
+		return _error("Node not found: '%s'." % node_id)
+
+	var def_dict = _get_parameter_def(node, parameter)
+	if def_dict == null:
+		return _error("Node '%s' has no parameter named '%s'." % [node_id, parameter])
+
+	var old_value = node.get_parameter(parameter)
+	var coerced_value = _coerce_value(def_dict, new_value)
+	node.set_parameter(parameter, coerced_value)
+
+	return {
+		"node_id": node_id,
+		"parameter": parameter,
+		"old_value": _serialize_value(old_value),
+		"new_value": _serialize_value(coerced_value),
+	}
+
+
+## set_multiple_parameters — Batch-set parameters across one or more nodes.
+## Each call to set_parameter() triggers its own recompile internally.
+func set_multiple_parameters(params: Dictionary) -> Dictionary:
+	if not params.has("updates"):
+		return _error("Missing required parameter: 'updates'.")
+
+	var updates = params["updates"]
+	if typeof(updates) != TYPE_ARRAY:
+		return _error("'updates' must be an array.")
+
+	var results: Array = []
+	var updated_count: int = 0
+
+	for i: int in range(updates.size()):
+		var entry = updates[i]
+
+		if typeof(entry) != TYPE_DICTIONARY:
+			results.append({"index": i, "error": true, "message": "Entry %d is not a dictionary." % i})
+			continue
+
+		if not entry.has("node_id") or not entry.has("parameter") or not entry.has("value"):
+			results.append({"index": i, "error": true, "message": "Entry %d missing node_id, parameter, or value." % i})
+			continue
+
+		var node_id: String = str(entry["node_id"])
+		var parameter: String = str(entry["parameter"])
+		var new_value = entry["value"]
+
+		var node = _find_node(node_id)
+		if node == null:
+			results.append({"index": i, "error": true, "message": "Node not found: '%s'." % node_id})
+			continue
+
+		var def_dict = _get_parameter_def(node, parameter)
+		if def_dict == null:
+			results.append({"index": i, "error": true, "message": "Node '%s' has no parameter '%s'." % [node_id, parameter]})
+			continue
+
+		var old_value = node.get_parameter(parameter)
+		var coerced_value = _coerce_value(def_dict, new_value)
+		node.set_parameter(parameter, coerced_value)
+		updated_count += 1
+
+		results.append({
+			"index": i,
+			"node_id": node_id,
+			"parameter": parameter,
+			"old_value": _serialize_value(old_value),
+			"new_value": _serialize_value(coerced_value),
+		})
+
+	return {
+		"updated": updated_count,
+		"results": results,
+	}
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+## Look up the definition dict for a specific parameter on a node.
+func _get_parameter_def(node, pname: String):
+	var defs: Array = node.get_parameter_defs()
+	for d: Dictionary in defs:
+		if d.get("name", "") == pname:
+			return d
+	return null
+
+
+# ---------------------------------------------------------------------------
+# Value coercion
+# ---------------------------------------------------------------------------
+
+## Coerce an incoming JSON value to the type expected by a parameter definition.
+func _coerce_value(def_dict: Dictionary, value):
+	var ptype: String = str(def_dict.get("type", ""))
+
+	match ptype:
+		"float":
+			return float(value)
+
+		"int", "size":
+			return int(value)
+
+		"boolean":
+			if typeof(value) == TYPE_BOOL:
+				return value
+			if typeof(value) == TYPE_STRING:
+				return value.to_lower() == "true"
+			return bool(value)
+
+		"enum":
+			if typeof(value) == TYPE_INT or typeof(value) == TYPE_FLOAT:
+				return int(value)
+			if typeof(value) == TYPE_STRING:
+				var values_list = def_dict.get("values", [])
+				for i: int in range(values_list.size()):
+					var opt = values_list[i]
+					var opt_name: String = str(opt["name"]) if typeof(opt) == TYPE_DICTIONARY else str(opt)
+					if opt_name.to_lower() == str(value).to_lower():
+						return i
+				if str(value).is_valid_int():
+					return int(value)
+			return int(value)
+
+		"color":
+			if typeof(value) == TYPE_COLOR:
+				return value
+			if typeof(value) == TYPE_DICTIONARY:
+				return Color(
+					float(value.get("r", 0.0)),
+					float(value.get("g", 0.0)),
+					float(value.get("b", 0.0)),
+					float(value.get("a", 1.0)),
+				)
+			if typeof(value) == TYPE_STRING:
+				return Color(value)
+			return value
+
+		"string":
+			return str(value)
+
+		"gradient", "curve", "polygon", "polyline", "splines", "pixels", "lattice":
+			return value
+
+		_:
+			return value
+
+
+# ---------------------------------------------------------------------------
+# Value serialization
+# ---------------------------------------------------------------------------
+
+## Serialize a Godot value into a JSON-safe representation.
+func _serialize_value(value) -> Variant:
+	if value == null:
+		return null
+
+	match typeof(value):
+		TYPE_COLOR:
+			var c: Color = value as Color
+			return {"r": c.r, "g": c.g, "b": c.b, "a": c.a}
+
+		TYPE_VECTOR2:
+			var v: Vector2 = value as Vector2
+			return {"x": v.x, "y": v.y}
+
+		TYPE_VECTOR3:
+			var v: Vector3 = value as Vector3
+			return {"x": v.x, "y": v.y, "z": v.z}
+
+		TYPE_OBJECT:
+			if value.has_method("serialize"):
+				return value.serialize()
+			return str(value)
+
+		TYPE_DICTIONARY:
+			var out: Dictionary = {}
+			for key in value:
+				out[str(key)] = _serialize_value(value[key])
+			return out
+
+		TYPE_ARRAY:
+			var out: Array = []
+			for item in value:
+				out.append(_serialize_value(item))
+			return out
+
+		_:
+			return value
+
+
+# ---------------------------------------------------------------------------
+# Error formatting
+# ---------------------------------------------------------------------------
+
+func _error(message: String) -> Dictionary:
+	return {
+		"error": true,
+		"message": message,
+	}

--- a/addons/material_maker_mcp/commands/scene.gd
+++ b/addons/material_maker_mcp/commands/scene.gd
@@ -1,0 +1,188 @@
+## scene.gd — Scene/Project command handlers for Material Maker MCP
+##
+## Handles commands: get_scene_info, save_project, load_project, new_project.
+##
+## Uses real Material Maker APIs:
+##   - _main_window.get_current_graph_edit() -> MMGraphEdit
+##   - graph_edit.top_generator -> MMGenGraph (root data model)
+##   - graph_edit.save_path -> String (file path)
+##   - graph_edit.need_save -> bool (unsaved changes flag)
+##   - graph_edit.save_file(path) -> void (save to disk)
+##   - graph_edit.get_material_node() -> MMGenMaterial or null
+##   - _main_window.do_load_project(path) -> bool (async)
+##   - _main_window.new_material() -> void (async, creates default PBR)
+##
+## Written for Godot 4.x / Material Maker 1.4+.
+
+extends RefCounted
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+## Reference to Material Maker's MainWindow Control. Set via init().
+var _main_window = null
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+## Called by addon.gd after construction to inject the MM main window reference.
+func init(main_window) -> void:
+	_main_window = main_window
+
+# ---------------------------------------------------------------------------
+# Helper — get the current MMGraphEdit
+# ---------------------------------------------------------------------------
+
+## Returns the active MMGraphEdit (UI graph editor) or null if none is open.
+func _get_graph_edit():
+	if _main_window == null:
+		return null
+	return _main_window.get_current_graph_edit()
+
+# ---------------------------------------------------------------------------
+# Command: get_scene_info
+# ---------------------------------------------------------------------------
+
+## Return metadata about the current open project.
+##
+## Response shape:
+##   { file_path, material_type, node_count, has_unsaved_changes, mm_version }
+func get_scene_info(params: Dictionary) -> Dictionary:
+	var graph_edit = _get_graph_edit()
+	if graph_edit == null:
+		return {
+			"file_path": "",
+			"material_type": "none",
+			"node_count": 0,
+			"has_unsaved_changes": false,
+			"mm_version": _get_mm_version(),
+		}
+
+	var generator = graph_edit.top_generator
+
+	# Material type — find the MMGenMaterial child node.
+	var material_type: String = "unknown"
+	var material_node = graph_edit.get_material_node()
+	if material_node != null:
+		material_type = material_node.get_type_name()
+
+	# Node count — all children of top_generator are MMGenBase instances.
+	var node_count: int = generator.get_children().size()
+
+	return {
+		"file_path": graph_edit.save_path,
+		"material_type": material_type,
+		"node_count": node_count,
+		"has_unsaved_changes": graph_edit.need_save,
+		"mm_version": _get_mm_version(),
+	}
+
+# ---------------------------------------------------------------------------
+# Command: save_project
+# ---------------------------------------------------------------------------
+
+## Save the current project to disk.
+##
+## Params:
+##   path (optional string) — file path to save to. If omitted, saves to the
+##       current project's existing path. Should end in ".ptex".
+##
+## Response shape:
+##   { saved: true, path }
+func save_project(params: Dictionary) -> Dictionary:
+	var graph_edit = _get_graph_edit()
+	if graph_edit == null:
+		return _error("No project is currently open.")
+
+	var path: String = params.get("path", "")
+
+	# If no path given, use the current save path.
+	if path.is_empty():
+		path = graph_edit.save_path
+
+	if path.is_empty():
+		return _error("No save path specified and the project has not been saved before. Provide a 'path' parameter.")
+
+	# Ensure the path ends with .ptex (Material Maker's project extension).
+	if not path.ends_with(".ptex"):
+		path += ".ptex"
+
+	graph_edit.save_file(path)
+
+	return { "saved": true, "path": path }
+
+# ---------------------------------------------------------------------------
+# Command: load_project
+# ---------------------------------------------------------------------------
+
+## Load a .ptex project file. This is async because do_load_project() is async.
+##
+## Params:
+##   path (string, required) — path to the .ptex file to open.
+##
+## Response shape:
+##   { loaded: true, path, node_count }
+func load_project(params: Dictionary):
+	var path: String = params.get("path", "")
+
+	if path.is_empty():
+		return _error("Missing required parameter 'path'.")
+
+	if not FileAccess.file_exists(path):
+		return _error("File not found: %s" % path)
+
+	if not path.ends_with(".ptex"):
+		return _error("Expected a .ptex file, got: %s" % path.get_extension())
+
+	if _main_window == null:
+		return _error("Main window reference not set.")
+
+	var success: bool = await _main_window.do_load_project(path)
+	if not success:
+		return _error("Failed to load project: %s" % path)
+
+	# After loading, get the new graph edit and count nodes.
+	var graph_edit = _get_graph_edit()
+	var node_count: int = 0
+	if graph_edit != null:
+		node_count = graph_edit.top_generator.get_children().size()
+
+	return { "loaded": true, "path": path, "node_count": node_count }
+
+# ---------------------------------------------------------------------------
+# Command: new_project
+# ---------------------------------------------------------------------------
+
+## Create a new default PBR material project. This is async because
+## new_material() is async.
+##
+## Note: MM's new_material() always creates a default PBR material.
+## The material_type parameter is accepted but ignored — MM does not support
+## choosing the type at creation time via this API.
+##
+## Response shape:
+##   { created: true, material_type: "pbr" }
+func new_project(params: Dictionary):
+	if _main_window == null:
+		return _error("Main window reference not set.")
+
+	await _main_window.new_material()
+
+	return { "created": true, "material_type": "pbr" }
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+## Get the Material Maker version string.
+func _get_mm_version() -> String:
+	if ProjectSettings.has_setting("application/config/actual_release"):
+		return ProjectSettings.get_setting("application/config/actual_release")
+	return "unknown"
+
+
+## Construct a standardised error dictionary.
+func _error(msg: String) -> Dictionary:
+	return { "error": true, "message": msg }

--- a/addons/material_maker_mcp/commands/utils.gd
+++ b/addons/material_maker_mcp/commands/utils.gd
@@ -1,0 +1,193 @@
+## utils.gd — Utility / escape-hatch command handlers for Material Maker MCP
+##
+## Handles `execute_mm_script` — an arbitrary GDScript execution tool modelled
+## after Blender MCP's `execute_blender_code`. This is DISABLED by default and
+## must be explicitly enabled in the MCP plugin configuration.
+##
+## WARNING: Enabling script execution allows any connected MCP client to run
+## arbitrary code inside the Material Maker process. Only enable this on
+## trusted, local-only connections. Never expose it on a network-accessible port.
+##
+## Written for Godot 4.x.
+
+class_name UtilsCommands
+extends RefCounted
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+## The error message returned when script execution is disabled.
+const DISABLED_MESSAGE: String = "execute_mm_script is disabled. Enable it in the MCP plugin configuration."
+
+## Maximum allowed script length in characters, as a basic safety measure.
+const MAX_SCRIPT_LENGTH: int = 50000
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+## Reference to the Material Maker main window, set via init().
+var _main_window = null
+
+## Whether execute_mm_script is enabled. Defaults to false (disabled).
+## Must be explicitly set to true via configuration to allow script execution.
+var script_execution_enabled: bool = false
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+## Called once after construction. Receives the MM main window so scripts
+## can access the full application context.
+func init(main_window) -> void:
+	_main_window = main_window
+
+
+## Enable or disable script execution. Called by the plugin based on its
+## configuration (e.g. from an environment variable or config file).
+func set_script_execution_enabled(enabled: bool) -> void:
+	script_execution_enabled = enabled
+	if enabled:
+		push_warning("[MCP Utils] execute_mm_script has been ENABLED. This allows arbitrary code execution.")
+	else:
+		print("[MCP Utils] execute_mm_script is disabled.")
+
+# ---------------------------------------------------------------------------
+# execute_mm_script
+# ---------------------------------------------------------------------------
+
+## Execute arbitrary GDScript inside Material Maker using Godot's Expression
+## class. This is the power-user escape hatch, mirroring Blender MCP's
+## `execute_blender_code` tool.
+##
+## Params:
+##   script  : String — The GDScript expression to evaluate.
+##   context : String — Optional context hint (unused currently, reserved for
+##                      future use such as selecting which node to bind as `self`).
+##
+## Returns:
+##   On success: { "result": <evaluation result>, "output": <string representation> }
+##   On failure: { "error": true, "message": "..." }
+##
+## IMPORTANT: This function is gated by the `script_execution_enabled` flag.
+## If disabled, it returns an error without evaluating anything.
+func execute_mm_script(params: Dictionary) -> Dictionary:
+	# ------------------------------------------------------------------
+	# Gate: check if script execution is enabled
+	# ------------------------------------------------------------------
+	if not script_execution_enabled:
+		return _error(DISABLED_MESSAGE)
+
+	# ------------------------------------------------------------------
+	# Validate params
+	# ------------------------------------------------------------------
+	if not params.has("script") or str(params["script"]).strip_edges().is_empty():
+		return _error("Missing required parameter: script")
+
+	var script_text: String = str(params["script"]).strip_edges()
+	var context: String = str(params.get("context", "")).strip_edges()
+
+	# Basic length check to prevent absurdly large inputs.
+	if script_text.length() > MAX_SCRIPT_LENGTH:
+		return _error("Script exceeds maximum length of %d characters." % MAX_SCRIPT_LENGTH)
+
+	# ------------------------------------------------------------------
+	# Execute via Godot's Expression class
+	# ------------------------------------------------------------------
+	# The Expression class parses and evaluates a single GDScript expression.
+	# It does NOT support multi-line statements, control flow (if/for/while),
+	# or variable declarations. For those, the user would need a different
+	# approach (e.g. loading a full GDScript resource).
+	#
+	# We pass the main_window as the base instance so the expression can
+	# call methods and access properties on it.
+	#
+	# Available input names allow the script to reference useful objects:
+	#   - main_window: the MM main window node
+	#   - graph_edit:  the currently active graph editor (may be null)
+	#
+	# TODO: Consider whether to also expose mm_globals or the project tree
+	# as additional input variables for more convenient scripting.
+
+	var expression := Expression.new()
+
+	# Define input variable names the expression can reference.
+	var input_names: PackedStringArray = PackedStringArray(["main_window", "graph_edit"])
+
+	# Gather input values.
+	var graph_edit = null
+	if _main_window != null and _main_window.has_method("get_current_graph_edit"):
+		graph_edit = _main_window.get_current_graph_edit()
+
+	var input_values: Array = [_main_window, graph_edit]
+
+	# Parse the expression.
+	var parse_err: Error = expression.parse(script_text, input_names)
+	if parse_err != OK:
+		return _error("Script parse error: %s" % expression.get_error_text())
+
+	# Execute the expression with the main_window as the base instance.
+	# This means unqualified method/property access resolves against main_window.
+	var result = expression.execute(input_values, _main_window, true)
+
+	# Check for runtime errors.
+	if expression.has_execute_failed():
+		return _error("Script execution error: %s" % expression.get_error_text())
+
+	# ------------------------------------------------------------------
+	# Build the response
+	# ------------------------------------------------------------------
+	# Convert the result to a JSON-safe representation. Not all Godot types
+	# are directly serializable, so we convert to string as a fallback.
+	var result_for_json = _make_json_safe(result)
+	var output_str: String = str(result) if result != null else ""
+
+	return {
+		"result": result_for_json,
+		"output": output_str,
+	}
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+## Attempt to convert a Godot Variant to a JSON-compatible value.
+## Primitives (bool, int, float, string, null) pass through. Arrays and
+## Dictionaries are recursively converted. Everything else becomes a string.
+func _make_json_safe(value) -> Variant:
+	if value == null:
+		return null
+
+	match typeof(value):
+		TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING:
+			return value
+		TYPE_ARRAY:
+			var safe_array: Array = []
+			for item in value:
+				safe_array.append(_make_json_safe(item))
+			return safe_array
+		TYPE_DICTIONARY:
+			var safe_dict: Dictionary = {}
+			for key in value.keys():
+				safe_dict[str(key)] = _make_json_safe(value[key])
+			return safe_dict
+		TYPE_VECTOR2, TYPE_VECTOR2I:
+			return { "x": value.x, "y": value.y }
+		TYPE_VECTOR3, TYPE_VECTOR3I:
+			return { "x": value.x, "y": value.y, "z": value.z }
+		TYPE_COLOR:
+			return { "r": value.r, "g": value.g, "b": value.b, "a": value.a }
+		TYPE_PACKED_STRING_ARRAY:
+			var arr: Array = []
+			for s in value:
+				arr.append(s)
+			return arr
+		_:
+			# Fallback: convert to string representation.
+			return str(value)
+
+
+## Construct a standardised error dictionary.
+func _error(message: String) -> Dictionary:
+	return { "error": true, "message": message }

--- a/addons/material_maker_mcp/plugin.cfg
+++ b/addons/material_maker_mcp/plugin.cfg
@@ -1,0 +1,6 @@
+[plugin]
+name="MCP Server"
+description="TCP socket server enabling MCP-compatible AI clients to control Material Maker"
+author="material-maker-mcp contributors"
+version="0.1.0"
+script="addon.gd"

--- a/project.godot
+++ b/project.godot
@@ -40,6 +40,7 @@ mm_deps="*res://addons/material_maker/engine/dependencies.gd"
 mm_renderer="*res://addons/material_maker/engine/multi_renderer.gd"
 mm_sdf_builder="*res://addons/material_maker/sdf_builder/sdf_builder.tscn"
 mm_preprocessor="*res://addons/material_maker/engine/preprocessor.gd"
+mm_mcp="*res://addons/material_maker_mcp/addon.gd"
 Html5="*res://material_maker/html5.gd"
 
 [debug]


### PR DESCRIPTION
## Summary

- Adds `addons/material_maker_mcp/` — a TCP socket server (port 9002) that enables MCP-compatible AI clients to control Material Maker programmatically
- Registers the addon as an autoload (`mm_mcp`) in `project.godot` so it starts automatically with MM
- Includes command handlers for all 17 MCP tools: scene/project management, graph/node manipulation, parameter control, material export, and a utility escape hatch
- All handlers written against real MM internal APIs (`MMGraphEdit`, `MMGenGraph`, `MMGenMaterial`, `mm_loader`, `NodeLibraryManager`)
- Async dispatch support for MM operations that require `await` (create_node, load_project, export)

## Architecture

```
[AI Client] <--MCP/stdio--> [Python MCP Server] <--TCP:9002--> [This Addon]
```

The addon runs a lightweight TCP server inside MM, accepting newline-delimited JSON commands. A companion Python MCP server ([material-maker-mcp](https://github.com/derekrhiggins/material-maker-mcp)) bridges MCP clients to this addon.

## Files

| File | Purpose |
|------|---------|
| `addons/material_maker_mcp/addon.gd` | TCP server, JSON dispatch, async handler support |
| `commands/scene.gd` | get_scene_info, save_project, load_project, new_project |
| `commands/graph.gd` | create_node, delete_node, connect/disconnect_nodes, get_graph_info, list_available_nodes |
| `commands/parameters.gd` | get/set_node_parameter(s), type coercion |
| `commands/export.gd` | export_material, export_for_engine, list_export_profiles |
| `commands/utils.gd` | execute_mm_script (disabled by default) |
| `TODO_MCP.md` | Development roadmap for MCP integration |

## Test plan

- [ ] Launch MM from Godot editor — verify `[MCP] Server listening on 127.0.0.1:9002` appears in console
- [ ] Connect with `nc localhost 9002`, send `{"type":"ping"}\n` — verify pong response
- [ ] Run the Python MCP server and test tool calls (create_node, get_graph_info, etc.)
- [ ] Verify existing MM functionality is not affected by the autoload
- [ ] Build Windows export and verify MCP server works in exported build

🤖 Generated with [Claude Code](https://claude.com/claude-code)