### PR TITLE
Add spacing for images in documentation

### DIFF
--- a/material_maker/doc/_static/css/custom.css
+++ b/material_maker/doc/_static/css/custom.css
@@ -226,6 +226,10 @@ legend,
     border: 1px solid var(--body-color);
 }
 
+section > img {
+	 padding-bottom: 16px;
+}
+
 p,
 article ul,
 article ol,


### PR DESCRIPTION
<img width="2994" height="2734" alt="Artboard" src="https://github.com/user-attachments/assets/c33ce097-bd84-4ad0-a876-d689d84fc1a5" />