### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ brew install --cask material-maker
 
 Can't wait for next release? Automated builds from master branch are available (use at your own risk):
 
-<a href="https://github.com/RodZill4/material-maker/actions?query=branch%3Amaster">
-    <img src="https://github.com/RodZill4/material-maker/workflows/dev-desktop-builds/badge.svg" alt="Build Passing" />
-</a>
+[![Build Material Maker](https://github.com/RodZill4/material-maker/actions/workflows/dev-desktop-builds.yml/badge.svg?branch=master)](https://github.com/RodZill4/material-maker/actions/workflows/dev-desktop-builds.yml?query=branch%3Amaster)
 
 ## Documentation
 


### PR DESCRIPTION
Updated badge to correctly reflect build status

**PR**

<img width="237" height="57" alt="image" src="https://github.com/user-attachments/assets/a374cae5-ffe8-47da-9dc2-b4e333712258" />

**Current**

<img width="214" height="55" alt="image" src="https://github.com/user-attachments/assets/8e7d1680-2d20-4ba3-9dc4-4a952b34cf98" />
