### PR TITLE
Fix group parameters using default values from linked widgets

### DIFF
--- a/addons/material_maker/engine/nodes/gen_remote.gd
+++ b/addons/material_maker/engine/nodes/gen_remote.gd
@@ -256,6 +256,11 @@ func link_parameter(widget_name : String, generator : MMGenBase, param : String)
 		match widget.type:
 			"linked_control":
 				parameters[widget_name] = generator.parameters[param]
+				# use linked floatedit value(instead of default) when linked
+				var param_def : Dictionary = generator.get_parameter_def(param)
+				if name == "gen_parameters" and param_def.has("type"):
+					if param_def.type == "float":
+						set_parameter(widget_name, parameters[widget_name])
 			"config_control":
 				parameters[widget_name] = 0
 	emit_signal("parameter_changed", "__update_all__", null)


### PR DESCRIPTION
Resolves issue via discord, this seems to only happen with float parameters
> linking paramters itself behaves funky. For example I just linked a parameter with value 16.0 and its value outside for some reason turned into 6.0 automatically, so I had to change it to 16.0 manually

https://github.com/user-attachments/assets/52388028-bbad-4d9d-9f19-62b719d114e6