### PR TITLE
Alternative inputs for graph panning/camera orbiting

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -335,6 +335,9 @@ func _gui_input(event) -> void:
 			accept_event()
 			lasso_points.append(get_local_mouse_position())
 			queue_redraw()
+		elif (event.button_mask & MOUSE_BUTTON_MASK_LEFT) != 0 and event.shift_pressed:
+			scroll_offset -= event.relative
+			accept_event()
 
 
 func get_padded_node_rect(graph_node:GraphNode) -> Rect2:

--- a/material_maker/windows/environment_editor/camera_controller.gd
+++ b/material_maker/windows/environment_editor/camera_controller.gd
@@ -20,7 +20,8 @@ func _ready():
 
 func process_event(event : InputEvent, viewport : Viewport = null) -> bool:
 	if event is InputEventMouseMotion:
-		if event.button_mask & MOUSE_BUTTON_MASK_MIDDLE != 0:
+		if (event.button_mask & MOUSE_BUTTON_MASK_MIDDLE != 0
+			or (event.alt_pressed and (event.button_mask & MOUSE_BUTTON_MASK_LEFT) != 0)):
 			if event.shift_pressed:
 				var factor = 0.0025*camera_position.position.z
 				camera_target_position.translate(-factor*event.relative.x*camera_position.global_transform.basis.x)


### PR DESCRIPTION
context via discord
> I can't rotate the object in the 3D panel. I think it is bound to a middle mouse button, which I do not have.

This adds `Shift + LMB` for graph panning and `Alt + LMB` for 3d orbit