### PR TITLE
Prevent self-referencing in FloatEdit

### DIFF
--- a/material_maker/widgets/float_edit/expression_editor.gd
+++ b/material_maker/widgets/float_edit/expression_editor.gd
@@ -31,14 +31,30 @@ func edit_parameter(wt : String, value : String, o : Object, m : String, ep : Ar
 	editor.set_caret_column(editor.text.length())
 	editor.grab_focus()
 
-func _on_Apply_pressed():
-	var value = editor.text.replace("\n", "").strip_edges()
+func check_self_reference_apply() -> bool:
+	var value : String = editor.text.replace("\n", "").strip_edges()
+	var self_reference := RegEx.new()
+	self_reference.compile("\\$\\b%s\\b" % object.name)
+	# warns if result expression causes variable to reference itself
+	if self_reference.search(value):
+		var dialog : AcceptDialog = load("res://material_maker/windows/accept_dialog/accept_dialog.tscn").instantiate()
+		var error_text := tr("Expression creates a loop. Remove $%s then try again." % object.name)
+		dialog.dialog_text = TranslationServer.translate(error_text)
+		add_child(dialog)
+		await dialog.ask()
+		return false 
 	var parameters : Array = [ value ]
 	parameters.append_array(extra_parameters)
 	object.callv(method, parameters)
+	return true
+
+func _on_Apply_pressed():
+	if not await check_self_reference_apply():
+		return
 
 func _on_OK_pressed():
-	_on_Apply_pressed()
+	if not await check_self_reference_apply():
+		return
 	queue_free()
 
 func _on_Cancel_pressed():

--- a/material_maker/widgets/float_edit/float_edit.gd
+++ b/material_maker/widgets/float_edit/float_edit.gd
@@ -259,6 +259,9 @@ func _on_edit_text_submitted(new_text: String) -> void:
 
 	mode = Modes.IDLE
 
+	var self_reference := RegEx.new()
+	self_reference.compile("\\$\\b%s\\b" % name)
+
 	if new_text.is_valid_float():
 		var new_value: float = new_text.to_float()
 		if abs(float_value-new_value) > 0.00001:
@@ -266,7 +269,7 @@ func _on_edit_text_submitted(new_text: String) -> void:
 			set_value(float_value, true)
 		else:
 			set_value(float_value)
-	elif float_only or new_text == "":
+	elif float_only or new_text == "" or self_reference.search(new_text):
 		set_value(float_value, true)
 	else:
 		set_value(new_text, true)


### PR DESCRIPTION
**FloatEdit: Rejects self-references when submitting value**

https://github.com/user-attachments/assets/f2089e69-36f0-4e15-a7a1-a3f6fb6becb9

**Expression Editor: Shows a warning if there's a self-reference**

https://github.com/user-attachments/assets/89c16d00-b56c-4351-9ecb-26ae610e74b0