### PR TITLE
Fix zoom in/out btns conflicting with node align

### DIFF
--- a/material_maker/projects_panel.tscn
+++ b/material_maker/projects_panel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://bnqq3vhwmudkw"]
+[gd_scene load_steps=20 format=3 uid="uid://bnqq3vhwmudkw"]
 
 [ext_resource type="Script" uid="uid://cryayuomvuwbo" path="res://material_maker/main_window_projects_panel.gd" id="1_m3usq"]
 [ext_resource type="PackedScene" uid="uid://bb6iar0tbj2qt" path="res://material_maker/panels/preview_2d/preview_2d.tscn" id="2_oiaqi"]
@@ -9,7 +9,7 @@
 [ext_resource type="Script" uid="uid://bos2fu0tsood3" path="res://material_maker/panels/preview_2d/simple_button.gd" id="7_qnupl"]
 [ext_resource type="PackedScene" uid="uid://rflulhsuy3ax" path="res://material_maker/widgets/float_edit/float_edit.tscn" id="8_1w3oe"]
 [ext_resource type="Script" uid="uid://bxwor0k6svci8" path="res://material_maker/panels/graph_edit/graph_view_menu.gd" id="8_nl2qi"]
-[ext_resource type="Script" uid="uid://pqxjwlcff5ko" path="res://material_maker/panels/graph_edit/graph_align_menu.gd" id="8_r5hxx"]
+[ext_resource type="Script" path="res://material_maker/panels/graph_edit/graph_align_menu.gd" id="8_r5hxx"]
 [ext_resource type="ButtonGroup" uid="uid://biv6we3po8wbb" path="res://material_maker/line_style_btn_group.tres" id="10_lbgjg"]
 
 [sub_resource type="Shader" id="1"]
@@ -19,6 +19,22 @@ code = "shader_type canvas_item;"
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_8fw7q"]
 resource_local_to_scene = true
 shader = SubResource("1")
+
+[sub_resource type="InputEventKey" id="InputEventKey_r5hxx"]
+device = -1
+command_or_control_autoremap = true
+keycode = 45
+
+[sub_resource type="Shortcut" id="Shortcut_qnupl"]
+events = [SubResource("InputEventKey_r5hxx")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_qnupl"]
+device = -1
+command_or_control_autoremap = true
+keycode = 61
+
+[sub_resource type="Shortcut" id="Shortcut_uk6aw"]
+events = [SubResource("InputEventKey_qnupl")]
 
 [sub_resource type="InputEventKey" id="InputEventKey_lbgjg"]
 device = -1
@@ -170,7 +186,7 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
 tooltip_text = "Zoom Out"
-shortcut = SubResource("Shortcut_7tisq")
+shortcut = SubResource("Shortcut_qnupl")
 shortcut_in_tooltip = false
 icon_alignment = 1
 script = ExtResource("7_qnupl")
@@ -181,7 +197,7 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
 tooltip_text = "Zoom In"
-shortcut = SubResource("Shortcut_7tisq")
+shortcut = SubResource("Shortcut_uk6aw")
 shortcut_in_tooltip = false
 icon_alignment = 1
 script = ExtResource("7_qnupl")
@@ -192,7 +208,6 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
 tooltip_text = "Zoom Reset"
-shortcut = SubResource("Shortcut_7tisq")
 shortcut_in_tooltip = false
 icon_alignment = 1
 script = ExtResource("7_qnupl")


### PR DESCRIPTION
Graph zoom in/out and reset view buttons had the same shortcut bound to `Ctrl/Command+]`