### PR TITLE
Make background dimming(when dialogs are visible) optional

### DIFF
--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -55,6 +55,7 @@ const DEFAULT_CONFIG : Dictionary = {
 	graph_line_style = 1,
 	ui_use_native_file_dialogs = true,
 	win_tablet_driver = 0,
+	dialog_dim_background = true,
 }
 
 

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -1424,9 +1424,10 @@ func _on_Tip_Timer_timeout():
 
 func add_dialog(dialog : Window):
 	var background : ColorRect = load("res://material_maker/darken.tscn").instantiate()
-	add_child(background)
+	if mm_globals.get_config("dialog_dim_background"):
+		add_child(background)
+		dialog.tree_exited.connect(background.queue_free)
 	add_child(dialog)
-	dialog.connect("tree_exited", background.queue_free)
 
 # Accept dialog
 

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://3lo2jh781ten" path="res://material_maker/windows/preferences/float_option.tscn" id="3"]
 [ext_resource type="Script" path="res://material_maker/windows/preferences/preferences_tree.gd" id="3_mlqij"]
 [ext_resource type="Script" uid="uid://gmystrme5ayw" path="res://material_maker/windows/preferences/lang_option.gd" id="4"]
-[ext_resource type="Script" uid="uid://d3h4xmek7b2vq" path="res://material_maker/windows/preferences/enum_option.gd" id="5_vp06c"]
+[ext_resource type="Script" path="res://material_maker/windows/preferences/enum_option.gd" id="5_vp06c"]
 
 [node name="Preferences" type="Window"]
 oversampling_override = 1.0
@@ -173,6 +173,27 @@ tooltip_text = "Prefer the use of native file dialogs"
 text = "On"
 flat = false
 config_variable = "ui_use_native_file_dialogs"
+
+[node name="DialogDimBackground" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/DialogDimBackground"]
+layout_mode = 2
+mouse_filter = 1
+text = "Dim background when showing dialogs"
+
+[node name="DialogDimBackground" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/DialogDimBackground" instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+tooltip_text = "Toggle background dimming when a dialog is visible."
+text = "On"
+flat = false
+config_variable = "dialog_dim_background"
+
+[node name="Spacer5" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
+custom_minimum_size = Vector2(0, 10)
+layout_mode = 2
 
 [node name="Gui3DPreviewResolution" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer"]
 layout_mode = 2


### PR DESCRIPTION
Makes it easier when previewing/editing outputs at the same time(i.e. tonality)

https://github.com/user-attachments/assets/e9ea5b5a-d6a0-4265-a9ec-57eaed2dd1f8