### PR TITLE
Fix linked controls using widget defaults

### DIFF
--- a/addons/material_maker/engine/nodes/gen_remote.gd
+++ b/addons/material_maker/engine/nodes/gen_remote.gd
@@ -256,11 +256,10 @@ func link_parameter(widget_name : String, generator : MMGenBase, param : String)
 		match widget.type:
 			"linked_control":
 				parameters[widget_name] = generator.parameters[param]
-				# use linked floatedit value(instead of default) when linked
+				# use linked value (instead of widget defaults)
 				var param_def : Dictionary = generator.get_parameter_def(param)
 				if name == "gen_parameters" and param_def.has("type"):
-					if param_def.type == "float":
-						set_parameter(widget_name, parameters[widget_name])
+					set_parameter(widget_name, parameters[widget_name])
 			"config_control":
 				parameters[widget_name] = 0
 	emit_signal("parameter_changed", "__update_all__", null)

--- a/material_maker/windows/node_editor/parameter_enum.gd
+++ b/material_maker/windows/node_editor/parameter_enum.gd
@@ -51,23 +51,24 @@ func _on_EnumValues_item_selected(id) -> void:
 	if id >= 0 and id < enum_values.size():
 		enum_current = id
 	elif id == ENUM_EDIT:
-		var dialog = preload("res://material_maker/windows/node_editor/enum_editor.tscn").instantiate()
+		var dialog : Window = preload("res://material_maker/windows/node_editor/enum_editor.tscn").instantiate()
 		dialog.content_scale_factor = content_scale_factor
 		dialog.min_size = Vector2(250, 90) * content_scale_factor
 		var v = enum_values[enum_current]
 		add_child(dialog)
 		dialog.set_value(v.name, v.value)
 		dialog.connect("ok", Callable(self, "update_enum_value").bind(enum_current))
+		dialog.close_requested.connect(dialog.queue_free)
 		dialog.connect("popup_hide", Callable(dialog, "queue_free"))
 		dialog.hide()
 		dialog.popup_centered()
 	elif id == ENUM_ADD:
-		var dialog = preload("res://material_maker/windows/node_editor/enum_editor.tscn").instantiate()
+		var dialog : Window = preload("res://material_maker/windows/node_editor/enum_editor.tscn").instantiate()
 		dialog.content_scale_factor = content_scale_factor
 		dialog.min_size = Vector2(250, 90) * content_scale_factor
 		add_child(dialog)
 		dialog.connect("ok", Callable(self, "update_enum_value").bind(-1))
-		dialog.connect("popup_hide", Callable(dialog, "queue_free"))
+		dialog.close_requested.connect(dialog.queue_free)
 		dialog.hide()
 		dialog.popup_centered()
 	elif id == ENUM_REMOVE:


### PR DESCRIPTION
Seems like this affects all parameter types, not just float
- https://github.com/RodZill4/material-maker/pull/1342

<img width="1944" alt="nolink" src="https://github.com/user-attachments/assets/037953fc-8712-4e7d-8967-c6f1e7927342" />
