### PR TITLE
Upgrade download-artifact action to v8

### DIFF
--- a/.github/workflows/dev-desktop-builds.yml
+++ b/.github/workflows/dev-desktop-builds.yml
@@ -173,7 +173,7 @@ jobs:
           rm ./build/mac/material_maker.zip
       - name: Get documentation 🚀
         if: ${{ github.event.inputs.gen_doc == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: documentation
           path: doc


### PR DESCRIPTION
Fix deprecated warning when building with documentation

<img width="938" height="196" alt="image" src="https://github.com/user-attachments/assets/57d1f72c-3e41-44d0-b085-933c9ef8fdf9" />
