### PR TITLE
Remove rcedit step

### DIFF
--- a/.github/workflows/dev-desktop-builds.yml
+++ b/.github/workflows/dev-desktop-builds.yml
@@ -43,20 +43,6 @@ jobs:
           unzip -a Godot_v${GODOT_VERSION}-${GODOT_SUB}_export_templates.tpz
           mkdir -v -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_SUB}
           mv ./templates/* ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_SUB}
-          sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install -y wine-stable && sudo apt-get install -y wine32
-          #chown root:root -R ~
-          wget -q https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
-          mkdir -v -p ~/.local/share/rcedit
-          mv rcedit-x64.exe ~/.local/share/rcedit
-          #./Godot_v${GODOT_VERSION}-stable_linux.x86_64 --headless -q
-          mkdir -p ~/.config/godot
-          cd ~/.local/share/rcedit
-          RCEDIT_PATH=`pwd`
-          cd -
-          echo '[gd_resource type="EditorSettings" format=2]' >> ~/.config/godot/editor_settings-4.tres
-          echo '[resource]' >> ~/.config/godot/editor_settings-4.tres
-          echo 'export/windows/wine = "/usr/bin/wine"' >> ~/.config/godot/editor_settings-4.tres
-          echo 'export/windows/rcedit = "'$RCEDIT_PATH'/rcedit-x64.exe"' >> ~/.config/godot/editor_settings-4.tres
           mkdir -v -p build/${EXPORT_NAME}_${MM_RELEASE}_windows build/${EXPORT_NAME}_${MM_RELEASE}_linux
       - name: Generate Documentation
         if: ${{ github.event.inputs.gen_doc == 'true' }}

--- a/.github/workflows/dev-desktop-builds.yml
+++ b/.github/workflows/dev-desktop-builds.yml
@@ -52,10 +52,8 @@ jobs:
       - name: Windows Build 🗔
         run: |
           ./Godot_v${GODOT_VERSION}-${GODOT_SUB}_linux.x86_64 --headless -v --export-release "Windows" ./build/${EXPORT_NAME}_${MM_RELEASE}_windows/$EXPORT_NAME.exe
-          ./Godot_v${GODOT_VERSION}-${GODOT_SUB}_linux.x86_64 --headless -v --export-release "Windows" ./build/${EXPORT_NAME}_${MM_RELEASE}_windows/$EXPORT_NAME.exe
       - name: Linux Build 🐧
         run: |
-          ./Godot_v${GODOT_VERSION}-${GODOT_SUB}_linux.x86_64 --headless -v --export-release "Linux/X11" ./build/${EXPORT_NAME}_${MM_RELEASE}_linux/$EXPORT_NAME.x86_64
           ./Godot_v${GODOT_VERSION}-${GODOT_SUB}_linux.x86_64 --headless -v --export-release "Linux/X11" ./build/${EXPORT_NAME}_${MM_RELEASE}_linux/$EXPORT_NAME.x86_64
       - name: Copy Material Maker data 📁
         run: |
@@ -150,7 +148,6 @@ jobs:
           chown runner Godot.app/Contents/MacOS/Godot
           chmod +x Godot.app/Contents/MacOS/Godot
           mkdir -v -p ./build/mac
-          Godot.app/Contents/MacOS/Godot --headless -v --export-release "Mac OSX" ./build/mac/material_maker.zip
           Godot.app/Contents/MacOS/Godot --headless -v --export-release "Mac OSX" ./build/mac/material_maker.zip
       - name: Make application executable 🔧
         run: |


### PR DESCRIPTION
rcedit is no longer required since Godot 4.5

- https://github.com/godotengine/godot/pull/75950

PR Removes rcedit commands and redundant export invocations 