### PR TITLE
Add short/long desription for switch node

### DIFF
--- a/addons/material_maker/engine/nodes/gen_switch.gd
+++ b/addons/material_maker/engine/nodes/gen_switch.gd
@@ -94,3 +94,10 @@ func _get_shader_code(uv : String, output_index : int, context : MMGenContext) -
 
 func _serialize(data: Dictionary) -> Dictionary:
 	return data
+
+func get_description() -> String:
+	var desc_list : PackedStringArray = PackedStringArray()
+	desc_list.push_back(TranslationServer.translate("Switch"))
+	desc_list.push_back(TranslationServer.translate("Switches between multiple inputs.\n" +
+			"Command/Ctrl+W toggles edit mode which allows changing options such as in/output count."))
+	return "\n".join(desc_list)


### PR DESCRIPTION
The editable feature isn't very obvious unless you have read the doc. This adds a hint via a tooltip

<img width="533" alt="image" src="https://github.com/user-attachments/assets/8246b85d-56da-49ff-b0c1-b7e24b1b2a2d" />
