### PR TITLE
Fix stack overflow when editing input portal link

### DIFF
--- a/material_maker/nodes/portal/portal.gd
+++ b/material_maker/nodes/portal/portal.gd
@@ -309,7 +309,8 @@ func setup_portal_edit() -> void:
 		func(new_text : String) -> void:
 			var new_link := new_text.strip_edges()
 			if not new_link.is_empty():
-				on_parameter_changed("link", new_link)
+				if is_link_unique(new_link):
+					on_parameter_changed("link", new_link)
 				edit.modulate = link_collision_warning_color(new_link)
 			edit_box_set_position(edit))
 	edit.focus_exited.connect(func(): edit.text_submitted.emit(edit.text))


### PR DESCRIPTION
Fixed a case where stack overflow can occur(in editor) when i.e. editing the highlighted input portal to "aperture_1"

This only happens if the node is connected by an output portal whose source the edited link will reference from

<img width="326" alt="image" src="https://github.com/user-attachments/assets/69b3d9a6-7955-482a-aefc-6c430db1d353" />
