### PR TITLE
Fix error spam in TAA Export dialog

### DIFF
--- a/addons/material_maker/engine/pipeline/texture.gd
+++ b/addons/material_maker/engine/pipeline/texture.gd
@@ -71,7 +71,7 @@ func in_thread_get_texture() -> Texture2D:
 			RenderingDevice.DATA_FORMAT_R8G8B8A8_UNORM:
 				image_format = Image.FORMAT_RGBA8
 		var image : Image = Image.create_from_data(texture_size.x, texture_size.y, false, image_format, byte_data)
-		texture.set_image(image)
+		texture.set_image.call_deferred(image)
 		texture_needs_update = false
 	return texture
 


### PR DESCRIPTION
```
E 0:00:12:021   texture.gd:74 @ in_thread_get_texture(): /root/MainWindow/ExportTAA/VBoxContainer/TextureRect: The caller thread can't call the function `queue_redraw()` on this node. Use `call_deferred()` or `call_deferred_thread_group()` instead.
  <C++ Error>   Condition "!is_accessible_from_caller_thread()" is true.
  <C++ Source>  scene/main/canvas_item.cpp:473 @ queue_redraw()
  <Stack Trace> texture.gd:74 @ in_thread_get_texture()
                multi_renderer.gd:132 @ thread_loop()

```