### PR TITLE
Fix portal node not grabbable and label not drawn

### DIFF
--- a/material_maker/nodes/portal/portal.gd
+++ b/material_maker/nodes/portal/portal.gd
@@ -304,7 +304,9 @@ func setup_portal_edit() -> void:
 			is_editing = false
 			generator.editable = false
 			edit.reset_size()
-			edit.queue_free())
+			edit.queue_free()
+			graph.grab_focus()
+			queue_redraw())
 	edit.text_changed.connect(
 		func(new_text : String) -> void:
 			var new_link := new_text.strip_edges()


### PR DESCRIPTION
Fix portal node not immediately grabbable via G key and label being empty after editing link in some cases