### PR TITLE
Add menu options to load/save/reset panels layout

### DIFF
--- a/material_maker/doc/user_interface_main_menu.rst
+++ b/material_maker/doc/user_interface_main_menu.rst
@@ -103,6 +103,10 @@ View menu
 
 * the *Panels* submenu can be used to show or hide all side panels
 
+* the *Presets* submenu can be used to load/save/edit panels presets.
+
+* *Reset panels* Resets panels layout to factory settings.
+
 Tools menu
 ^^^^^^^^^^
 

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -48,6 +48,9 @@ const RECENT_FILES_COUNT = 15
 const MENU_QUICK_EXPORT : int = 1000
 const RECENTS_MENU_CLEAR = 1001
 
+const MENU_SAVE_PRESET : int = 1002
+const MENU_MANAGE_PRESETS : int = 1003
+
 const THEMES = ["Default Dark", "Default Light", "Classic"]
 
 const MENU : Array[Dictionary] = [
@@ -100,6 +103,8 @@ const MENU : Array[Dictionary] = [
 	{ menu="View/-" },
 	# { menu="View/Show or Hide side panels", command="toggle_side_panels", shortcut="Control+Space" },
 	{ menu="View/Panels", submenu="show_panels" },
+	{ menu="View/Presets", submenu="panels_preset" },
+	{ menu="View/Reset Panels", command="view_reset_panels" },
 
 	{ menu="Tools/Create", submenu="create" },
 	{ menu="Tools/Create group", command="create_subgraph", shortcut="Control+G" },
@@ -648,9 +653,60 @@ func create_menu_show_panels(menu : MMMenuManager.MenuBase) -> void:
 		menu.set_item_checked(i, layout.is_panel_visible(panels[i]))
 	menu.connect_id_pressed(self._on_ShowPanels_id_pressed)
 
+func create_menu_panels_preset(menu : MMMenuManager.MenuBase) -> void:
+	menu.clear()
+	menu.add_item("Save Preset", MENU_SAVE_PRESET)
+	menu.add_item("Manage Presets", MENU_MANAGE_PRESETS)
+	if not layout.presets.is_empty():
+		menu.add_separator()
+		for id in layout.presets.size():
+			menu.add_item(layout.presets[id].name, id)
+	menu.connect_id_pressed(self._on_PanelsPreset_id_pressed)
+
 func _on_ShowPanels_id_pressed(id) -> void:
 	var panel : String = layout.get_panel_list()[id]
 	layout.set_panel_visible(panel, not layout.is_panel_visible(panel))
+	update_menus()
+
+func _on_PanelsPreset_id_pressed(id : int) -> void:
+	match id:
+		MENU_MANAGE_PRESETS:
+			if get_node_or_null("PanelPresetsDialog"):
+				return
+			var dialog : Window = preload("res://material_maker/windows/panels_presets_dialog/panels_presets_dialog.tscn").instantiate()
+			add_child(dialog)
+			await dialog.edit_presets(layout.presets)
+		MENU_SAVE_PRESET:
+			var dialog : Window = preload("res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
+			add_child(dialog)
+			var status : Dictionary = await dialog.enter_text("Save Preset",
+					"Enter a name for the new preset", "")
+			if status.ok:
+				var preset_name : String = status.text.strip_edges()
+				if preset_name.is_empty():
+					accept_dialog("Preset name cannot be empty.")
+				else:
+					var is_unique_preset : bool = true
+					var existing_preset : Dictionary
+					if not layout.presets.is_empty():
+						for preset in layout.presets:
+							if preset.name.to_lower() == preset_name.to_lower():
+								is_unique_preset = false
+								existing_preset = preset
+								break
+					if not is_unique_preset:
+						var replace_status : String = await accept_dialog(
+							"Preset \"%s\" already exists. Do you want to replace it?" % [preset_name], true)
+						if replace_status == "ok":
+							existing_preset.preset = $VBoxContainer/Layout/FlexibleLayout.serialize()
+					else:
+						var new_preset : Dictionary = {
+							"name": preset_name,
+							"preset": $VBoxContainer/Layout/FlexibleLayout.serialize()
+						}
+						layout.presets.push_back(new_preset)
+		_:
+			$VBoxContainer/Layout/FlexibleLayout.init(layout.presets[id].preset)
 	update_menus()
 
 func create_menu_create(menu : MMMenuManager.MenuBase) -> void:
@@ -1035,6 +1091,9 @@ func view_center() -> void:
 func view_reset_zoom() -> void:
 	var graph_edit : MMGraphEdit = get_current_graph_edit()
 	graph_edit.zoom = 1
+
+func view_reset_panels() -> void:
+	$VBoxContainer/Layout.reset_panels()
 
 func toggle_side_panels() -> void:
 	$VBoxContainer/Layout.toggle_side_panels()

--- a/material_maker/main_window_layout.gd
+++ b/material_maker/main_window_layout.gd
@@ -40,6 +40,7 @@ var previous_width : float
 var current_mode : String = "material"
 var layout : Dictionary = {}
 
+var presets : Array[Dictionary]
 
 func _ready() -> void:
 	previous_width = size.x
@@ -67,12 +68,29 @@ func load_panels() -> void:
 			layout[mode] = default_paint_layout
 	$FlexibleLayout.init(layout[current_mode] if layout.has(current_mode) else null)
 
+	# Restore layout presets
+	var preset_keys : PackedStringArray
+	if mm_globals.config.has_section("layout_presets"):
+		preset_keys = mm_globals.config.get_section_keys("layout_presets")
+	for preset in preset_keys:
+		presets.push_back({
+			"name": preset,
+			"preset": JSON.parse_string(
+					mm_globals.config.get_value("layout_presets", preset))
+		})
 
 func save_config() -> void:
 	layout[current_mode] = $FlexibleLayout.serialize()
 	for mode in [ "material", "paint" ]:
 		if layout.has(mode):
 			mm_globals.config.set_value("layout", mode, JSON.stringify(layout[mode]))
+
+	# Save layout presets
+	if mm_globals.config.has_section("layout_presets"):
+		mm_globals.config.erase_section("layout_presets")
+	for preset in presets:
+		mm_globals.config.set_value("layout_presets",
+			preset.name, JSON.stringify(preset.preset))
 
 
 func get_panel(n) -> Control:
@@ -102,3 +120,10 @@ func change_mode(m : String) -> void:
 
 func _on_tab_changed(_tab):
 	pass
+
+func reset_panels() -> void:
+	if current_mode == "material":
+		$FlexibleLayout.init(default_material_layout)
+	elif current_mode == "paint":
+		$FlexibleLayout.init(default_paint_layout)
+	owner.view_center()

--- a/material_maker/windows/panels_presets_dialog/panels_presets_dialog.gd
+++ b/material_maker/windows/panels_presets_dialog/panels_presets_dialog.gd
@@ -1,0 +1,88 @@
+extends Window
+
+var layout_presets : Array[Dictionary]
+var selected_item : int = -1
+
+func _ready() -> void:
+	if not get_tree().root.gui_embed_subwindows:
+		content_scale_factor = get_tree().root.content_scale_factor
+	size = $MarginContainer.get_combined_minimum_size() * content_scale_factor
+	min_size = size
+
+func edit_presets(presets : Array[Dictionary]) -> void:
+	layout_presets = presets
+	_ready()
+	hide()
+	popup_centered()
+	update_item_list()
+	await %Buttons/Close.pressed
+	queue_free()
+
+func update_item_list() -> void:
+	%ItemList.clear()
+	if not layout_presets.is_empty():
+		for preset in layout_presets:
+			var idx : int = %ItemList.add_item(preset.name)
+			%ItemList.set_item_tooltip_enabled(idx, false)
+	else:
+		enable_buttons(false)
+	if selected_item != -1 and selected_item < %ItemList.item_count:
+		%ItemList.select(selected_item)
+
+func enable_buttons(enable : bool) -> void:
+	for btn in %Buttons.get_children():
+		if btn.name != "Close":
+			btn.disabled = not enable
+
+func _on_item_list_item_selected(index : int) -> void:
+	selected_item = index
+
+func _on_rename_pressed() -> void:
+	if selected_item == -1:
+		return
+	var renamed_item : String = %ItemList.get_item_text(selected_item)
+	var dialog : Window = preload(
+					"res://material_maker/windows/line_dialog/line_dialog.tscn").instantiate()
+	add_child(dialog)
+
+	var status : Dictionary = await dialog.enter_text("Rename Preset",
+			"Enter a new name for this preset", renamed_item)
+	var renamed_item_id : int = -1
+	var preset_data : Dictionary
+	if status.ok and not status.text.strip_edges().is_empty():
+		for preset in layout_presets.size():
+			if layout_presets[preset].name == renamed_item:
+				renamed_item_id = preset
+				preset_data = layout_presets[preset].duplicate()
+				break
+	else:
+		return
+
+	var new_preset_name : String = status.text.strip_edges()
+	for item_index in %ItemList.item_count:
+		if %ItemList.get_item_text(item_index) == new_preset_name:
+			if renamed_item_id != item_index:
+				mm_globals.main_window.accept_dialog(
+						"Preset \"%s\" already exists." % [new_preset_name])
+				return
+	layout_presets.remove_at(renamed_item_id)
+	preset_data.name = status.text.strip_edges()
+	layout_presets.insert(renamed_item_id, preset_data)
+	update_item_list()
+
+func _on_remove_pressed() -> void:
+	if selected_item == -1:
+		return
+	for preset in layout_presets.size():
+		if layout_presets[preset].name == %ItemList.get_item_text(selected_item):
+			layout_presets.remove_at(preset)
+			break
+	if layout_presets.is_empty():
+		enable_buttons(false)
+	update_item_list()
+
+func _on_apply_pressed() -> void:
+	if selected_item == -1:
+		return
+	var layout : HBoxContainer = mm_globals.main_window.layout
+	layout.get_node("FlexibleLayout").init(layout_presets[selected_item].preset)

--- a/material_maker/windows/panels_presets_dialog/panels_presets_dialog.gd.uid
+++ b/material_maker/windows/panels_presets_dialog/panels_presets_dialog.gd.uid
@@ -1,0 +1,1 @@
+uid://cbelggpnaih8k

--- a/material_maker/windows/panels_presets_dialog/panels_presets_dialog.tscn
+++ b/material_maker/windows/panels_presets_dialog/panels_presets_dialog.tscn
@@ -1,0 +1,77 @@
+[gd_scene format=3 uid="uid://l3a3x237y66n"]
+
+[ext_resource type="Script" uid="uid://cbelggpnaih8k" path="res://material_maker/windows/panels_presets_dialog/panels_presets_dialog.gd" id="1_p4t34"]
+
+[node name="PanelPresetsDialog" type="Window" unique_id=1375078152]
+oversampling_override = 1.0
+title = "Manage Presets"
+position = Vector2i(0, 36)
+size = Vector2i(350, 350)
+script = ExtResource("1_p4t34")
+
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=1323210345]
+custom_minimum_size = Vector2(350, 350)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 4
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1612899448]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer" unique_id=1214955961]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ItemList" type="ItemList" parent="MarginContainer/VBoxContainer/HBoxContainer" unique_id=1960428380]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/HBoxContainer" unique_id=339801386]
+layout_mode = 2
+theme_override_constants/margin_left = 4
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
+
+[node name="Buttons" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer" unique_id=808754394]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Apply" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Buttons" unique_id=1091220633]
+custom_minimum_size = Vector2(60, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Apply"
+
+[node name="Rename" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Buttons" unique_id=1818598517]
+custom_minimum_size = Vector2(60, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Rename"
+
+[node name="Remove" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Buttons" unique_id=1180899143]
+custom_minimum_size = Vector2(60, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Remove"
+
+[node name="Close" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Buttons" unique_id=200813023]
+custom_minimum_size = Vector2(60, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 10
+text = "Close"
+
+[connection signal="item_selected" from="MarginContainer/VBoxContainer/HBoxContainer/ItemList" to="." method="_on_item_list_item_selected"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Buttons/Apply" to="." method="_on_apply_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Buttons/Rename" to="." method="_on_rename_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Buttons/Remove" to="." method="_on_remove_pressed"]


### PR DESCRIPTION
addresses suggestion via discord
>  be able to save a layout and or at least reset to the default layout with "factory settings" for what panels are visible and where they are docked

https://github.com/user-attachments/assets/3b59798d-b533-4fde-b0cc-9d97c100106d