### PR TITLE
Fix GLTF/GLB importing by using append_from_file instead of buffers

### DIFF
--- a/addons/material_maker/loaders/mesh_loader.gd
+++ b/addons/material_maker/loaders/mesh_loader.gd
@@ -14,11 +14,7 @@ static func load_gltf_mesh(file_path) -> ArrayMesh:
 	if not FileAccess.file_exists(file_path):
 		printerr("GLTF/GLB file does not exists or is not accesible")
 		return null
-	var glb_filebytes = FileAccess.get_file_as_bytes(file_path)
-	if glb_filebytes == null:
-		printerr("GLTF/GLB file data is null")
-		return null
-	var err = gltf.append_from_buffer(glb_filebytes, "", gltf_state)
+	var err = gltf.append_from_file(file_path, gltf_state)
 	if err != OK:
 		printerr("Failure during parsing GLTF/GLB buffer")
 		return null


### PR DESCRIPTION
i got this error when trying to load a gltf as model in the new paint project menu:

ERROR: Condition "p_base_path.is_empty()" is true. Returning: ERR_INVALID_PARAMETER

   at: _parse_buffers (modules/gltf/gltf_document.cpp:790)

ERROR: Condition "err != OK" is true. Returning: ERR_PARSE_ERROR

   at: _parse_gltf_state (modules/gltf/gltf_document.cpp:6930)

ERROR: Condition "err != OK" is true. Returning: err

   at: _parse (modules/gltf/gltf_document.cpp:6545)

ERROR: Condition "err != OK" is true. Returning: err

   at: append_from_buffer (modules/gltf/gltf_document.cpp:7146)

Failure during parsing GLTF/GLB buffer

cause for the error was probably the empty string in this line: 
var err = gltf.append_from_buffer(glb_filebytes, "", gltf_state)

so i changed it to use load_from_file instead, i dont see a reason why the file should first be converted to bytes instead of using the build in function