### PR TITLE
Add sorting options for add node popup

### DIFF
--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -61,6 +61,7 @@ const DEFAULT_CONFIG : Dictionary = {
 	node_minimize_button = false,
 	node_close_button = false,
 	ui_single_window_mode = false,
+	add_node_popup_sort = SortMenu.Sorting.QUALITY_DESCENDING,
 }
 
 

--- a/material_maker/panels/preview_2d/simple_button.gd
+++ b/material_maker/panels/preview_2d/simple_button.gd
@@ -1,3 +1,4 @@
+class_name SimpleButton
 extends Button
 
 @export var icon_name := ""

--- a/material_maker/theme/classic_base.tres
+++ b/material_maker/theme/classic_base.tres
@@ -402,6 +402,16 @@ metadata/recolor = true
 atlas = ExtResource("1_fw8f4")
 region = Rect2(32, 96, 16, 16)
 
+[sub_resource type="AtlasTexture" id="AtlasTexture_t38jc"]
+atlas = ExtResource("1_fw8f4")
+region = Rect2(32, 224, 16, 16)
+metadata/scale = 2.0
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_j6702"]
+atlas = ExtResource("1_fw8f4")
+region = Rect2(48, 224, 16, 16)
+metadata/scale = 2.0
+
 [sub_resource type="AtlasTexture" id="AtlasTexture_q32qs"]
 atlas = ExtResource("1_fw8f4")
 region = Rect2(32, 48, 16, 16)
@@ -413,6 +423,16 @@ region = Rect2(48, 48, 16, 16)
 [sub_resource type="AtlasTexture" id="AtlasTexture_dnklm"]
 atlas = ExtResource("1_fw8f4")
 region = Rect2(112, 176, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_50kh2"]
+atlas = ExtResource("1_fw8f4")
+region = Rect2(96, 224, 16, 16)
+metadata/scale = 2.0
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ivx1c"]
+atlas = ExtResource("1_fw8f4")
+region = Rect2(112, 224, 16, 16)
+metadata/scale = 2.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_7ns35"]
 atlas = ExtResource("1_fw8f4")
@@ -441,6 +461,16 @@ region = Rect2(16, 0, 16, 16)
 [sub_resource type="AtlasTexture" id="AtlasTexture_rqlqa"]
 atlas = ExtResource("1_fw8f4")
 region = Rect2(0, 32, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_6kl5u"]
+atlas = ExtResource("1_fw8f4")
+region = Rect2(64, 224, 16, 16)
+metadata/scale = 2.0
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ya45l"]
+atlas = ExtResource("1_fw8f4")
+region = Rect2(80, 224, 16, 16)
+metadata/scale = 2.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_jxpkm"]
 atlas = ExtResource("1_fw8f4")
@@ -545,6 +575,10 @@ region = Rect2(48, 16, 16, 16)
 [sub_resource type="AtlasTexture" id="AtlasTexture_en6gw"]
 atlas = ExtResource("1_fw8f4")
 region = Rect2(0, 0, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_3gtjo"]
+atlas = ExtResource("1_fw8f4")
+region = Rect2(112, 0, 16, 16)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_h5b0q"]
 bg_color = Color(0.266667, 0.278431, 0.301961, 1)
@@ -1130,9 +1164,13 @@ MM_Icons/icons/2D_preview = SubResource("AtlasTexture_1yu4y")
 MM_Icons/icons/3D_preview = SubResource("AtlasTexture_ao7ds")
 MM_Icons/icons/3D_preview_control = SubResource("AtlasTexture_hht3q")
 MM_Icons/icons/add_image = SubResource("AtlasTexture_c5jyp")
+MM_Icons/icons/alphabetical_ascending = SubResource("AtlasTexture_t38jc")
+MM_Icons/icons/alphabetical_descending = SubResource("AtlasTexture_j6702")
 MM_Icons/icons/arrow_left = SubResource("AtlasTexture_q32qs")
 MM_Icons/icons/arrow_right = SubResource("AtlasTexture_r3xak")
 MM_Icons/icons/arrow_updown = SubResource("AtlasTexture_dnklm")
+MM_Icons/icons/category_ascending = SubResource("AtlasTexture_50kh2")
+MM_Icons/icons/category_descending = SubResource("AtlasTexture_ivx1c")
 MM_Icons/icons/color_picker = SubResource("AtlasTexture_7ns35")
 MM_Icons/icons/delete = SubResource("AtlasTexture_agwde")
 MM_Icons/icons/draw = SubResource("AtlasTexture_oy0ko")
@@ -1140,6 +1178,8 @@ MM_Icons/icons/dropdown = SubResource("AtlasTexture_2gawd")
 MM_Icons/icons/environment = SubResource("AtlasTexture_x8swe")
 MM_Icons/icons/export = SubResource("AtlasTexture_5e0gw")
 MM_Icons/icons/folder = SubResource("AtlasTexture_rqlqa")
+MM_Icons/icons/frequency_ascending = SubResource("AtlasTexture_6kl5u")
+MM_Icons/icons/frequency_descending = SubResource("AtlasTexture_ya45l")
 MM_Icons/icons/function = SubResource("AtlasTexture_jxpkm")
 MM_Icons/icons/link = SubResource("AtlasTexture_c7xvc")
 MM_Icons/icons/lock_locked = SubResource("AtlasTexture_m27ao")
@@ -1164,6 +1204,7 @@ MM_Icons/icons/spline_progressive = SubResource("AtlasTexture_70aex")
 MM_Icons/icons/spline_reverse = SubResource("AtlasTexture_ahanl")
 MM_Icons/icons/spline_unlink = SubResource("AtlasTexture_iofl8")
 MM_Icons/icons/view = SubResource("AtlasTexture_en6gw")
+MM_Icons/icons/zoom = SubResource("AtlasTexture_3gtjo")
 MM_LibrarySectionButton/base_type = &"Button"
 MM_LibrarySectionButton/colors/icon_disabled_color = Color(0.443137, 0.45098, 0.470588, 1)
 MM_LibrarySectionButton/colors/icon_focus_color = Color(1, 1, 1, 1)

--- a/material_maker/theme/default.tres
+++ b/material_maker/theme/default.tres
@@ -443,6 +443,16 @@ region = Rect2(32, 208, 16, 16)
 atlas = ExtResource("1_s43fy")
 region = Rect2(0, 208, 16, 16)
 
+[sub_resource type="AtlasTexture" id="AtlasTexture_ujqqf"]
+atlas = ExtResource("1_s43fy")
+region = Rect2(32, 224, 16, 16)
+metadata/scale = 2.0
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_0wsok"]
+atlas = ExtResource("1_s43fy")
+region = Rect2(48, 224, 16, 16)
+metadata/scale = 2.0
+
 [sub_resource type="AtlasTexture" id="AtlasTexture_60g77"]
 atlas = ExtResource("1_s43fy")
 region = Rect2(96, 144, 16, 16)
@@ -462,6 +472,16 @@ region = Rect2(112, 176, 16, 16)
 [sub_resource type="AtlasTexture" id="AtlasTexture_cscp3"]
 atlas = ExtResource("1_s43fy")
 region = Rect2(80, 192, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ha0qk"]
+atlas = ExtResource("1_s43fy")
+region = Rect2(96, 224, 16, 16)
+metadata/scale = 2.0
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_4tel2"]
+atlas = ExtResource("1_s43fy")
+region = Rect2(112, 224, 16, 16)
+metadata/scale = 2.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_j13i3"]
 atlas = ExtResource("1_s43fy")
@@ -510,6 +530,16 @@ region = Rect2(16, 0, 16, 16)
 [sub_resource type="AtlasTexture" id="AtlasTexture_rqlqa"]
 atlas = ExtResource("1_s43fy")
 region = Rect2(0, 32, 16, 16)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_xdmf6"]
+atlas = ExtResource("1_s43fy")
+region = Rect2(64, 224, 16, 16)
+metadata/scale = 2.0
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_5jxva"]
+atlas = ExtResource("1_s43fy")
+region = Rect2(80, 224, 16, 16)
+metadata/scale = 2.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0jwmb"]
 atlas = ExtResource("1_s43fy")
@@ -1353,11 +1383,15 @@ MM_Icons/icons/add_image = SubResource("AtlasTexture_86qok")
 MM_Icons/icons/align_center = SubResource("AtlasTexture_khddu")
 MM_Icons/icons/align_end = SubResource("AtlasTexture_xbfay")
 MM_Icons/icons/align_start = SubResource("AtlasTexture_nw6qx")
+MM_Icons/icons/alphabetical_ascending = SubResource("AtlasTexture_ujqqf")
+MM_Icons/icons/alphabetical_descending = SubResource("AtlasTexture_0wsok")
 MM_Icons/icons/arrange_nodes = SubResource("AtlasTexture_60g77")
 MM_Icons/icons/arrow_left = SubResource("AtlasTexture_q32qs")
 MM_Icons/icons/arrow_right = SubResource("AtlasTexture_r3xak")
 MM_Icons/icons/arrow_updown = SubResource("AtlasTexture_ovvp6")
 MM_Icons/icons/camera = SubResource("AtlasTexture_cscp3")
+MM_Icons/icons/category_ascending = SubResource("AtlasTexture_ha0qk")
+MM_Icons/icons/category_descending = SubResource("AtlasTexture_4tel2")
 MM_Icons/icons/color_picker = SubResource("AtlasTexture_j13i3")
 MM_Icons/icons/connection_bezier = SubResource("AtlasTexture_rqjp3")
 MM_Icons/icons/connection_diagonal = SubResource("AtlasTexture_8tn7x")
@@ -1370,6 +1404,8 @@ MM_Icons/icons/dropdown = SubResource("AtlasTexture_2gawd")
 MM_Icons/icons/environment = SubResource("AtlasTexture_x8swe")
 MM_Icons/icons/export = SubResource("AtlasTexture_5e0gw")
 MM_Icons/icons/folder = SubResource("AtlasTexture_rqlqa")
+MM_Icons/icons/frequency_ascending = SubResource("AtlasTexture_xdmf6")
+MM_Icons/icons/frequency_descending = SubResource("AtlasTexture_5jxva")
 MM_Icons/icons/function = SubResource("AtlasTexture_0jwmb")
 MM_Icons/icons/grid = SubResource("AtlasTexture_pkv4t")
 MM_Icons/icons/link = SubResource("AtlasTexture_8uenv")

--- a/material_maker/theme/default_theme_icons.svg
+++ b/material_maker/theme/default_theme_icons.svg
@@ -28,15 +28,15 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="8"
-     inkscape:cx="36.6875"
-     inkscape:cy="213.8125"
+     inkscape:zoom="11.313709"
+     inkscape:cx="100.98369"
+     inkscape:cy="222.82702"
      inkscape:window-width="1152"
      inkscape:window-height="981"
      inkscape:window-x="0"
      inkscape:window-y="38"
      inkscape:window-maximized="0"
-     inkscape:current-layer="g46"
+     inkscape:current-layer="g282"
      showguides="false">
     <inkscape:grid
        id="grid2"
@@ -81,6 +81,40 @@
   </sodipodi:namedview>
   <defs
      id="defs1">
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect267"
+       is_visible="true"
+       lpeversion="1"
+       nodesatellites_param="F,0,0,1,0,0,0,1 @ F,0,0,1,0,0.86291261,0,1 @ F,0,0,1,0,0.93779296,0,1 @ F,0,0,1,0,0,0,1"
+       radius="0"
+       unit="px"
+       method="auto"
+       mode="F"
+       chamfer_steps="1"
+       flexible="false"
+       use_knot_distance="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect266"
+       is_visible="true"
+       lpeversion="1"
+       nodesatellites_param="F,0,0,1,0,0,0,1 @ F,0,0,1,0,1.5,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1"
+       radius="0"
+       unit="px"
+       method="auto"
+       mode="F"
+       chamfer_steps="1"
+       flexible="false"
+       use_knot_distance="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
     <inkscape:path-effect
        effect="fillet_chamfer"
        id="path-effect100"
@@ -2739,6 +2773,334 @@
        d="m 17.836663,238.07516 2.571223,-9.97576 9.642069,-2.23754"
        inkscape:label="bevel"
        style="stroke-linecap:round;stroke-linejoin:round" />
+    <g
+       id="g115"
+       inkscape:label="freq_sort_descending"
+       transform="translate(16.652664)"
+       style="display:inline">
+      <g
+         id="g108"
+         inkscape:label="bars"
+         transform="matrix(1,0,0,1.0588235,1.25,-12.676471)">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.163658;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect107"
+           width="1.75"
+           height="8.7111473"
+           x="75.25"
+           y="229.04059"
+           ry="0.13138665"
+           rx="0.13138665" />
+      </g>
+      <g
+         id="g116"
+         inkscape:label="bars"
+         transform="matrix(1,0,0,1.0588235,-1.625,-12.676468)">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.163658;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect115"
+           width="1.75"
+           height="12.700075"
+           x="75.4375"
+           y="225.05167"
+           ry="0.13138665"
+           rx="0.13138665" />
+      </g>
+      <g
+         id="g117"
+         inkscape:label="bars"
+         transform="matrix(0.99936402,0,0,1.0581501,-4.0771945,-12.516983)">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.163658;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect116"
+           width="1.75"
+           height="5.6282549"
+           x="75.25"
+           y="232.12411"
+           ry="0.1460309"
+           rx="0.1460309" />
+      </g>
+      <g
+         id="g215"
+         inkscape:label="arrrow"
+         transform="matrix(1.2885923,0,0,-1.2885923,22.33506,530.60797)"
+         style="display:inline;stroke-width:1.32283;stroke-dasharray:none">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 35,236.99441 v -10.5"
+           id="path213"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="M 36.938213,231.75696 35,226.49441"
+           id="path214"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 32.987145,231.75696 1.938213,-5.26255"
+           id="path215"
+           sodipodi:nodetypes="cc" />
+      </g>
+    </g>
+    <g
+       id="g282"
+       style="display:inline"
+       inkscape:label="category_sort_descending"
+       transform="translate(15.896725,0.02276541)">
+      <g
+         id="g280"
+         inkscape:label="arrrow"
+         transform="matrix(1.2885923,0,0,-1.2885923,54.544936,530.60788)"
+         style="display:inline;stroke-width:1.32283;stroke-dasharray:none">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 35,236.99441 v -10.5"
+           id="path278"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="M 36.938213,231.75696 35,226.49441"
+           id="path279"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 32.987145,231.75696 1.938213,-5.26255"
+           id="path280"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         id="g281"
+         style="display:inline"
+         transform="translate(-0.14672532,-0.02276541)">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.036658;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect280"
+           width="6.5937524"
+           height="3.2112255"
+           x="103.69351"
+           y="224.96577"
+           ry="0.58616638"
+           rx="0.55142021" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.501819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="circle280"
+           cx="110.24905"
+           cy="231.61568"
+           r="1.3232234" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.501819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="circle281"
+           cx="103.71275"
+           cy="236.36742"
+           r="1.3232234" />
+      </g>
+      <path
+         d="m 104.24414,228.74414 c -0.30549,0 -0.55078,0.2612 -0.55078,0.58594 v 5.20508 a 1.8314563,1.8314563 0 0 1 0.0195,0 1.8314563,1.8314563 0 0 1 1.83203,1.83203 1.8314563,1.8314563 0 0 1 -1.83203,1.83203 1.8314563,1.8314563 0 0 1 -0.0195,0 v 0.43945 c 0,0.32474 0.24529,0.58594 0.55078,0.58594 h 5.49219 c 0.30548,0 0.55078,-0.2612 0.55078,-0.58594 v -5.1914 a 1.8314563,1.8314563 0 0 1 -0.0371,0 1.8314563,1.8314563 0 0 1 -1.83203,-1.83204 1.8314563,1.8314563 0 0 1 1.83203,-1.83007 1.8314563,1.8314563 0 0 1 0.0371,0 v -0.45508 c 0,-0.32474 -0.2453,-0.58594 -0.55078,-0.58594 z"
+         style="display:inline;fill:#ffffff;stroke-width:0.0377953;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke fill markers"
+         id="path281"
+         transform="translate(-0.14672532,-0.02276541)" />
+    </g>
+    <g
+       id="g273"
+       style="display:inline"
+       inkscape:label="category_sort_ascending"
+       transform="translate(0.14672532,0.02276541)">
+      <g
+         id="g272"
+         inkscape:label="arrrow"
+         transform="matrix(1.2885923,0,0,1.2885923,54.544936,-66.640245)"
+         style="display:inline;stroke-width:1.32283;stroke-dasharray:none">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 35,236.99441 v -10.5"
+           id="path269"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="M 36.938213,231.75696 35,226.49441"
+           id="path270"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 32.987145,231.75696 1.938213,-5.26255"
+           id="path271"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <g
+         id="g277"
+         style="display:inline"
+         transform="translate(-0.14672532,-0.02276541)">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.036658;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect273"
+           width="6.5937524"
+           height="3.2112255"
+           x="103.69351"
+           y="224.96577"
+           ry="0.58616638"
+           rx="0.55142021" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.501819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="circle273"
+           cx="110.24905"
+           cy="231.61568"
+           r="1.3232234" />
+        <circle
+           style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.501819;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="circle275"
+           cx="103.71275"
+           cy="236.36742"
+           r="1.3232234" />
+      </g>
+      <path
+         d="m 104.24414,228.74414 c -0.30549,0 -0.55078,0.2612 -0.55078,0.58594 v 5.20508 a 1.8314563,1.8314563 0 0 1 0.0195,0 1.8314563,1.8314563 0 0 1 1.83203,1.83203 1.8314563,1.8314563 0 0 1 -1.83203,1.83203 1.8314563,1.8314563 0 0 1 -0.0195,0 v 0.43945 c 0,0.32474 0.24529,0.58594 0.55078,0.58594 h 5.49219 c 0.30548,0 0.55078,-0.2612 0.55078,-0.58594 v -5.1914 a 1.8314563,1.8314563 0 0 1 -0.0371,0 1.8314563,1.8314563 0 0 1 -1.83203,-1.83204 1.8314563,1.8314563 0 0 1 1.83203,-1.83007 1.8314563,1.8314563 0 0 1 0.0371,0 v -0.45508 c 0,-0.32474 -0.2453,-0.58594 -0.55078,-0.58594 z"
+         style="display:inline;fill:#ffffff;stroke-width:0.0377953;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke fill markers"
+         id="path277"
+         transform="translate(-0.14672532,-0.02276541)" />
+    </g>
+    <g
+       id="g213"
+       inkscape:label="freq_sort_asscending"
+       transform="translate(0.42440897)"
+       style="display:inline">
+      <g
+         id="g206"
+         inkscape:label="bars"
+         transform="matrix(1,0,0,1.0588235,1.25,-12.676471)">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.163658;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect206"
+           width="1.75"
+           height="8.7111473"
+           x="75.25"
+           y="229.04059"
+           ry="0.13138665"
+           rx="0.13138665" />
+      </g>
+      <g
+         id="g208"
+         inkscape:label="bars"
+         transform="matrix(1,0,0,1.0588235,-1.625,-12.676468)">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.163658;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect208"
+           width="1.75"
+           height="12.700075"
+           x="75.4375"
+           y="225.05167"
+           ry="0.13138665"
+           rx="0.13138665" />
+      </g>
+      <g
+         id="g209"
+         inkscape:label="bars"
+         transform="matrix(0.99936402,0,0,1.0581501,-4.0771945,-12.516983)">
+        <rect
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.163658;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           id="rect209"
+           width="1.75"
+           height="5.6282549"
+           x="75.25"
+           y="232.12411"
+           ry="0.1460309"
+           rx="0.1460309" />
+      </g>
+      <g
+         id="g212"
+         inkscape:label="arrrow"
+         transform="matrix(1.2885923,0,0,1.2885923,22.334024,-66.640245)"
+         style="display:inline;stroke-width:1.32283;stroke-dasharray:none">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 35,236.99441 v -10.5"
+           id="path210"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="M 36.938213,231.75696 35,226.49441"
+           id="path211"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 32.987145,231.75696 1.938213,-5.26255"
+           id="path212"
+           sodipodi:nodetypes="cc" />
+      </g>
+    </g>
+    <g
+       id="g202"
+       inkscape:label="az_sort_descending"
+       transform="matrix(1.2885923,0,0,1.2885923,4.6652299,-66.965984)"
+       style="display:inline">
+      <path
+         d="m 42.070312,226.18945 c -0.07587,0 -0.136113,0.0201 -0.18164,0.0606 -0.04047,0.0354 -0.06881,0.0783 -0.08398,0.12891 l -1.828125,4.89257 c -0.01011,0.0253 -0.01563,0.0481 -0.01563,0.0684 10e-7,0.0455 0.01653,0.0849 0.04687,0.11524 0.03541,0.0303 0.07281,0.0449 0.113282,0.0449 h 0.660156 c 0.07082,0 0.121997,-0.0146 0.152344,-0.0449 0.03541,-0.0354 0.05825,-0.0693 0.06836,-0.0996 l 0.355469,-0.92578 h 2.253906 l 0.357422,0.92578 c 0.01012,0.0303 0.0302,0.0642 0.06055,0.0996 0.03541,0.0303 0.08739,0.0449 0.158203,0.0449 h 0.660156 c 0.04047,0 0.07708,-0.0146 0.107422,-0.0449 0.03035,-0.0303 0.04492,-0.0697 0.04492,-0.11524 0,-0.0203 -0.0027,-0.0431 -0.0078,-0.0684 l -1.828125,-4.89257 c -0.02023,-0.0506 -0.05133,-0.0935 -0.0918,-0.12891 -0.04047,-0.0405 -0.09795,-0.0606 -0.173829,-0.0606 z m 0.410157,1.02344 0.865234,2.34375 h -1.722656 z"
+         style="font-weight:500;font-size:7.58752px;font-family:Rubik;-inkscape-font-specification:'Rubik, Medium';fill:#ffffff;stroke-width:1.03238;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke fill markers"
+         id="path201"
+         inkscape:label="A" />
+      <path
+         d="m 40.664062,232.25586 c -0.0565,0 -0.102718,0.0187 -0.138671,0.0547 -0.03082,0.036 -0.04687,0.0822 -0.04687,0.13867 v 0.53125 c 0,0.0514 0.01606,0.0949 0.04687,0.13086 0.03596,0.0359 0.08217,0.0547 0.138671,0.0547 h 2.535157 l -2.681641,3.46679 c -0.01541,0.0205 -0.03949,0.0533 -0.07031,0.0996 -0.03082,0.0462 -0.04492,0.1085 -0.04492,0.18555 v 0.53906 c 0,0.0565 0.01678,0.10274 0.05273,0.13867 0.03596,0.0359 0.07949,0.0527 0.130859,0.0527 h 3.845704 c 0.0565,0 0.102718,-0.0168 0.138671,-0.0527 0.03595,-0.036 0.05469,-0.0795 0.05469,-0.13086 v -0.53906 c 0,-0.0565 -0.01873,-0.10274 -0.05469,-0.13867 -0.03596,-0.0359 -0.08217,-0.0547 -0.138671,-0.0547 H 41.8125 L 44.439453,233.25 c 0.02568,-0.036 0.04781,-0.0742 0.06836,-0.11523 0.02055,-0.0411 0.03125,-0.0926 0.03125,-0.1543 v -0.53125 c 0,-0.0565 -0.01678,-0.10274 -0.05273,-0.13867 -0.03596,-0.0359 -0.08217,-0.0547 -0.138672,-0.0547 z"
+         style="font-weight:500;font-size:7.70483px;font-family:Rubik;-inkscape-font-specification:'Rubik, Medium';fill:#ffffff;stroke-width:1.04834;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke fill markers"
+         id="path202"
+         inkscape:label="Z" />
+      <g
+         id="g205"
+         inkscape:label="arrrow"
+         transform="matrix(1,0,0,-1,1.8248369,463.74161)"
+         style="display:inline;stroke-width:1.32283;stroke-dasharray:none">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 35,236.99441 v -10.5"
+           id="path203"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="M 36.938213,231.75696 35,226.49441"
+           id="path204"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 32.987145,231.75696 1.938213,-5.26255"
+           id="path205"
+           sodipodi:nodetypes="cc" />
+      </g>
+    </g>
+    <g
+       id="g32"
+       inkscape:label="az_sort_ascending"
+       transform="matrix(1.2885923,0,0,1.2885923,-11.288867,-66.965984)"
+       style="display:inline">
+      <g
+         id="g33"
+         inkscape:label="arrrow"
+         transform="translate(1.8253886,0.252795)"
+         style="stroke-width:1.32283;stroke-dasharray:none">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 35,236.99441 v -10.5"
+           id="path27"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="M 36.938213,231.75696 35,226.49441"
+           id="path27-7"
+           sodipodi:nodetypes="cc" />
+        <path
+           style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.05673;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 32.987145,231.75696 1.938213,-5.26255"
+           id="path197"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <path
+         d="m 42.070312,226.18945 c -0.07587,0 -0.136113,0.0201 -0.18164,0.0606 -0.04047,0.0354 -0.06881,0.0783 -0.08398,0.12891 l -1.828125,4.89257 c -0.01011,0.0253 -0.01563,0.0481 -0.01563,0.0684 10e-7,0.0455 0.01653,0.0849 0.04687,0.11524 0.03541,0.0303 0.07281,0.0449 0.113282,0.0449 h 0.660156 c 0.07082,0 0.121997,-0.0146 0.152344,-0.0449 0.03541,-0.0354 0.05825,-0.0693 0.06836,-0.0996 l 0.355469,-0.92578 h 2.253906 l 0.357422,0.92578 c 0.01012,0.0303 0.0302,0.0642 0.06055,0.0996 0.03541,0.0303 0.08739,0.0449 0.158203,0.0449 h 0.660156 c 0.04047,0 0.07708,-0.0146 0.107422,-0.0449 0.03035,-0.0303 0.04492,-0.0697 0.04492,-0.11524 0,-0.0203 -0.0027,-0.0431 -0.0078,-0.0684 l -1.828125,-4.89257 c -0.02023,-0.0506 -0.05133,-0.0935 -0.0918,-0.12891 -0.04047,-0.0405 -0.09795,-0.0606 -0.173829,-0.0606 z m 0.410157,1.02344 0.865234,2.34375 h -1.722656 z"
+         style="font-weight:500;font-size:7.58752px;font-family:Rubik;-inkscape-font-specification:'Rubik, Medium';fill:#ffffff;stroke-width:1.03238;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke fill markers"
+         id="path39"
+         inkscape:label="A" />
+      <path
+         d="m 40.664062,232.25586 c -0.0565,0 -0.102718,0.0187 -0.138671,0.0547 -0.03082,0.036 -0.04687,0.0822 -0.04687,0.13867 v 0.53125 c 0,0.0514 0.01606,0.0949 0.04687,0.13086 0.03596,0.0359 0.08217,0.0547 0.138671,0.0547 h 2.535157 l -2.681641,3.46679 c -0.01541,0.0205 -0.03949,0.0533 -0.07031,0.0996 -0.03082,0.0462 -0.04492,0.1085 -0.04492,0.18555 v 0.53906 c 0,0.0565 0.01678,0.10274 0.05273,0.13867 0.03596,0.0359 0.07949,0.0527 0.130859,0.0527 h 3.845704 c 0.0565,0 0.102718,-0.0168 0.138671,-0.0527 0.03595,-0.036 0.05469,-0.0795 0.05469,-0.13086 v -0.53906 c 0,-0.0565 -0.01873,-0.10274 -0.05469,-0.13867 -0.03596,-0.0359 -0.08217,-0.0547 -0.138671,-0.0547 H 41.8125 L 44.439453,233.25 c 0.02568,-0.036 0.04781,-0.0742 0.06836,-0.11523 0.02055,-0.0411 0.03125,-0.0926 0.03125,-0.1543 v -0.53125 c 0,-0.0565 -0.01678,-0.10274 -0.05273,-0.13867 -0.03596,-0.0359 -0.08217,-0.0547 -0.138672,-0.0547 z"
+         style="font-weight:500;font-size:7.70483px;font-family:Rubik;-inkscape-font-specification:'Rubik, Medium';fill:#ffffff;stroke-width:1.04834;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke fill markers"
+         id="path38"
+         inkscape:label="Z" />
+    </g>
   </g>
   <g
      inkscape:groupmode="layer"

--- a/material_maker/windows/add_node_popup/add_node_popup.gd
+++ b/material_maker/windows/add_node_popup/add_node_popup.gd
@@ -1,8 +1,10 @@
+class_name AddNodePopup
 extends Popup
 
 
-@onready var filter : LineEdit = $PanelContainer/VBoxContainer/Filter
+@onready var filter : LineEdit = %Filter
 
+var item_sort_mode : SortMenu.Sorting = mm_globals.get_config("add_node_popup_sort")
 
 var insert_position : Vector2
 
@@ -12,7 +14,6 @@ var qc_slot_type : int
 var qc_is_output : bool
 
 @onready var library_manager = get_node("/root/MainWindow/NodeLibraryManager")
-
 
 func get_current_graph():
 	return get_parent().get_current_graph_edit()
@@ -161,24 +162,21 @@ func check_quick_connect(obj) -> bool:
 
 func update_list(filter_text : String = "") -> void:
 	filter_text = filter_text.to_lower()
-
 	%List.clear()
-	var idx := 0
-	var items: Array = library_manager.get_items(filter_text, true)
-	items.sort_custom(func(a,b): return a.idx < b.idx if a.quality == b.quality else a.quality > b.quality)
+	var idx : int = 0
+	var items : Array = library_manager.get_items(filter_text, true)
+	items.sort_custom(SortMenu.sort_function(item_sort_mode, library_manager.item_usage))
 	for i in items:
-		var obj = i.item
+		var obj : Dictionary = i.item
 		if not obj.has("type"):
 			continue
 		if qc_slot_type != -1 and ! check_quick_connect(obj):
 			continue
-		var section = obj.tree_item.get_slice("/", 0)
+		var section : String = obj.tree_item.get_slice("/", 0)
 		var color : Color = get_node("/root/MainWindow/NodeLibraryManager").get_section_color(section)
 		color = color.lerp(get_theme_color("font_color", "Label"), 0.5)
-		#print(i)
-		var _name = obj.display_name
+		var _name : String = obj.display_name
 		_name = obj.tree_item# + "("+str(i.quality)+")" + " ("+str(i.idx)+")"
-		#if obj.has("shortdesc")
 
 		%List.add_item(_name, i.icon)
 		%List.set_item_custom_fg_color(idx, color)
@@ -187,7 +185,8 @@ func update_list(filter_text : String = "") -> void:
 
 		idx += 1
 
-	%List.select(0)
+	if %List.item_count:
+		%List.select(0)
 	%List.ensure_current_is_visible()
 
 func _unhandled_input(event) -> void:
@@ -226,3 +225,17 @@ func _on_list_item_activated(index: int) -> void:
 	if not data == null:
 		add_node(data.item)
 		todo_renamed_hide()
+
+func _on_sort_menu_pressed() -> void:
+	var panel : SortMenu = preload("res://material_maker/windows/add_node_popup/sort_menu.tscn").instantiate()
+	panel.hide()
+	add_child(panel)
+	panel.sorting_changed.connect(update_list.bind(filter.text))
+	panel.popup_hide.connect(panel.queue_free)
+	if get_tree().root.gui_embed_subwindows:
+		panel.content_scale_factor = 1.0
+		panel.position = Vector2i(get_mouse_position()) + position
+		panel.size = panel.get_contents_minimum_size()
+		panel.show()
+	else:
+		panel.popup(Rect2(panel.get_mouse_position() * content_scale_factor, panel.size))

--- a/material_maker/windows/add_node_popup/add_node_popup.tscn
+++ b/material_maker/windows/add_node_popup/add_node_popup.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=20 format=3 uid="uid://clw8sb0p8webl"]
+[gd_scene format=3 uid="uid://clw8sb0p8webl"]
 
 [ext_resource type="Script" uid="uid://di33ywsh7i1mp" path="res://material_maker/windows/add_node_popup/add_node_popup.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://cjcxjmoki7j0n" path="res://material_maker/windows/add_node_popup/quick_button.tscn" id="2"]
+[ext_resource type="Script" uid="uid://bos2fu0tsood3" path="res://material_maker/panels/preview_2d/simple_button.gd" id="4_c6ii2"]
 
 [sub_resource type="Shader" id="11"]
 code = "shader_type canvas_item;
@@ -20,7 +21,7 @@ void fragment() {
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_buqpn"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_88qrb"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_j7uv1"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
@@ -29,7 +30,7 @@ shader_parameter/tex = SubResource("PlaceholderTexture2D_buqpn")
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_jt68i"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_wwply"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_c6ii2"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
@@ -38,7 +39,7 @@ shader_parameter/tex = SubResource("PlaceholderTexture2D_jt68i")
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_nfnnr"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_h5yl4"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ycd3q"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
@@ -47,77 +48,78 @@ shader_parameter/tex = SubResource("PlaceholderTexture2D_nfnnr")
 
 [sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_gqmjk"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_xysbp"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_6e0vi"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
 shader_parameter/brightness = 0.8
 shader_parameter/tex = SubResource("PlaceholderTexture2D_gqmjk")
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_2fcwt"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_vuu0v"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
 shader_parameter/brightness = 0.8
 shader_parameter/tex = SubResource("PlaceholderTexture2D_buqpn")
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_l7flh"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_301qr"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
 shader_parameter/brightness = 0.8
 shader_parameter/tex = SubResource("PlaceholderTexture2D_buqpn")
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_s5pxd"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_0flf1"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
 shader_parameter/brightness = 0.8
 shader_parameter/tex = SubResource("PlaceholderTexture2D_buqpn")
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_irmk8"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_0v1a3"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
 shader_parameter/brightness = 0.8
 shader_parameter/tex = SubResource("PlaceholderTexture2D_buqpn")
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_nyf2o"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_r7qcy"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
 shader_parameter/brightness = 0.8
 shader_parameter/tex = SubResource("PlaceholderTexture2D_buqpn")
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_7i7iy"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_241uj"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
 shader_parameter/brightness = 0.8
 shader_parameter/tex = SubResource("PlaceholderTexture2D_buqpn")
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_j7uv1"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_e17e2"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
 shader_parameter/brightness = 0.8
 shader_parameter/tex = SubResource("PlaceholderTexture2D_buqpn")
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_c6ii2"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_uvyxa"]
 resource_local_to_scene = true
 shader = SubResource("11")
 shader_parameter/disabled = false
 shader_parameter/brightness = 0.8
 shader_parameter/tex = SubResource("PlaceholderTexture2D_buqpn")
 
-[node name="AddNodePopup" type="Popup"]
+[node name="AddNodePopup" type="Popup" unique_id=125164369]
 transparent_bg = true
+oversampling_override = 1.0
 size = Vector2i(360, 400)
 visible = true
 transparent = true
 script = ExtResource("1")
 
-[node name="PanelContainer" type="PanelContainer" parent="."]
+[node name="PanelContainer" type="PanelContainer" parent="." unique_id=1838977186]
 custom_minimum_size = Vector2(0, 400)
 anchors_preset = 15
 anchor_right = 1.0
@@ -125,90 +127,100 @@ anchor_bottom = 1.0
 mouse_filter = 2
 theme_type_variation = &"MM_AddNodePanel"
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer" unique_id=1510473407]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Buttons" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
+[node name="Buttons" type="HBoxContainer" parent="PanelContainer/VBoxContainer" unique_id=1827652292]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Button1" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_88qrb")
+[node name="Button1" parent="PanelContainer/VBoxContainer/Buttons" unique_id=1084464729 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_j7uv1")
 layout_mode = 2
 size_flags_horizontal = 6
 default_library_item = "Simple/Uniform/Greyscale"
 
-[node name="Button2" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_wwply")
+[node name="Button2" parent="PanelContainer/VBoxContainer/Buttons" unique_id=1719375990 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_c6ii2")
 layout_mode = 2
 size_flags_horizontal = 6
 default_library_item = "Simple/Shape"
 
-[node name="Button3" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_h5yl4")
+[node name="Button3" parent="PanelContainer/VBoxContainer/Buttons" unique_id=1819193398 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_ycd3q")
 layout_mode = 2
 size_flags_horizontal = 6
 default_library_item = "Noise/FBM"
 
-[node name="Button4" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_xysbp")
+[node name="Button4" parent="PanelContainer/VBoxContainer/Buttons" unique_id=626390886 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_6e0vi")
 layout_mode = 2
 size_flags_horizontal = 6
 default_library_item = "Filter/Colorize"
 
-[node name="Button5" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_2fcwt")
+[node name="Button5" parent="PanelContainer/VBoxContainer/Buttons" unique_id=2043827964 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_vuu0v")
 layout_mode = 2
 size_flags_horizontal = 6
 default_library_item = "Transform"
 
-[node name="Button6" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_l7flh")
+[node name="Button6" parent="PanelContainer/VBoxContainer/Buttons" unique_id=929933485 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_301qr")
 layout_mode = 2
 size_flags_horizontal = 6
 default_library_item = "Transform/Tiler"
 
-[node name="Button7" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_s5pxd")
+[node name="Button7" parent="PanelContainer/VBoxContainer/Buttons" unique_id=569857914 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_0flf1")
 layout_mode = 2
 size_flags_horizontal = 6
 default_library_item = "Filter/Blend"
 
-[node name="Button8" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_irmk8")
+[node name="Button8" parent="PanelContainer/VBoxContainer/Buttons" unique_id=892024961 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_0v1a3")
 layout_mode = 2
 size_flags_horizontal = 6
 default_library_item = "Filter/Math"
 
-[node name="Button9" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_nyf2o")
+[node name="Button9" parent="PanelContainer/VBoxContainer/Buttons" unique_id=1312620572 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_r7qcy")
 layout_mode = 2
 size_flags_horizontal = 6
 
-[node name="Button10" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_7i7iy")
+[node name="Button10" parent="PanelContainer/VBoxContainer/Buttons" unique_id=2034306559 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_241uj")
 layout_mode = 2
 size_flags_horizontal = 6
 
-[node name="Button11" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_j7uv1")
+[node name="Button11" parent="PanelContainer/VBoxContainer/Buttons" unique_id=1883149735 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_e17e2")
 layout_mode = 2
 size_flags_horizontal = 6
 
-[node name="Button12" parent="PanelContainer/VBoxContainer/Buttons" instance=ExtResource("2")]
-material = SubResource("ShaderMaterial_c6ii2")
+[node name="Button12" parent="PanelContainer/VBoxContainer/Buttons" unique_id=1473887026 instance=ExtResource("2")]
+material = SubResource("ShaderMaterial_uvyxa")
 layout_mode = 2
 size_flags_horizontal = 6
 
-[node name="Filter" type="LineEdit" parent="PanelContainer/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer" unique_id=600375832]
+layout_mode = 2
+
+[node name="Filter" type="LineEdit" parent="PanelContainer/VBoxContainer/HBoxContainer" unique_id=1428036658]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
+size_flags_horizontal = 3
 placeholder_text = "Filter"
 clear_button_enabled = true
 
-[node name="List" type="ItemList" parent="PanelContainer/VBoxContainer"]
+[node name="SortMenu" type="Button" parent="PanelContainer/VBoxContainer/HBoxContainer" unique_id=988418438]
+unique_name_in_owner = true
+layout_mode = 2
+script = ExtResource("4_c6ii2")
+icon_name = "settings"
+
+[node name="List" type="ItemList" parent="PanelContainer/VBoxContainer" unique_id=1173598757]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
@@ -228,6 +240,7 @@ fixed_icon_size = Vector2i(18, 18)
 [connection signal="object_selected" from="PanelContainer/VBoxContainer/Buttons/Button10" to="." method="add_node"]
 [connection signal="object_selected" from="PanelContainer/VBoxContainer/Buttons/Button11" to="." method="add_node"]
 [connection signal="object_selected" from="PanelContainer/VBoxContainer/Buttons/Button12" to="." method="add_node"]
-[connection signal="gui_input" from="PanelContainer/VBoxContainer/Filter" to="." method="_on_filter_gui_input"]
+[connection signal="gui_input" from="PanelContainer/VBoxContainer/HBoxContainer/Filter" to="." method="_on_filter_gui_input"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/HBoxContainer/SortMenu" to="." method="_on_sort_menu_pressed"]
 [connection signal="gui_input" from="PanelContainer/VBoxContainer/List" to="." method="_on_list_gui_input"]
 [connection signal="item_activated" from="PanelContainer/VBoxContainer/List" to="." method="_on_list_item_activated"]

--- a/material_maker/windows/add_node_popup/sort_button_group.tres
+++ b/material_maker/windows/add_node_popup/sort_button_group.tres
@@ -1,0 +1,3 @@
+[gd_resource type="ButtonGroup" format=3 uid="uid://b2cktlktu8ghy"]
+
+[resource]

--- a/material_maker/windows/add_node_popup/sort_menu.gd
+++ b/material_maker/windows/add_node_popup/sort_menu.gd
@@ -1,0 +1,120 @@
+class_name SortMenu
+extends PopupPanel
+
+signal sorting_changed
+
+enum Sorting {
+	FREQUENCY_ASCENDING,
+	FREQUENCY_DESCENDING,
+	ALPHABETICAL_ASCENDING,
+	ALPHABETICAL_DESCENDING,
+	CATEGORY_ASCENDING,
+	CATEGORY_DESCENDING,
+	QUALITY_DESCENDING,
+}
+
+static func item_used(usage_map : Dictionary, item : String) -> int:
+	if usage_map.has(item):
+		return usage_map[item]
+	return 0
+
+static func sort_function(type : Sorting, freq_map : Dictionary) -> Callable:
+	match type:
+		Sorting.QUALITY_DESCENDING:
+			return func(a : Dictionary, b : Dictionary) -> bool:
+				return a.idx < b.idx if a.quality == b.quality else a.quality > b.quality
+		Sorting.FREQUENCY_ASCENDING:
+			return func(a : Dictionary, b : Dictionary) -> bool:
+					var a_freq = item_used(freq_map, a.name)
+					var b_freq = item_used(freq_map, b.name)
+					return a_freq < b_freq if a_freq != b_freq else a.quality > b.quality
+		Sorting.FREQUENCY_DESCENDING:
+			return func(a : Dictionary, b : Dictionary) -> bool:
+					var a_freq = item_used(freq_map, a.name)
+					var b_freq = item_used(freq_map, b.name)
+					return a_freq > b_freq if a_freq != b_freq else a.quality > b.quality
+		Sorting.ALPHABETICAL_ASCENDING:
+			return func(a : Dictionary, b : Dictionary) -> bool:
+					return a.item.display_name.naturalcasecmp_to(b.item.display_name) == -1
+		Sorting.ALPHABETICAL_DESCENDING:
+			return func(a : Dictionary, b : Dictionary) -> bool:
+					return a.item.display_name.naturalcasecmp_to(b.item.display_name) == 1
+		Sorting.CATEGORY_ASCENDING:
+			return func(a : Dictionary, b : Dictionary) -> bool:
+					return a.name.naturalcasecmp_to(b.name) == -1
+		Sorting.CATEGORY_DESCENDING:
+			return func(a : Dictionary, b : Dictionary) -> bool:
+					return a.name.naturalcasecmp_to(b.name) == 1
+	return sort_function(Sorting.QUALITY_DESCENDING, freq_map)
+
+func _ready() -> void:
+	content_scale_factor = get_tree().root.content_scale_factor
+	load_button_state()
+
+func load_button_state() -> void:
+	match get_parent().item_sort_mode:
+		Sorting.FREQUENCY_ASCENDING:
+			%Frequency.icon_name = "frequency_ascending"
+			%Frequency.button_pressed = true
+		Sorting.FREQUENCY_DESCENDING:
+			%Frequency.icon_name = "frequency_descending"
+			%Frequency.button_pressed = true
+		Sorting.ALPHABETICAL_ASCENDING:
+			%Alphabetical.icon_name = "alphabetical_ascending"
+			%Alphabetical.button_pressed = true
+		Sorting.ALPHABETICAL_DESCENDING:
+			%Alphabetical.icon_name = "alphabetical_descending"
+			%Alphabetical.button_pressed = true
+		Sorting.CATEGORY_ASCENDING:
+			%Category.icon_name = "category_ascending"
+			%Category.button_pressed = true
+		Sorting.CATEGORY_DESCENDING:
+			%Category.icon_name = "category_descending"
+			%Category.button_pressed = true
+		Sorting.QUALITY_DESCENDING:
+			%Quality.button_pressed = true
+
+	# update button icons
+	for btn in $PanelContainer/VBoxContainer.get_children():
+		btn._ready()
+
+func toggle_button_icon(btn : SimpleButton) -> void:
+	if "ascending" in btn.icon_name:
+		btn.icon_name = btn.name.to_lower() + "_descending"
+	else:
+		btn.icon_name = btn.name.to_lower() + "_ascending"
+	btn._ready()
+
+func save_button_state(btn : SimpleButton) -> void:
+	var sort : Sorting
+	var ascending : bool = "ascending" in btn.icon_name
+	match btn.name.to_lower():
+		"frequency":
+			sort = Sorting.FREQUENCY_ASCENDING if ascending else Sorting.FREQUENCY_DESCENDING
+		"alphabetical":
+			sort = Sorting.ALPHABETICAL_ASCENDING if ascending else Sorting.ALPHABETICAL_DESCENDING
+		"category":
+			sort = Sorting.CATEGORY_ASCENDING if ascending else Sorting.CATEGORY_DESCENDING
+		"quality":
+			sort = Sorting.QUALITY_DESCENDING
+	mm_globals.set_config("add_node_popup_sort", sort)
+	get_parent().item_sort_mode = sort
+
+func _on_frequency_pressed() -> void:
+	toggle_button_icon(%Frequency)
+	save_button_state(%Frequency)
+	sorting_changed.emit()
+
+func _on_alphabetical_pressed() -> void:
+	toggle_button_icon(%Alphabetical)
+	save_button_state(%Alphabetical)
+	sorting_changed.emit()
+
+func _on_category_pressed() -> void:
+	toggle_button_icon(%Category)
+	save_button_state(%Category)
+	sorting_changed.emit()
+
+func _on_quality_pressed() -> void:
+	save_button_state(%Quality)
+	sorting_changed.emit()

--- a/material_maker/windows/add_node_popup/sort_menu.gd.uid
+++ b/material_maker/windows/add_node_popup/sort_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://sy2sjsibdh33

--- a/material_maker/windows/add_node_popup/sort_menu.tscn
+++ b/material_maker/windows/add_node_popup/sort_menu.tscn
@@ -1,0 +1,74 @@
+[gd_scene format=3 uid="uid://ccn6lirlng4mf"]
+
+[ext_resource type="Script" uid="uid://sy2sjsibdh33" path="res://material_maker/windows/add_node_popup/sort_menu.gd" id="1_a3m20"]
+[ext_resource type="Script" uid="uid://bos2fu0tsood3" path="res://material_maker/panels/preview_2d/simple_button.gd" id="1_uh4sk"]
+[ext_resource type="ButtonGroup" uid="uid://b2cktlktu8ghy" path="res://material_maker/windows/add_node_popup/sort_button_group.tres" id="2_eswfh"]
+
+[node name="SortMenuPanel" type="PopupPanel" unique_id=348406576]
+oversampling_override = 1.0
+size = Vector2i(56, 124)
+visible = true
+theme_type_variation = &"MM_PanelMenuSubPanelLabel"
+script = ExtResource("1_a3m20")
+
+[node name="PanelContainer" type="PanelContainer" parent="." unique_id=1059872005]
+offset_left = 4.0
+offset_top = 4.0
+offset_right = 52.0
+offset_bottom = 120.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer" unique_id=1741003019]
+layout_mode = 2
+
+[node name="Quality" type="Button" parent="PanelContainer/VBoxContainer" unique_id=1545685784]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(26, 26)
+layout_mode = 2
+tooltip_text = "Sort items by relevancy"
+toggle_mode = true
+button_group = ExtResource("2_eswfh")
+icon_alignment = 1
+expand_icon = true
+script = ExtResource("1_uh4sk")
+icon_name = "zoom"
+
+[node name="Frequency" type="Button" parent="PanelContainer/VBoxContainer" unique_id=491345268]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(26, 26)
+layout_mode = 2
+tooltip_text = "Sort items by usage frequency"
+toggle_mode = true
+button_group = ExtResource("2_eswfh")
+icon_alignment = 1
+expand_icon = true
+script = ExtResource("1_uh4sk")
+icon_name = "frequency_ascending"
+
+[node name="Alphabetical" type="Button" parent="PanelContainer/VBoxContainer" unique_id=1776522408]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(26, 26)
+layout_mode = 2
+tooltip_text = "Sort items by alphabetical order"
+toggle_mode = true
+button_group = ExtResource("2_eswfh")
+icon_alignment = 1
+expand_icon = true
+script = ExtResource("1_uh4sk")
+icon_name = "alphabetical_ascending"
+
+[node name="Category" type="Button" parent="PanelContainer/VBoxContainer" unique_id=1436273603]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(26, 26)
+layout_mode = 2
+tooltip_text = "Sort items by node category/section"
+toggle_mode = true
+button_group = ExtResource("2_eswfh")
+icon_alignment = 1
+expand_icon = true
+script = ExtResource("1_uh4sk")
+icon_name = "category_ascending"
+
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Quality" to="." method="_on_quality_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Frequency" to="." method="_on_frequency_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Alphabetical" to="." method="_on_alphabetical_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Category" to="." method="_on_category_pressed"]


### PR DESCRIPTION
Addresses suggestion via discord

Adds several sorting options for the add node popup items

**Quality(best match/relevancy)**: Sort by item [quality score](https://github.com/RodZill4/material-maker/blob/c0c36b5577b78e1139c20abf655e19f7b70127c9/material_maker/tools/library_manager/library.gd#L66), current behavior
**Frequency:** Sort by node usage
**Alphabetical**: Sort by node items(`display_name` in tree item), via `naturalcasecmp_to`
**Category:** Sort by node section, via `naturalcasecmp_to` on the full tree item path


https://github.com/user-attachments/assets/f04b1c3e-e523-44ec-8cca-ac87b1a7861c