### PR TITLE
Fix paint mode default model path on macOS

### DIFF
--- a/material_maker/windows/new_painter/new_painter.gd
+++ b/material_maker/windows/new_painter/new_painter.gd
@@ -31,6 +31,8 @@ func _on_ModelFile_pressed():
 	dialog.min_size = Vector2(500, 500)
 	dialog.access = FileDialog.ACCESS_FILESYSTEM
 	dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
+	if not Engine.is_editor_hint() and OS.get_name() == "macOS":
+		dialog.current_dir = dialog.current_dir.get_base_dir().path_join("MacOS")
 	dialog.add_filter("*.glb,*.gltf;GLTF file")
 	dialog.add_filter("*.obj;Wavefront OBJ file")
 	dialog.add_filter("*.fbx;FBX file")


### PR DESCRIPTION
on macOS (in exported builds) the default path for the file dialog when loading a model is set to `Contents/Resources` in the app bundle:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6f45b570-fd2b-4ee5-9351-b55e335b2510" />

This sets the path to `Contents/MacOS`(which contains MM's files, especially the mesh folder) to be consistent with other platforms:

<img width="615" alt="image" src="https://github.com/user-attachments/assets/322cd34d-4dbc-4c4d-8d07-7ea490df3972" />

also the project path dialog should probably be set to user's home directory instead of within the app bundle/app files(for other platforms too)