### PR TITLE
Remove `fix_nodes.sh`

### DIFF
--- a/material_maker/doc/images/fix_nodes.sh
+++ b/material_maker/doc/images/fix_nodes.sh
@@ -1,7 +1,0 @@
-#! /bin/env bash
-
-for f in `git status . |grep png |sed "s/\s*modified:\s*//"`
-do
-    echo $f
-    magick $f -alpha off -background transparent -fuzz 0.1% -transparent "#303236" $f
-done


### PR DESCRIPTION
This is now handled by the `generate_screenshot` function in `library.gd` as of https://github.com/RodZill4/material-maker/commit/dae9bb01b58a03f5fad2f5f4ddeba6d2bc24184a so it is no longer necessary to use the script