### PR TITLE
Disable irrelevant options from show panels menu

### DIFF
--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -656,6 +656,8 @@ func create_menu_show_panels(menu : MMMenuManager.MenuBase) -> void:
 	for i in range(panels.size()):
 		menu.add_check_item(panels[i], i)
 		menu.set_item_checked(i, layout.is_panel_visible(panels[i]))
+		if current_mode:
+			menu.set_item_disabled(i, panels[i] in layout.HIDE_PANELS[current_mode])
 	menu.connect_id_pressed(self._on_ShowPanels_id_pressed)
 
 func create_menu_panels_preset(menu : MMMenuManager.MenuBase) -> void:

--- a/material_maker/main_window_layout.gd
+++ b/material_maker/main_window_layout.gd
@@ -29,9 +29,9 @@ var default_material_layout := {
 
 var default_paint_layout : Dictionary = { main={ children=[ { children=[ { children=[], current=0, h=766.0, tabs=["Brushes"], type="FlexTab", w=279.0 }, { children=[], h=766.0, type="FlexMain", w=844.0 }, { children=[ { children=[], current=0, h=370.0, tabs=["Parameters"], type="FlexTab", w=240.0 }, { children=[], current=0, h=386.0, tabs=["Layers"], type="FlexTab", w=240.0 }], dir="v", h=766.0, type="FlexSplit", w=240.0 }], dir="h", h=766.0, type="FlexSplit", w=1383.0 }], h=766.0, type="FlexTop", w=1383.0 }, windows=[] }
 
-const HIDE_PANELS = {
-	material=[ "Brushes", "Layers", "Parameters" ],
-	paint=[ "Preview3D", "Histogram", "Hierarchy" ]
+const HIDE_PANELS : Dictionary[String, Array] = {
+	"material": [ "Brushes", "Layers", "Parameters" ],
+	"paint": [ "Preview3D", "Histogram", "Hierarchy" ]
 }
 
 


### PR DESCRIPTION
> Show panels should probably only list the panels usable for the current project type. Some panels do not work in material mode and looks like they are broken when shown(i.e. parameters) 

**Material / Paint mode:**

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/30994577-7d67-4ec8-ab7b-a0509a19e4b4" />
