### PR TITLE
Add button in graph panel to reroll node seeds

### DIFF
--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -2009,3 +2009,17 @@ func _on_connection_drag_started(_from_node : StringName, _from_port : int, _is_
 
 func _on_connection_drag_ended() -> void:
 	is_dragging_connection = false
+
+func _on_button_reroll_pressed() -> void:
+	undoredo.start_group()
+	for node in get_children():
+		if node is MMGraphNodeMinimal and node.has_method("on_randomness_pressed"):
+			if Input.is_key_pressed(KEY_SHIFT):
+				if node.selected:
+					node.on_randomness_pressed()
+			else:
+				node.on_randomness_pressed()
+	undoredo.end_group()
+
+func _on_button_reroll_mouse_entered() -> void:
+	mm_globals.set_tip_text("#LMB: Reroll all nodes, Shift+#LMB: Reroll selected nodes")

--- a/material_maker/panels/graph_edit/graph_edit.tscn
+++ b/material_maker/panels/graph_edit/graph_edit.tscn
@@ -4,14 +4,19 @@
 [ext_resource type="Texture2D" uid="uid://c0j4px4n72di5" path="res://material_maker/icons/icons.tres" id="2"]
 [ext_resource type="Script" uid="uid://bne3k0g56crmy" path="res://material_maker/tools/undo_redo/undo_redo.gd" id="3"]
 [ext_resource type="PackedScene" uid="uid://buj231c2gxm4o" path="res://material_maker/widgets/desc_button/desc_button.tscn" id="4"]
+[ext_resource type="Texture2D" uid="uid://1s0c37uoj4rf" path="res://material_maker/theme/default_theme_icons.svg" id="4_u5byk"]
 
 [sub_resource type="AtlasTexture" id="3"]
-atlas = ExtResource("2")
-region = Rect2(64, 32, 16, 16)
+atlas = ExtResource("4_u5byk")
+region = Rect2(96, 64, 16, 16)
 
 [sub_resource type="AtlasTexture" id="4"]
 atlas = ExtResource("2")
 region = Rect2(15.4016, 47.1451, 16.7512, 17.8319)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_u5byk"]
+atlas = ExtResource("4_u5byk")
+region = Rect2(96, 64, 16, 16)
 
 [sub_resource type="AtlasTexture" id="5"]
 atlas = ExtResource("2")
@@ -76,12 +81,21 @@ size_flags_horizontal = 9
 tooltip_text = "Back to parent"
 icon = SubResource("4")
 
+[node name="Spacer" type="Control" parent="GraphUI/SubGraphUI" unique_id=1049559029]
+custom_minimum_size = Vector2(14, 0)
+layout_mode = 2
+
+[node name="ButtonReroll" type="Button" parent="GraphUI" unique_id=1352135248]
+layout_mode = 2
+tooltip_text = "Reroll Seeds"
+icon = SubResource("AtlasTexture_u5byk")
+
 [node name="ButtonShowTree" type="Button" parent="GraphUI" unique_id=305280196]
 layout_mode = 2
 tooltip_text = "Show hierarchy"
 icon = SubResource("5")
 
-[node name="Control" type="Control" parent="GraphUI" unique_id=805364353]
+[node name="Spacer" type="Control" parent="GraphUI" unique_id=805364353]
 custom_minimum_size = Vector2(14, 0)
 layout_mode = 2
 
@@ -105,4 +119,6 @@ script = ExtResource("3")
 [connection signal="descriptions_changed" from="GraphUI/SubGraphUI/Description" to="." method="_on_Description_descriptions_changed"]
 [connection signal="toggled" from="GraphUI/SubGraphUI/ButtonTransmitsSeed" to="." method="_on_ButtonTransmitsSeed_toggled"]
 [connection signal="pressed" from="GraphUI/SubGraphUI/ButtonUp" to="." method="on_ButtonUp_pressed"]
+[connection signal="mouse_entered" from="GraphUI/ButtonReroll" to="." method="_on_button_reroll_mouse_entered"]
+[connection signal="pressed" from="GraphUI/ButtonReroll" to="." method="_on_button_reroll_pressed"]
 [connection signal="pressed" from="GraphUI/ButtonShowTree" to="." method="_on_ButtonShowTree_pressed"]


### PR DESCRIPTION
via discord
> a button somewhere to reroll all random seeds

Adds a button to reroll seeds in the current graph. By default it rolls all nodes, unless if the Shift key is held down which only selected nodes will be rolled. Also updated the randomness icon to use the new icon from the icon sheet.

https://github.com/user-attachments/assets/f3972121-204f-4535-9d01-788c1f2803dd

Tip text when hovering over button:

<img width="413" height="59" alt="image" src="https://github.com/user-attachments/assets/52d974a3-992b-432e-9f84-2759a9e44c7d" />
