### PR TITLE
Improve window title for EasySDF, Material and Export editors

### DIFF
--- a/addons/material_maker/engine/nodes/gen_shader.gd
+++ b/addons/material_maker/engine/nodes/gen_shader.gd
@@ -817,6 +817,9 @@ func do_edit(node, edit_window_scene : PackedScene, tab : String = "") -> void:
 		mm_globals.main_window.add_dialog(edit_window)
 		edit_window.set_model_data(get_shader_model_for_edit())
 		edit_window.node_changed.connect(node.update_shader_generator)
+		if node.generator is MMGenMaterial:
+			var material : String = node.generator.shader_model.name
+			edit_window.title = "%s - %s" % [material, edit_window.title]
 		edit_window.get_window().content_scale_factor = mm_globals.ui_scale_factor()
 		edit_window.get_window().min_size = Vector2(950, 450) * edit_window.get_window().content_scale_factor
 		edit_window.hide()

--- a/material_maker/windows/sdf_builder/sdf_builder.tscn
+++ b/material_maker/windows/sdf_builder/sdf_builder.tscn
@@ -26,6 +26,7 @@ region = Rect2(48, 0, 16, 16)
 
 [node name="Control" type="Window"]
 oversampling_override = 1.0
+title = "Easy SDF"
 position = Vector2i(0, 36)
 exclusive = true
 script = ExtResource("3")


### PR DESCRIPTION
**EasySDF**: Add a title for the window
<img width="309" height="123" alt="image" src="https://github.com/user-attachments/assets/94f6edae-2610-4ab1-a6ff-da73ab4a4c66" />


**Material/Export Editor**: Add material name to clarify the editor is associated with the current active material

<img width="406" height="138" alt="image" src="https://github.com/user-attachments/assets/198a7b5c-c366-4f36-9845-59c2a17778a3" />

<img width="371" height="133" alt="image" src="https://github.com/user-attachments/assets/9db6422a-1e21-4da7-9b68-ac719be5366f" />
