### PR TITLE
Add option to make color picker popups floating windows

### DIFF
--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -64,6 +64,7 @@ const DEFAULT_CONFIG : Dictionary = {
 	node_minimize_button = true,
 	node_close_button = true,
 	ui_field_sensitivity = 1.0,
+	color_picker_floating = false
 }
 
 

--- a/material_maker/nodes/comment/comment.gd
+++ b/material_maker/nodes/comment/comment.gd
@@ -186,6 +186,7 @@ func _on_ColorChooser_gui_input(event: InputEvent) -> void:
 		$PopupSelector.get_window().min_size = $PopupSelector.get_window().get_contents_minimum_size() * content_scale_factor
 		$PopupSelector.get_window().position = get_screen_transform() * get_local_mouse_position()
 		var color_picker : ColorPicker = $PopupSelector/PanelContainer/ColorPicker
+		color_picker.get_window().borderless = not mm_globals.get_config("color_picker_floating")
 		$PopupSelector.about_to_popup.connect(func():
 			if mm_globals.has_config("color_picker_color_mode"):
 				color_picker.color_mode = mm_globals.get_config("color_picker_color_mode")

--- a/material_maker/panels/graph_edit/graph_edit.gd
+++ b/material_maker/panels/graph_edit/graph_edit.gd
@@ -1932,8 +1932,9 @@ func colorize_nodes() -> void:
 		return
 	undoredo.start_group()
 
-	var picker = ColorPicker.new()
+	var picker : ColorPicker = ColorPicker.new()
 	var popup : PopupPanel = PopupPanel.new()
+	popup.borderless = not mm_globals.get_config("color_picker_floating")
 	popup.add_child(picker)
 	popup.hide()
 	add_child(popup)

--- a/material_maker/widgets/color_picker_button/color_picker_button.gd
+++ b/material_maker/widgets/color_picker_button/color_picker_button.gd
@@ -4,7 +4,6 @@ var previous_color : Color
 
 signal color_changed_undo(c, previous)
 
-
 func _ready():
 	custom_minimum_size = Vector2(24, 24)
 	connect("color_changed",Callable(self,"on_color_changed"))
@@ -12,6 +11,7 @@ func _ready():
 	connect("popup_closed",Callable(self,"on_popup_closed"))
 	get_popup().content_scale_factor = mm_globals.ui_scale_factor()
 	get_popup().min_size = get_popup().get_contents_minimum_size() * get_popup().content_scale_factor
+	get_popup().borderless = not mm_globals.get_config("color_picker_floating")
 
 func set_color(c):
 	color = c
@@ -32,15 +32,12 @@ func _drop_data(_position, data) -> void:
 	emit_signal("color_changed", color)
 	emit_signal("color_changed_undo", color, old_color)
 
-
 func on_color_changed(c):
 	emit_signal("color_changed_undo", c, null)
-
 
 func on_picker_created():
 	get_popup().connect("about_to_popup", Callable(self, "on_about_to_show"))
 	previous_color = color
-
 
 func on_about_to_show():
 	previous_color = color
@@ -48,7 +45,6 @@ func on_about_to_show():
 		get_picker().color_mode = mm_globals.get_config("color_picker_color_mode")
 	if mm_globals.has_config("color_picker_shape"):
 		get_picker().picker_shape = mm_globals.get_config("color_picker_shape")
-
 
 func on_popup_closed():
 	emit_signal("color_changed_undo", color, previous_color)

--- a/material_maker/widgets/gradient_editor/gradient_edit.gd
+++ b/material_maker/widgets/gradient_editor/gradient_edit.gd
@@ -108,19 +108,19 @@ func _gui_input(ev:InputEvent) -> void:
 	if preview_cursor:
 		preview_cursor.set_cursor_offset(position_to_offset(get_local_mouse_position()))
 
-
-func select_color(cursor:GradientEditCursor) -> void:
+func select_color(cursor : GradientEditCursor) -> void:
 	active_cursor = cursor.cursor_index
 	mode = Modes.SELECTING_COLOR
 
-	var color_picker_popup := preload("res://material_maker/widgets/color_picker_popup/color_picker_popup.tscn").instantiate()
+	var color_picker_popup : PopupPanel = preload("res://material_maker/widgets/color_picker_popup/color_picker_popup.tscn").instantiate()
 	color_picker_popup.hide()
+	color_picker_popup.borderless = not mm_globals.get_config("color_picker_floating")
 	add_child(color_picker_popup)
 
-	var color_picker := color_picker_popup.get_node("ColorPicker")
+	var color_picker : ColorPicker = color_picker_popup.get_node("ColorPicker")
 	color_picker.color = cursor.color
 	color_picker.color_changed.connect(cursor.set_cursor_color)
-		
+
 	if mm_globals.has_config("color_picker_color_mode"):
 		color_picker.color_mode = mm_globals.get_config("color_picker_color_mode")
 	if mm_globals.has_config("color_picker_shape"):
@@ -135,12 +135,14 @@ func select_color(cursor:GradientEditCursor) -> void:
 
 	var content_scale_factor : float = mm_globals.ui_scale_factor()
 	color_picker_popup.content_scale_factor = content_scale_factor
-	color_picker_popup.min_size = color_picker_popup.get_contents_minimum_size() * content_scale_factor
+	color_picker_popup.size = Vector2.ZERO
 
 	var _scale := get_global_transform().get_scale()
-
+	
+	@warning_ignore_start("narrowing_conversion")
 	color_picker_popup.position.x = (global_position.x + size.x*_scale.x) * content_scale_factor
 	color_picker_popup.position.y = global_position.y * content_scale_factor
+	@warning_ignore_restore("narrowing_conversion")
 
 	if not get_tree().root.gui_embed_subwindows:
 		color_picker_popup.position += get_window().position

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -565,6 +565,27 @@ max_value = 2.0
 step = 0.01
 float_only = true
 
+[node name="Spacer4" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer" unique_id=888694524]
+custom_minimum_size = Vector2(0, 10)
+layout_mode = 2
+
+[node name="ColorPickerFloating" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer" unique_id=717745548]
+layout_mode = 2
+
+[node name="LabelPickerFloating" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer/ColorPickerFloating" unique_id=875464274]
+layout_mode = 2
+text = "Floating color picker"
+
+[node name="ColorPickerFloating" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/Graph/VBoxContainer/ColorPickerFloating" unique_id=92490270 instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+tooltip_text = "Make color picker popups floating windows, which allows them to be moved around."
+button_pressed = true
+text = "On"
+flat = false
+config_variable = "color_picker_floating"
+
 [node name="Export" type="ScrollContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer" unique_id=848471352]
 visible = false
 layout_mode = 2


### PR DESCRIPTION
via discord
> for windows that come up for things such as choosing a different color value, it'd be great if they could be made into floating windows so that they can be moved around when they're brought up. For my specific reason, it's just bc if the window is in the wrong spot, then it just gets in the way of my 3D preview or other things under the window

This PR Adds an option to make color picker popups shown with a window border, so they can be moved around

https://github.com/user-attachments/assets/2c582dd6-66f6-4058-a9a8-40b60494172c

also fixes extra spacing in gradient color picker popup
