### PR TITLE
Add option to disable controller actions

### DIFF
--- a/material_maker/globals.gd
+++ b/material_maker/globals.gd
@@ -64,6 +64,7 @@ const DEFAULT_CONFIG : Dictionary = {
 	node_minimize_button = true,
 	node_close_button = true,
 	ui_field_sensitivity = 1.0,
+	joypad_events = true,
 }
 
 

--- a/material_maker/main_window.gd
+++ b/material_maker/main_window.gd
@@ -258,6 +258,13 @@ func _ready() -> void:
 	size = get_viewport().size/get_viewport().content_scale_factor
 	position = Vector2i(0, 0)
 
+	# Remove Joypad events from action mappings
+	if not mm_globals.get_config("joypad_events"):
+		for x in InputMap.get_actions():
+			for event in InputMap.action_get_events(x):
+				if event is InputEventJoypadButton or event is InputEventJoypadMotion:
+					InputMap.action_erase_event(x, event)
+
 
 var menu_update_requested : bool = false
 

--- a/material_maker/windows/preferences/preferences.tscn
+++ b/material_maker/windows/preferences/preferences.tscn
@@ -273,6 +273,27 @@ text = "On"
 flat = false
 config_variable = "ui_3d_preview_sun_shadow"
 
+[node name="Spacer6" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer" unique_id=1887764222]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 10)
+layout_mode = 2
+
+[node name="JoypadInput" type="HBoxContainer" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer" unique_id=1395946192]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/JoypadInput" unique_id=167353790]
+layout_mode = 2
+text = "Enable controller input (requires restart)"
+
+[node name="JoypadInput" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer/JoypadInput" unique_id=737154037 instance=ExtResource("1")]
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+size_flags_horizontal = 10
+tooltip_text = "Toggle controller/joypad input."
+text = "On"
+flat = false
+config_variable = "joypad_events"
+
 [node name="WinTabletDriverSpacer" type="Control" parent="HSplitContainer/PreferencesPanel/VBoxContainer/TabContainer/General/VBoxContainer" unique_id=1614702595]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 10)


### PR DESCRIPTION
bug report via discord
> **Cannot write/search in the Filter (space/right mouse) when PS5 Controller is connected with cable.**

> Please Remove Auto Connect Controller from Godot Engine. I use my ps5 controller as a second soundcard. In the gif in the second part of it I remove my controller cable and it works normally.

This adds an option in the preferences to disable controller input, via removing relevant events from input actions

<img width="700" alt="image" src="https://github.com/user-attachments/assets/64ee808b-891f-48ad-87b6-4970cbc5044e" />
