### PR TITLE
Move preview_2d.gd texture leak fix into MMShaderMaterial to cover Histogram too

### DIFF
--- a/addons/material_maker/engine/shader_material.gd
+++ b/addons/material_maker/engine/shader_material.gd
@@ -13,6 +13,11 @@ func _init(m : ShaderMaterial = null):
 		material.shader = Shader.new()
 
 func set_shader(shader_code : String) -> bool:
+	# Remove the Texture2D references, otherwise they will remain
+	if material.shader != null and not material.shader.code.is_empty():
+		for p in material.get_property_list():
+			if p.hint_string == "Texture2D" and p.name.begins_with("shader_parameter/"):
+				material.set_shader_parameter(p.name.right(-17), null)
 	var shader : Shader = Shader.new()
 	shader.code = shader_code
 	material.shader = shader

--- a/material_maker/panels/preview_2d/preview_2d.gd
+++ b/material_maker/panels/preview_2d/preview_2d.gd
@@ -31,10 +31,6 @@ func do_update_material(source, target_material : ShaderMaterial, template : Str
 		print("Template has time") # This should not happen
 	var code = generate_preview_shader(source, template)
 	mm_deps.create_buffer("preview_"+str(get_instance_id()), self)
-	# Remove the Texture2D references, otherwise they will remain
-	for p in target_material.get_property_list():
-		if p.hint_string == "Texture2D" and p.name.begins_with("shader_parameter/"):
-			target_material.set_shader_parameter(p.name.right(-17), null)
 	await mm_deps.buffer_create_shader_material("preview_"+str(get_instance_id()), MMShaderMaterial.new(target_material), code)
 	for u in source.uniforms:
 		if u.value:


### PR DESCRIPTION
**Issue**: `histogram.gd` has a texture leak when updating the shader.

**Fix**: This seems to be the same issue `preview_2d.gd` had a fix for. So I moved the fix into `MMShaderMaterial.set_shader()`, that way it covers both `histogram.gd` and `preview_2d.gd`.