### PR TITLE
Fix image/reference export

### DIFF
--- a/addons/material_maker/engine/multi_renderer.gd
+++ b/addons/material_maker/engine/multi_renderer.gd
@@ -158,6 +158,7 @@ func thread_run(c : Callable, p : Array = [], stop_thread = false):
 			rv = rendering_return_value
 			rendering_mutex.unlock()
 		rendering_thread_working = false
+		await get_tree().process_frame
 		return rv
 	else:
 		return await c.callv(p)


### PR DESCRIPTION
image export/to references is broken for me on master, im unsure if it's just me(mac m1 on 26.5.2) or godot 4.7 - tested metal/vulkan, but waiting for a frame seems to fix it for me

https://github.com/user-attachments/assets/bec3353a-fc55-4249-bed5-6b7da41c18ee

<img width="1008" height="222" alt="image" src="https://github.com/user-attachments/assets/e860274b-1fcd-4d32-8b4b-805183710a1e" />
