### PR TITLE
Fix non-existent `popup_hide` signal connection errors

### DIFF
--- a/material_maker/nodes/debug/debug_popup.gd
+++ b/material_maker/nodes/debug/debug_popup.gd
@@ -11,8 +11,6 @@ func _on_ready() -> void:
 func show_code(s) -> void:
 	src_code = s
 	_on_ShaderType_item_selected(0)
-	if ! is_connected("popup_hide", Callable(self, "queue_free")):
-		connect("popup_hide", Callable(self, "queue_free"))
 	hide()
 	popup_centered()
 

--- a/material_maker/windows/node_editor/parameter_enum.gd
+++ b/material_maker/windows/node_editor/parameter_enum.gd
@@ -59,7 +59,6 @@ func _on_EnumValues_item_selected(id) -> void:
 		dialog.set_value(v.name, v.value)
 		dialog.connect("ok", Callable(self, "update_enum_value").bind(enum_current))
 		dialog.close_requested.connect(dialog.queue_free)
-		dialog.connect("popup_hide", Callable(dialog, "queue_free"))
 		dialog.hide()
 		dialog.popup_centered()
 	elif id == ENUM_ADD:


### PR DESCRIPTION
These are already handled via an existing `close_requested` signal to `queue_free`