### PR TITLE
Force left-to-right layout

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -132,6 +132,10 @@ left_click={
 ]
 }
 
+[internationalization]
+
+rendering/root_node_layout_direction=1
+
 [locale]
 
 translations=PackedStringArray()


### PR DESCRIPTION
There isn't a runtime option to set this but since MM isn't really designed for that it should be fine to force LTR by default. This is based on a user report via discord having trouble with it on a RTL system.