### PR TITLE
Fix smooth curvature node size not linked to fast blur

### DIFF
--- a/addons/material_maker/nodes/smooth_curvature.mmg
+++ b/addons/material_maker/nodes/smooth_curvature.mmg
@@ -321,6 +321,10 @@
 						{
 							"node": "buffer_2",
 							"widget": "size"
+						},
+						{
+							"node": "fast_blur_6",
+							"widget": "param0"
 						}
 					],
 					"longdesc": "The buffer size for the filter",


### PR DESCRIPTION
`Size` isn't connected to the first fast blur's `Size`

<img width="623" height="382" alt="image" src="https://github.com/user-attachments/assets/db1b4ebb-de2b-4b17-8794-9bc6bed4fada" />
