### PR TITLE
Make value stepping consistent for sdCross

### DIFF
--- a/addons/material_maker/nodes/sdcross.mmg
+++ b/addons/material_maker/nodes/sdcross.mmg
@@ -50,7 +50,7 @@
 				"max": 1,
 				"min": 0,
 				"name": "bx",
-				"step": 0.1,
+				"step": 0.01,
 				"type": "float"
 			},
 			{
@@ -61,7 +61,7 @@
 				"max": 1,
 				"min": 0,
 				"name": "by",
-				"step": 0.1,
+				"step": 0.01,
 				"type": "float"
 			},
 			{


### PR DESCRIPTION
via discord
> sdCross should have it's width and height parameters set to second decimals slider precision to have it unified with the rest of parametrs